### PR TITLE
Add ability to specify erase sector layout, report firmware version

### DIFF
--- a/drivers/parallel_flash.h
+++ b/drivers/parallel_flash.h
@@ -55,6 +55,13 @@ typedef enum ParallelFlashChipType
 	ParallelFlash_M29F160FB5AN6E2_x4,
 } ParallelFlashChipType;
 
+/// Struct representing a group of identical erase sectors
+typedef struct ParallelFlashEraseSectorGroup
+{
+	uint32_t count;
+	uint32_t size;
+} ParallelFlashEraseSectorGroup;
+
 // Tells which type of flash chip we are communicating with
 void ParallelFlash_SetChipType(ParallelFlashChipType type);
 ParallelFlashChipType ParallelFlash_ChipType(void);

--- a/drivers/parallel_flash.h
+++ b/drivers/parallel_flash.h
@@ -77,7 +77,7 @@ void ParallelFlash_IdentifyChips(ParallelFlashChipID *chips);
 
 // Erases the chips/sectors requested
 void ParallelFlash_EraseChips(uint8_t chipsMask);
-bool ParallelFlash_EraseSectors(uint32_t address, uint32_t length, uint8_t chipsMask);
+bool ParallelFlash_EraseSectors(uint32_t address, uint32_t length, uint8_t chipsMask, uint8_t numEraseSectorGroups, ParallelFlashEraseSectorGroup const *eraseSectorGroups);
 
 // Writes a buffer to all 4 chips simultaneously (each uint32_t contains an 8-bit portion for each chip).
 // Optimized variant of this function if we know we're writing to all 4 chips simultaneously.

--- a/programmer_protocol.h
+++ b/programmer_protocol.h
@@ -48,7 +48,8 @@ typedef enum ProgrammerCommand
     WriteChipsAt,
     ReadChipsAt,
 	SetChipsMask,
-	SetSectorLayout
+	SetSectorLayout,
+	GetFirmwareVersion
 } ProgrammerCommand;
 
 // After a command is sent, the programmer will always respond with
@@ -185,5 +186,16 @@ typedef enum ProgrammerErasePortionOfChipReply
 	ProgrammerErasePortionError,
 	ProgrammerErasePortionFinished
 } ProgrammerErasePortionOfChipReply;
+
+// -------------------------  GET FIRMWARE VERSION PROTOCOL  -------------------------
+// If the command is GetFirmwareVersion, the programmer will reply CommandReplyOK.
+// Next, it will return 4 bytes: major version, minor version, revision, and a final
+// byte where 0 means it's a normal version and 1 means it's a prerelease version.
+// Other values are reserved.
+// Finally, it will finish the response with ProgrammerGetFWVersionDone.
+typedef enum ProgrammerGetFWVersionReply
+{
+	ProgrammerGetFWVersionDone
+} ProgrammerGetFWVersionReply;
 
 #endif /* PROGRAMMER_PROTOCOL_H_ */

--- a/programmer_protocol.h
+++ b/programmer_protocol.h
@@ -47,7 +47,8 @@ typedef enum ProgrammerCommand
     ErasePortion,
     WriteChipsAt,
     ReadChipsAt,
-    SetChipsMask
+	SetChipsMask,
+	SetSectorLayout
 } ProgrammerCommand;
 
 // After a command is sent, the programmer will always respond with

--- a/simm_programmer.c
+++ b/simm_programmer.c
@@ -44,6 +44,11 @@
 /// The maximum number of erase groups we deal with
 #define MAX_ERASE_SECTOR_GROUPS				10
 
+/// Version info to respond with
+#define VERSION_MAJOR						1
+#define VERSION_MINOR						5
+#define VERSION_REVISION					0
+
 /// The number of erase sector groups we know about currently.
 /// If it's zero, we don't know, so fall back to defaults.
 static uint8_t numEraseSectorGroups = 0;
@@ -281,6 +286,14 @@ static void SIMMProgrammer_HandleWaitingForCommandByte(uint8_t byte)
 	case SetSectorLayout:
 		curCommandState = ReadingSectorLayout;
 		USBCDC_SendByte(CommandReplyOK);
+		break;
+	case GetFirmwareVersion:
+		USBCDC_SendByte(CommandReplyOK);
+		USBCDC_SendByte(VERSION_MAJOR);
+		USBCDC_SendByte(VERSION_MINOR);
+		USBCDC_SendByte(VERSION_REVISION);
+		USBCDC_SendByte(0);
+		USBCDC_SendByte(ProgrammerGetFWVersionDone);
 		break;
 	// We don't know what this command is, so reply that it was invalid.
 	default:


### PR DESCRIPTION
The sector layout capability is much needed now that there are so many different ROM SIMMs out there. The "partial erase" capability has always assumed two hardcoded sector layouts that are completely wrong in many cases. Along with an upcoming programmer software update, now we will be able to use the correct sector layout.

Also, add the ability for the firmware to self-identify its version.