### PR TITLE
Nuvoton M258KE support

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -13,7 +13,7 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactName="${ProjName}" buildArtefactType="de.innot.avreclipse.buildArtefactType.app" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=de.innot.avreclipse.buildArtefactType.app,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" description="" id="de.innot.avreclipse.configuration.app.debug.1674332705" name="Debug" parent="de.innot.avreclipse.configuration.app.debug">
+				<configuration artifactName="${ProjName}" buildArtefactType="de.innot.avreclipse.buildArtefactType.app" buildProperties="org.eclipse.cdt.build.core.buildArtefactType=de.innot.avreclipse.buildArtefactType.app,org.eclipse.cdt.build.core.buildType=org.eclipse.cdt.build.core.buildType.debug" description="" id="de.innot.avreclipse.configuration.app.debug.1674332705" name="Debug" optionalBuildProperties="" parent="de.innot.avreclipse.configuration.app.debug">
 					<folderInfo id="de.innot.avreclipse.configuration.app.debug.1674332705." name="/" resourcePath="">
 						<toolChain id="de.innot.avreclipse.toolchain.winavr.app.debug.1454585760" name="AVR-GCC Toolchain" superClass="de.innot.avreclipse.toolchain.winavr.app.debug">
 							<option id="de.innot.avreclipse.toolchain.options.toolchain.objcopy.flash.app.debug.511484921" name="Generate HEX file for Flash memory" superClass="de.innot.avreclipse.toolchain.options.toolchain.objcopy.flash.app.debug"/>
@@ -35,7 +35,7 @@
 									<listOptionValue builtIn="false" value="USE_LUFA_CONFIG_HEADER"/>
 								</option>
 								<option id="de.innot.avreclipse.compiler.option.otherflags.1513967861" name="Other flags" superClass="de.innot.avreclipse.compiler.option.otherflags" value="-ffunction-sections -fdata-sections" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="de.innot.avreclipse.compiler.option.incpath.173462079" superClass="de.innot.avreclipse.compiler.option.incpath" valueType="includePath">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="de.innot.avreclipse.compiler.option.incpath.173462079" name="Include Paths (-I)" superClass="de.innot.avreclipse.compiler.option.incpath" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SIMMProgrammer/hal/at90usb646}&quot;"/>
 								</option>
 								<inputType id="de.innot.avreclipse.compiler.winavr.input.1367172122" name="C Source Files" superClass="de.innot.avreclipse.compiler.winavr.input"/>
@@ -60,9 +60,29 @@
 							<tool id="de.innot.avreclipse.tool.avrdude.app.debug.403293383" name="AVRDude" superClass="de.innot.avreclipse.tool.avrdude.app.debug"/>
 						</toolChain>
 					</folderInfo>
+					<folderInfo id="de.innot.avreclipse.configuration.app.debug.1674332705.1156861983" name="/" resourcePath="hal/m258ke">
+						<toolChain id="de.innot.avreclipse.toolchain.winavr.app.debug.1121931489" name="AVR-GCC Toolchain" superClass="de.innot.avreclipse.toolchain.winavr.app.debug" unusedChildren="">
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.objcopy.flash.app.debug.511484921.1081100272" name="Generate HEX file for Flash memory" superClass="de.innot.avreclipse.toolchain.options.toolchain.objcopy.flash.app.debug.511484921"/>
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.objcopy.eeprom.app.debug.102499711.1750673643" name="Generate HEX file for EEPROM" superClass="de.innot.avreclipse.toolchain.options.toolchain.objcopy.eeprom.app.debug.102499711"/>
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.objdump.app.debug.1447923913.2030782937" name="Generate Extended Listing (Source + generated Assembler)" superClass="de.innot.avreclipse.toolchain.options.toolchain.objdump.app.debug.1447923913"/>
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.size.app.debug.839780790.1223122061" name="Print Size" superClass="de.innot.avreclipse.toolchain.options.toolchain.size.app.debug.839780790"/>
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.avrdude.app.debug.1298864252.700671531" name="AVRDude" superClass="de.innot.avreclipse.toolchain.options.toolchain.avrdude.app.debug.1298864252"/>
+							<tool id="de.innot.avreclipse.tool.assembler.winavr.app.debug.1182760221" name="AVR Assembler" superClass="de.innot.avreclipse.tool.assembler.winavr.app.debug.1341917862"/>
+							<tool id="de.innot.avreclipse.tool.compiler.winavr.app.debug.1955722307" name="AVR Compiler" superClass="de.innot.avreclipse.tool.compiler.winavr.app.debug.1123922496"/>
+							<tool id="de.innot.avreclipse.tool.cppcompiler.app.debug.1324575955" name="AVR C++ Compiler" superClass="de.innot.avreclipse.tool.cppcompiler.app.debug.24092953"/>
+							<tool id="de.innot.avreclipse.tool.linker.winavr.app.debug.1850327980" name="AVR C Linker" superClass="de.innot.avreclipse.tool.linker.winavr.app.debug.806884166"/>
+							<tool id="de.innot.avreclipse.tool.cpplinker.app.debug.575860580" name="AVR C++ Linker" superClass="de.innot.avreclipse.tool.cpplinker.app.debug.198227335"/>
+							<tool id="de.innot.avreclipse.tool.archiver.winavr.base.880080809" name="AVR Archiver" superClass="de.innot.avreclipse.tool.archiver.winavr.base.1956389786"/>
+							<tool id="de.innot.avreclipse.tool.objdump.winavr.app.debug.1747827762" name="AVR Create Extended Listing" superClass="de.innot.avreclipse.tool.objdump.winavr.app.debug.1166552106"/>
+							<tool id="de.innot.avreclipse.tool.objcopy.flash.winavr.app.debug.12146022" name="AVR Create Flash image" superClass="de.innot.avreclipse.tool.objcopy.flash.winavr.app.debug.1427404113"/>
+							<tool id="de.innot.avreclipse.tool.objcopy.eeprom.winavr.app.debug.1807335718" name="AVR Create EEPROM image" superClass="de.innot.avreclipse.tool.objcopy.eeprom.winavr.app.debug.2030541034"/>
+							<tool id="de.innot.avreclipse.tool.size.winavr.app.debug.805654159" name="Print Size" superClass="de.innot.avreclipse.tool.size.winavr.app.debug.335508392"/>
+							<tool id="de.innot.avreclipse.tool.avrdude.app.debug.220339009" name="AVRDude" superClass="de.innot.avreclipse.tool.avrdude.app.debug.403293383"/>
+						</toolChain>
+					</folderInfo>
 					<sourceEntries>
+						<entry excluding="hal/m258ke|tests" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="tests"/>
-						<entry excluding="tests" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -104,7 +124,7 @@
 									<listOptionValue builtIn="false" value="USE_LUFA_CONFIG_HEADER"/>
 								</option>
 								<option id="de.innot.avreclipse.compiler.option.otherflags.1566165436" name="Other flags" superClass="de.innot.avreclipse.compiler.option.otherflags" value="-ffunction-sections -fdata-sections" valueType="string"/>
-								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="de.innot.avreclipse.compiler.option.incpath.2119807530" superClass="de.innot.avreclipse.compiler.option.incpath" valueType="includePath">
+								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="de.innot.avreclipse.compiler.option.incpath.2119807530" name="Include Paths (-I)" superClass="de.innot.avreclipse.compiler.option.incpath" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/SIMMProgrammer/hal/at90usb646}&quot;"/>
 								</option>
 								<inputType id="de.innot.avreclipse.compiler.winavr.input.2084198580" name="C Source Files" superClass="de.innot.avreclipse.compiler.winavr.input"/>
@@ -129,9 +149,29 @@
 							<tool id="de.innot.avreclipse.tool.avrdude.app.release.1179659974" name="AVRDude" superClass="de.innot.avreclipse.tool.avrdude.app.release"/>
 						</toolChain>
 					</folderInfo>
+					<folderInfo id="de.innot.avreclipse.configuration.app.release.1163010375.1768967941" name="/" resourcePath="hal/m258ke">
+						<toolChain id="de.innot.avreclipse.toolchain.winavr.app.release.637923190" name="AVR-GCC Toolchain" superClass="de.innot.avreclipse.toolchain.winavr.app.release" unusedChildren="">
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.objcopy.flash.app.release.1550189649.1760992087" name="Generate HEX file for Flash memory" superClass="de.innot.avreclipse.toolchain.options.toolchain.objcopy.flash.app.release.1550189649"/>
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.objcopy.eeprom.app.release.804255150.1237218347" name="Generate HEX file for EEPROM" superClass="de.innot.avreclipse.toolchain.options.toolchain.objcopy.eeprom.app.release.804255150"/>
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.objdump.app.release.498398371.1030616078" name="Generate Extended Listing (Source + generated Assembler)" superClass="de.innot.avreclipse.toolchain.options.toolchain.objdump.app.release.498398371"/>
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.size.app.release.544896205.72930579" name="Print Size" superClass="de.innot.avreclipse.toolchain.options.toolchain.size.app.release.544896205"/>
+							<option id="de.innot.avreclipse.toolchain.options.toolchain.avrdude.app.release.1698397894.1466640013" name="AVRDude" superClass="de.innot.avreclipse.toolchain.options.toolchain.avrdude.app.release.1698397894"/>
+							<tool id="de.innot.avreclipse.tool.assembler.winavr.app.release.1845098382" name="AVR Assembler" superClass="de.innot.avreclipse.tool.assembler.winavr.app.release.1168333362"/>
+							<tool id="de.innot.avreclipse.tool.compiler.winavr.app.release.211599198" name="AVR Compiler" superClass="de.innot.avreclipse.tool.compiler.winavr.app.release.883804772"/>
+							<tool id="de.innot.avreclipse.tool.cppcompiler.app.release.1341464787" name="AVR C++ Compiler" superClass="de.innot.avreclipse.tool.cppcompiler.app.release.912002244"/>
+							<tool id="de.innot.avreclipse.tool.linker.winavr.app.release.899751834" name="AVR C Linker" superClass="de.innot.avreclipse.tool.linker.winavr.app.release.381852607"/>
+							<tool id="de.innot.avreclipse.tool.cpplinker.app.release.776550318" name="AVR C++ Linker" superClass="de.innot.avreclipse.tool.cpplinker.app.release.929102657"/>
+							<tool id="de.innot.avreclipse.tool.archiver.winavr.base.1378114625" name="AVR Archiver" superClass="de.innot.avreclipse.tool.archiver.winavr.base.534869254"/>
+							<tool id="de.innot.avreclipse.tool.objdump.winavr.app.release.744454197" name="AVR Create Extended Listing" superClass="de.innot.avreclipse.tool.objdump.winavr.app.release.1162163813"/>
+							<tool id="de.innot.avreclipse.tool.objcopy.flash.winavr.app.release.770873154" name="AVR Create Flash image" superClass="de.innot.avreclipse.tool.objcopy.flash.winavr.app.release.1254097849"/>
+							<tool id="de.innot.avreclipse.tool.objcopy.eeprom.winavr.app.release.1006892833" name="AVR Create EEPROM image" superClass="de.innot.avreclipse.tool.objcopy.eeprom.winavr.app.release.1435818473"/>
+							<tool id="de.innot.avreclipse.tool.size.winavr.app.release.1301170685" name="Print Size" superClass="de.innot.avreclipse.tool.size.winavr.app.release.1166766118"/>
+							<tool id="de.innot.avreclipse.tool.avrdude.app.release.12593576" name="AVRDude" superClass="de.innot.avreclipse.tool.avrdude.app.release.1179659974"/>
+						</toolChain>
+					</folderInfo>
 					<sourceEntries>
+						<entry excluding="hal/m258ke|tests" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="tests"/>
-						<entry excluding="tests" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
 					</sourceEntries>
 				</configuration>
 			</storageModule>
@@ -143,7 +183,14 @@
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
 		<project id="SIMMProgrammer.de.innot.avreclipse.project.winavr.elf_2.1.0.1374953899" name="AVR Cross Target Application" projectType="de.innot.avreclipse.project.winavr.elf_2.1.0"/>
 	</storageModule>
-	<storageModule moduleId="refreshScope"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Debug">
+			<resource resourceType="PROJECT" workspacePath="/SIMMProgrammer"/>
+		</configuration>
+		<configuration configurationName="Release">
+			<resource resourceType="PROJECT" workspacePath="/SIMMProgrammer"/>
+		</configuration>
+	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="scannerConfiguration">

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
+enable_language(ASM)
 project(SIMMProgrammer)
 
 # Create a list of all source files common to all architectures
@@ -26,6 +27,8 @@ set(SOURCES
 # Get hardware-specific source files
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "avr")
 	include(hal/at90usb646/at90usb646_sources.cmake)
+elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm")
+	include(hal/m258ke/m258ke_sources.cmake)
 else()
 	message(FATAL_ERROR "unrecognized architecture for build")
 endif()
@@ -47,4 +50,6 @@ target_link_options(SIMMProgrammer.elf PRIVATE
 # Get hardware-specific options
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "avr")
 	include(hal/at90usb646/at90usb646_options.cmake)
+elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm")
+	include(hal/m258ke/m258ke_options.cmake)
 endif()

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,281 +1,622 @@
                     GNU GENERAL PUBLIC LICENSE
-                       Version 2, June 1991
+                       Version 3, 29 June 2007
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
                             Preamble
 
-  The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
-General Public License applies to most of the Free Software
-Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.)  You can apply it to
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
 your programs, too.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
-this service if you wish), that you receive source code or can get it
-if you want it, that you can change the software or use pieces of it
-in new free programs; and that you know you can do these things.
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
 
-  To protect your rights, we need to make restrictions that forbid
-anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
 
   For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
-rights.
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
 
-  We protect your rights with two steps: (1) copyright the software, and
-(2) offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
 
-  Also, for each author's protection and ours, we want to make certain
-that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
 
-  Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
-program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
 
-                    GNU GENERAL PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+                       TERMS AND CONDITIONS
 
-  0. This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The "Program", below,
-refers to any such program or work, and a "work based on the Program"
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term "modification".)  Each licensee is addressed as "you".
+  0. Definitions.
 
-Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
-running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+  "This License" refers to version 3 of the GNU General Public License.
 
-  1. You may copy and distribute verbatim copies of the Program's
-source code as you receive it, in any medium, provided that you
-conspicuously and appropriately publish on each copy an appropriate
-copyright notice and disclaimer of warranty; keep intact all the
-notices that refer to this License and to the absence of any warranty;
-and give any other recipients of the Program a copy of this License
-along with the Program.
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
 
-You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
 
-  2. You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
-distribute such modifications or work under the terms of Section 1
-above, provided that you also meet all of these conditions:
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
 
-    a) You must cause the modified files to carry prominent notices
-    stating that you changed the files and the date of any change.
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
 
-    b) You must cause any work that you distribute or publish, that in
-    whole or in part contains or is derived from the Program or any
-    part thereof, to be licensed as a whole at no charge to all third
-    parties under the terms of this License.
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
 
-    c) If the modified program normally reads commands interactively
-    when run, you must cause it, when started running for such
-    interactive use in the most ordinary way, to print or display an
-    announcement including an appropriate copyright notice and a
-    notice that there is no warranty (or else, saying that you provide
-    a warranty) and that users may redistribute the program under
-    these conditions, and telling the user how to view a copy of this
-    License.  (Exception: if the Program itself is interactive but
-    does not normally print such an announcement, your work based on
-    the Program is not required to print an announcement.)
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
 
-These requirements apply to the modified work as a whole.  If
-identifiable sections of that work are not derived from the Program,
-and can be reasonably considered independent and separate works in
-themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
-distribute the same sections as part of a whole which is a work based
-on the Program, the distribution of the whole must be on the terms of
-this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
 
-Thus, it is not the intent of this section to claim rights or contest
-your rights to work written entirely by you; rather, the intent is to
-exercise the right to control the distribution of derivative or
-collective works based on the Program.
+  1. Source Code.
 
-In addition, mere aggregation of another work not based on the Program
-with the Program (or with a work based on the Program) on a volume of
-a storage or distribution medium does not bring the other work under
-the scope of this License.
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
 
-  3. You may copy and distribute the Program (or a work based on it,
-under Section 2) in object code or executable form under the terms of
-Sections 1 and 2 above provided that you also do one of the following:
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
 
-    a) Accompany it with the complete corresponding machine-readable
-    source code, which must be distributed under the terms of Sections
-    1 and 2 above on a medium customarily used for software interchange; or,
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
 
-    b) Accompany it with a written offer, valid for at least three
-    years, to give any third party, for a charge no more than your
-    cost of physically performing source distribution, a complete
-    machine-readable copy of the corresponding source code, to be
-    distributed under the terms of Sections 1 and 2 above on a medium
-    customarily used for software interchange; or,
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
 
-    c) Accompany it with the information you received as to the offer
-    to distribute corresponding source code.  (This alternative is
-    allowed only for noncommercial distribution and only if you
-    received the program in object code or executable form with such
-    an offer, in accord with Subsection b above.)
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
 
-The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
-code means all the source code for all modules it contains, plus any
-associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
-special exception, the source code distributed need not include
-anything that is normally distributed (in either source or binary
-form) with the major components (compiler, kernel, and so on) of the
-operating system on which the executable runs, unless that component
-itself accompanies the executable.
+  The Corresponding Source for a work in source code form is that
+same work.
 
-If distribution of executable or object code is made by offering
-access to copy from a designated place, then offering equivalent
-access to copy the source code from the same place counts as
-distribution of the source code, even though third parties are not
-compelled to copy the source along with the object code.
+  2. Basic Permissions.
 
-  4. You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
-parties remain in full compliance.
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
 
-  5. You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
-modifying or distributing the Program (or any work based on the
-Program), you indicate your acceptance of this License to do so, and
-all its terms and conditions for copying, distributing or modifying
-the Program or works based on it.
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
 
-  6. Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
-original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
-restrictions on the recipients' exercise of the rights granted herein.
-You are not responsible for enforcing compliance by third parties to
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
 this License.
 
-  7. If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply and the section as a whole is intended to apply in other
-circumstances.
+  13. Use with the GNU Affero General Public License.
 
-It is not the purpose of this section to induce you to infringe any
-patents or other property right claims or to contest validity of any
-such claims; this section has the sole purpose of protecting the
-integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
-generous contributions to the wide range of software distributed
-through that system in reliance on consistent application of that
-system; it is up to the author/donor to decide if he or she is willing
-to distribute software through any other system and a licensee cannot
-impose that choice.
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
 
-This section is intended to make thoroughly clear what is believed to
-be a consequence of the rest of this License.
+  14. Revised Versions of this License.
 
-  8. If the distribution and/or use of the Program is restricted in
-certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Program under this License
-may add an explicit geographical distribution limitation excluding
-those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
-
-  9. The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and "any
-later version", you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
 
-  10. If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
 
-                            NO WARRANTY
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
 
-  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
+  15. Disclaimer of Warranty.
 
-  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
 
                      END OF TERMS AND CONDITIONS
 
@@ -287,15 +628,15 @@ free software which everyone can redistribute and change under these terms.
 
   To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
-convey the exclusion of warranty; and each file should have at least
+state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
     Copyright (C) <year>  <name of author>
 
-    This program is free software; you can redistribute it and/or modify
+    This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
@@ -303,37 +644,31 @@ the "copyright" line and a pointer to where the full notice is found.
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
 
 The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w' and `show c'; they could even be
-mouse-clicks or menu items--whatever suits your program.
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
 
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
 
-  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-  `Gnomovision' (which makes passes at compilers) written by James Hacker.
-
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
-
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 This project is a bootloader and firmware for a Macintosh ROM SIMM programmer, along with control software for Mac OS X, Windows, and Linux. The ROM SIMM is compatible with the SE/30, all II-series Macs with a 64-pin SIMM socket (should include the IIx, IIcx, IIci, IIfx, and IIsi), and the Quadra 700.
 
-This particular repository contains the main firmware that runs on the programmer board. The current compiler version used with this project is avr-gcc 4.8.2. Using a different version of gcc may result in worse performance due to some very tight optimization performed on this project to decrease programming time.
+This particular repository contains the main firmware that runs on the programmer board. There are two variants of the firmware that are built from this source code:
+
+1. The firmware for [my original programmer](https://www.downtowndougbrown.com/2012/08/mac-rom-simm-programmer/), the [Big Mess o' Wires programmer](http://www.bigmessowires.com/mac-rom-inator-ii-programming/), and the [CayMac Vintage revision 1 programmer](https://ko-fi.com/s/6f9e9644e4). These programmers use the Atmel/Microchip AT90USB646/1286 AVR microcontroller. The current compiler version used with this version of the firmware is avr-gcc 4.8.2. Using a different version of gcc may result in worse performance due to some very tight optimizations performed on this project to decrease programming time.
+2. The firmware for the [CayMac Vintage ROMmate-2](https://ko-fi.com/s/d6e7e4494d), which uses the Nuvoton M258KE3AE ARM Cortex-M23 microcontroller. The compiler that has been tested with this firmware is [ARM GCC 6-2017-q1-update](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/6-2017-q1-update).
 
 # Downloads
 
-Binary downloads (originally [from Google Code](https://code.google.com/p/mac-rom-simm-programmer/downloads/list)) can be found at https://github.com/dougg3/mac-rom-simm-programmer/tree/downloads/downloads
+Binary downloads can be found at the following links:
+
+- [Firmware](https://github.com/dougg3/mac-rom-simm-programmer/releases)
+- [Control Software](https://github.com/dougg3/mac-rom-simm-programmer.software/releases)
+- [Bootloader](https://github.com/dougg3/mac-rom-simm-programmer.bootloader/releases)
 
 # Repositories
 
@@ -18,23 +25,49 @@ The project is spread over a few repositories. Some of them have a wiki.
 | Bootloader (AVR microcontroller)                       | https://github.com/dougg3/mac-rom-simm-programmer.bootloader
 | Programmer Software (Windows/Mac/Linux)                | https://github.com/dougg3/mac-rom-simm-programmer.software       | none |
 | Windows Driver (.inf file, not needed on Windows 10)   | https://github.com/dougg3/mac-rom-simm-programmer.windriver      | none |
-| Custom QextSerialPort for Programmer Software          | https://github.com/dougg3/doug-qextserialport-linuxnotifications | none |
-| QextSerialPort base                                    | https://github.com/qextserialport/qextserialport                 | https://github.com/qextserialport/qextserialport/blob/wiki/Welcome.md |
 | CAD for programmer, along with 2 MB and 8 MB SIMM PCBs | https://github.com/dougg3/mac-rom-simm-programmer.cad            | none |                    
 | Mac ROM patcher                                        | https://github.com/jpluimers/macrompatcher/ (from https://code.google.com/p/macrompatcher) | none |
 
 # Firmware compilation instructions
 
-As mentioned earlier, this is an AVR project that is currently optimized for avr-gcc 4.8.2. It can be built using either CMake or Eclipse with the [AVR Eclipse plugin](https://avr-eclipse.sourceforge.net/wiki/index.php/The_AVR_Eclipse_Plugin). To build with CMake:
+## AT90USB646/AT90USB1286
+
+This firmware is used on my original programmer, the BMOW programmer, and CayMac's original programmer.
+
+As mentioned earlier, this is an AVR project that is currently optimized for avr-gcc 4.8.2. It can be built using either CMake or Eclipse with the [AVR Eclipse plugin](https://avr-eclipse.sourceforge.net/wiki/index.php/The_AVR_Eclipse_Plugin). To build with CMake, make sure avr-gcc is in your path, and then run:
 
 ```
-mkdir build
-cd build
+mkdir build_avr
+cd build_avr
 cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-avr.cmake ..
 make
 ```
 
-This will result in a generated SIMMProgrammer.bin file which can be programmed to the board using the [Windows/Mac/Linux software](https://github.com/dougg3/mac-rom-simm-programmer.software).
+## M258KE3AE
+
+This firmware is used on the CayMac ROMmate-2.
+
+Tested with [ARM GCC 6-2017-q1-update](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/6-2017-q1-update). To build with CMake, make sure arm-none-eabi-gcc is in your path, and then run:
+
+```
+mkdir build_arm
+cd build_arm
+cmake -DCMAKE_TOOLCHAIN_FILE=../toolchain-m258ke.cmake ..
+make
+```
+
+## Common information
+
+The build processes described above will create a SIMMProgrammer.bin file that can be programmed to the board using the [Windows/Mac/Linux software](https://github.com/dougg3/mac-rom-simm-programmer.software). You can also generate a combined firmware image containing both the AVR and ARM builds that automatically flashes the correct firmware based on the detected board when using software version 2.0 or newer:
+
+```
+cat build_avr/SIMMProgrammer.bin \
+    <(echo -en "\xDB\x00\xDB\x01\xDB\x02\xDB\x03\xDB\x04\xDB\x05\xDB\x06\xDB\x07") \
+    <(echo -en "\xDB\x08\xDB\x09\xDB\x0A\xDB\x0B\xDB\x0C\xDB\x0D\xDB\x0E\xDB\x0F") \
+    <(echo -en "\xDB\xDB\xDB\xDB\xAA\xAA\xAA\xAA\xDB\xDB\xDB\xDB\x55\x55\x55\x55") \
+    build_arm/SIMMProgrammer.bin \
+    > SIMMProgrammerFirmware.bin
+```
 
 # Videos
 

--- a/chip_id.h
+++ b/chip_id.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/drivers/mcp23s17.c
+++ b/drivers/mcp23s17.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/drivers/mcp23s17.h
+++ b/drivers/mcp23s17.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/drivers/parallel_flash.c
+++ b/drivers/parallel_flash.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/drivers/parallel_flash.h
+++ b/drivers/parallel_flash.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/board.c
+++ b/hal/at90usb646/board.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/board_hw.h
+++ b/hal/at90usb646/board_hw.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/cdc_device_definition.c
+++ b/hal/at90usb646/cdc_device_definition.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/cdc_device_definition.h
+++ b/hal/at90usb646/cdc_device_definition.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/gpio.c
+++ b/hal/at90usb646/gpio.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/gpio.c
+++ b/hal/at90usb646/gpio.c
@@ -75,6 +75,18 @@ void GPIO_SetPullup(GPIOPin pin, bool pullup)
 	GPIO_Set(pin, pullup);
 }
 
+/**
+ * @brief Sets whether an input GPIO pin is pulled down
+ * @param pin The pin
+ * @param pulldown True if it should be pulled down, false if not
+ */
+void GPIO_SetPulldown(GPIOPin pin, bool pulldown)
+{
+	(void)pin;
+	(void)pulldown;
+	// The AVR doesn't support pulldowns
+}
+
 /** Turns a GPIO pin on (sets it high)
  *
  * @param pin The pin

--- a/hal/at90usb646/gpio_hw.h
+++ b/hal/at90usb646/gpio_hw.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/hardware.h
+++ b/hal/at90usb646/hardware.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/parallel_bus.c
+++ b/hal/at90usb646/parallel_bus.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * -----------------------------------------------------------------------------
  *

--- a/hal/at90usb646/parallel_bus.c
+++ b/hal/at90usb646/parallel_bus.c
@@ -313,6 +313,17 @@ void ParallelBus_SetAddressPullups(uint32_t pullups)
 	ParallelBus_SetAddress(pullups);
 }
 
+/** Sets which pins on the 21-bit address bus should be pulled down (if inputs)
+ *
+ * @param pulldowns Mask of pins that should be pulldowns.
+ *
+ * Not supported on the AVR. It's only for electrical testing, so no big deal.
+ */
+void ParallelBus_SetAddressPulldowns(uint32_t pulldowns)
+{
+	(void)pulldowns;
+}
+
 /** Sets which pins on the 32-bit data bus should be pulled up (if inputs)
  *
  * @param pullups Mask of pins that should be pullups.
@@ -340,6 +351,17 @@ void ParallelBus_SetDataPullups(uint32_t pullups)
 	MCP23S17_SetPullups(&mcp23s17, u.dataShorts[1]);
 }
 
+/** Sets which pins on the 32-bit data bus should be pulled down (if inputs)
+ *
+ * @param pulldowns Mask of pins that should be pulldowns.
+ *
+ * Not supported on the AVR. It's only for electrical testing, so no big deal.
+ */
+void ParallelBus_SetDataPulldowns(uint32_t pulldowns)
+{
+	(void)pulldowns;
+}
+
 /** Sets whether the CS pin is pulled up, if it's an input.
  *
  * @param pullup True if the CS pin should be pulled up, false if not
@@ -350,6 +372,17 @@ void ParallelBus_SetDataPullups(uint32_t pullups)
 void ParallelBus_SetCSPullup(bool pullup)
 {
 	GPIO_SetPullup(flashCSPin, pullup);
+}
+
+/** Sets whether the CS pin is pulled down, if it's an input.
+ *
+ * @param pulldown True if the CS pin should be pulled down, false if not
+ *
+ * Not supported on the AVR. It's only for electrical testing, so no big deal.
+ */
+void ParallelBus_SetCSPulldown(bool pulldown)
+{
+	(void)pulldown;
 }
 
 /** Sets whether the OE pin is pulled up, if it's an input.
@@ -364,6 +397,17 @@ void ParallelBus_SetOEPullup(bool pullup)
 	GPIO_SetPullup(flashOEPin, pullup);
 }
 
+/** Sets whether the OE pin is pulled down, if it's an input.
+ *
+ * @param pulldown True if the OE pin should be pulled down, false if not
+ *
+ * Not supported on the AVR. It's only for electrical testing, so no big deal.
+ */
+void ParallelBus_SetOEPulldown(bool pulldown)
+{
+	(void)pulldown;
+}
+
 /** Sets whether the WE pin is pulled up, if it's an input.
  *
  * @param pullup True if the WE pin should be pulled up, false if not
@@ -374,6 +418,17 @@ void ParallelBus_SetOEPullup(bool pullup)
 void ParallelBus_SetWEPullup(bool pullup)
 {
 	GPIO_SetPullup(flashWEPin, pullup);
+}
+
+/** Sets whether the WE pin is pulled down, if it's an input.
+ *
+ * @param pulldown True if the WE pin should be pulled down, false if not
+ *
+ * Not supported on the AVR. It's only for electrical testing, so no big deal.
+ */
+void ParallelBus_SetWEPulldown(bool pulldown)
+{
+	(void)pulldown;
 }
 
 /** Reads the current data on the address bus.

--- a/hal/at90usb646/spi.c
+++ b/hal/at90usb646/spi.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/spi_private.h
+++ b/hal/at90usb646/spi_private.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/usbcdc.c
+++ b/hal/at90usb646/usbcdc.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/at90usb646/usbcdc_hw.h
+++ b/hal/at90usb646/usbcdc_hw.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/board.h
+++ b/hal/board.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/gpio.h
+++ b/hal/gpio.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/gpio.h
+++ b/hal/gpio.h
@@ -43,6 +43,7 @@ typedef struct GPIOPin
 
 void GPIO_SetDirection(GPIOPin pin, bool output);
 void GPIO_SetPullup(GPIOPin pin, bool pullup);
+void GPIO_SetPulldown(GPIOPin pin, bool pulldown);
 void GPIO_SetOn(GPIOPin pin);
 void GPIO_SetOff(GPIOPin pin);
 void GPIO_Toggle(GPIOPin pin);

--- a/hal/m258ke/board.c
+++ b/hal/m258ke/board.c
@@ -1,0 +1,71 @@
+/*
+ * board.c
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "board_hw.h"
+
+/** Initializes any board hardware-specific stuff
+ *
+ */
+void Board_Init(void)
+{
+	// Unlock protected registers so we can configure clocks, flash, WDT, etc.
+	do
+	{
+		SYS->REGLCTL = 0x59UL;
+		SYS->REGLCTL = 0x16UL;
+		SYS->REGLCTL = 0x88UL;
+	} while (SYS->REGLCTL == 0UL);
+
+	// Enable 48 MHz internal high-speed RC oscillator
+	CLK->PWRCTL |= CLK_PWRCTL_HIRCEN_Msk;
+
+	// Wait until it's ready
+	while (!(CLK->STATUS & CLK_STATUS_HIRCSTB_Msk));
+
+	// Clock HCLK and USB from 48 MHz HIRC
+	CLK->CLKSEL0 = (CLK->CLKSEL0 & (~(CLK_CLKSEL0_HCLKSEL_Msk | CLK_CLKSEL0_USBDSEL_Msk))) |
+			(7 << CLK_CLKSEL0_HCLKSEL_Pos) | (0 << CLK_CLKSEL0_USBDSEL_Pos);
+
+	// SystemCoreClock, CyclesPerUs, CyclesPerUs default to correct values already
+
+	// Enable USB device controller
+	CLK->APBCLK0 |= CLK_APBCLK0_USBDCKEN_Msk;
+
+	// Enable all GPIO
+	CLK->AHBCLK |=
+			CLK_AHBCLK_GPACKEN_Msk |
+			CLK_AHBCLK_GPBCKEN_Msk |
+			CLK_AHBCLK_GPCCKEN_Msk |
+			CLK_AHBCLK_GPDCKEN_Msk |
+			CLK_AHBCLK_GPECKEN_Msk |
+			CLK_AHBCLK_GPFCKEN_Msk;
+}
+
+/** Determines if a brownout was detected at startup
+ *
+ * @return True if a brownout was detected
+ */
+bool Board_BrownoutDetected(void)
+{
+	return false;
+}

--- a/hal/m258ke/board.c
+++ b/hal/m258ke/board.c
@@ -68,6 +68,9 @@ void Board_Init(void)
 
 	// Start the timer, prescaler = 48, so 1 MHz
 	TIMER0->CTL = TIMER_CTL_CNTEN_Msk | (3UL << TIMER_CTL_OPMODE_Pos) | 47;
+
+	// Disable WDT now; the main firmware is booted.
+	WDT->CTL = (6 << WDT_CTL_TOUTSEL_Pos);
 }
 
 /** Determines if a brownout was detected at startup

--- a/hal/m258ke/board.c
+++ b/hal/m258ke/board.c
@@ -51,6 +51,12 @@ void Board_Init(void)
 	// Enable USB device controller
 	CLK->APBCLK0 |= CLK_APBCLK0_USBDCKEN_Msk;
 
+	// Enable timer 0
+	CLK->APBCLK0 |= CLK_APBCLK0_TMR0CKEN_Msk;
+
+	// Timer 0 clock source = 48 MHz HIRC
+	CLK->CLKSEL1 = (CLK->CLKSEL1 & (~(CLK_CLKSEL1_TMR0SEL_Msk))) | (7UL << CLK_CLKSEL1_TMR0SEL_Pos);
+
 	// Enable all GPIO
 	CLK->AHBCLK |=
 			CLK_AHBCLK_GPACKEN_Msk |
@@ -59,6 +65,9 @@ void Board_Init(void)
 			CLK_AHBCLK_GPDCKEN_Msk |
 			CLK_AHBCLK_GPECKEN_Msk |
 			CLK_AHBCLK_GPFCKEN_Msk;
+
+	// Start the timer, prescaler = 48, so 1 MHz
+	TIMER0->CTL = TIMER_CTL_CNTEN_Msk | (3UL << TIMER_CTL_OPMODE_Pos) | 47;
 }
 
 /** Determines if a brownout was detected at startup

--- a/hal/m258ke/board_hw.h
+++ b/hal/m258ke/board_hw.h
@@ -1,0 +1,77 @@
+/*
+ * board_hw.h
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAL_M258KE_BOARD_HW_H_
+#define HAL_M258KE_BOARD_HW_H_
+
+#include "gpio_hw.h"
+#include "../gpio.h"
+#include "hardware.h"
+#include "../usbcdc.h"
+
+#define BOARD_LED_INVERTED true
+
+/** Gets the GPIO pin on the board that controls the status LED
+ *
+ * @return The status LED pin
+ */
+static inline GPIOPin Board_LEDPin(void)
+{
+	return GPIO_PIN(GPIOC, 9);
+}
+
+/** Jumps to the bootloader
+ *
+ */
+static inline void Board_EnterBootloader(void)
+{
+	// Insert a small delay to ensure that it arrives before rebooting.
+	DelayMS(1000);
+
+	// Disable interrupts so nothing weird happens...
+	DisableInterrupts();
+
+	// Done with the USB interface -- the bootloader will re-initialize it.
+	USBCDC_Disable();
+
+	// Wait a little bit to let everything settle and let the program
+	// close the port after the USB disconnect
+	DelayMS(2000);
+
+	// Clear reset status bits so that bootloader knows reset reason
+	SYS->RSTSTS = (SYS_RSTSTS_PORF_Msk | SYS_RSTSTS_PINRF_Msk);
+
+	// Boot to LDROM next time
+	FMC->ISPCTL |= FMC_ISPCTL_BS_Msk;
+
+	// Save a special flag in RAM to indicate we want to stay in the bootloader
+	*(uint32_t *)(0x20003FFC) = 0xBADF00D5;
+
+	// Reset!
+	NVIC_SystemReset();
+
+	// Should never get here, but just in case...
+	while (1);
+}
+
+#endif /* HAL_M258KE_BOARD_HW_H_ */

--- a/hal/m258ke/board_hw.h
+++ b/hal/m258ke/board_hw.h
@@ -30,6 +30,7 @@
 #include "../usbcdc.h"
 
 #define BOARD_LED_INVERTED true
+#define BOARD_SUPPORTS_PULLDOWNS true
 
 /** Gets the GPIO pin on the board that controls the status LED
  *

--- a/hal/m258ke/descriptors.c
+++ b/hal/m258ke/descriptors.c
@@ -1,0 +1,194 @@
+/****************************************************************************//**
+ * @file     descriptors.c
+ * @version  V0.10
+ * @brief    USBD descriptors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ ******************************************************************************/
+
+#include "usbcdc_hw.h"
+
+/// VID and PID of our device
+#define USB_VID        0x16D0
+#define USB_PID        0x06AA
+
+/// Device descriptor
+const uint8_t deviceDescriptor[] = {
+    LEN_DEVICE,       // bLength
+    DESC_DEVICE,      // bDescriptorType
+    0x10, 0x01,       // bcdUSB
+    0x02,             // bDeviceClass
+    0x00,             // bDeviceSubClass
+    0x00,             // bDeviceProtocol
+    EP0_MAX_PKT_SIZE, // bMaxPacketSize0
+    // idVendor
+    USB_VID & 0x00FF, (USB_VID & 0xFF00) >> 8,
+    // idProduct
+    USB_PID & 0x00FF, (USB_PID & 0xFF00) >> 8,
+    0x02, 0x00, // bcdDevice
+    0x01,       // iManufacturer
+    0x02,       // iProduct
+    0x03,       // iSerialNumber
+    0x01        // bNumConfigurations
+};
+
+/// Config descriptor (includes interface, endpoint descriptors)
+const uint8_t configDescriptor[] =
+{
+    LEN_CONFIG,     // bLength
+    DESC_CONFIG,    // bDescriptorType
+    0x3E, 0x00,     // wTotalLength
+    0x02,           // bNumInterfaces
+    0x01,           // bConfigurationValue
+    0x00,           // iConfiguration
+    0xC0,           // bmAttributes
+    0xFA,           // MaxPower
+
+    // Interface descriptor: communication class interface
+    LEN_INTERFACE,  // bLength
+    DESC_INTERFACE, // bDescriptorType
+    0x00,           // bInterfaceNumber
+    0x00,           // bAlternateSetting
+    0x01,           // bNumEndpoints
+    0x02,           // bInterfaceClass
+    0x02,           // bInterfaceSubClass
+    0x01,           // bInterfaceProtocol
+    0x00,           // iInterface
+
+    // Header functional descriptor
+    0x05,           // Size of the descriptor, in bytes
+    0x24,           // CS_INTERFACE descriptor type
+    0x00,           // Header functional descriptor subtype
+    0x10, 0x01,     // Communication device compliant to the communication spec. ver. 1.10
+
+    // Abstract control management functional descriptor
+    0x04,           // Size of the descriptor, in bytes
+    0x24,           // CS_INTERFACE descriptor type
+    0x02,           // Abstract control management functional descriptor subtype
+    0x06,           // bmCapabilities
+
+    // Union functional descriptor
+    0x05,           // bLength
+    0x24,           // bDescriptorType: CS_INTERFACE descriptor type
+    0x06,           // bDescriptorSubType
+    0x00,           // bMasterInterface
+    0x01,           // bSlaveInterface0
+
+    // Endpoint descriptor
+    LEN_ENDPOINT,                   // bLength
+    DESC_ENDPOINT,                  // bDescriptorType
+    (EP_INPUT | INT_IN_EP_NUM),     // bEndpointAddress
+    EP_INT,                         // bmAttributes
+    EP2_MAX_PKT_SIZE, 0x00,         // wMaxPacketSize
+    0xFF,                           // bInterval
+
+    // Interface descriptor: data class interface
+    LEN_INTERFACE,  // bLength
+    DESC_INTERFACE, // bDescriptorType
+    0x01,           // bInterfaceNumber
+    0x00,           // bAlternateSetting
+    0x02,           // bNumEndpoints
+    0x0A,           // bInterfaceClass
+    0x00,           // bInterfaceSubClass
+    0x00,           // bInterfaceProtocol
+    0x00,           // iInterface
+
+    // Endpoint descriptor
+    LEN_ENDPOINT,                   // bLength
+    DESC_ENDPOINT,                  // bDescriptorType
+    (EP_OUTPUT | BULK_OUT_EP_NUM),  // bEndpointAddress
+    EP_BULK,                        // bmAttributes
+    EP4_MAX_PKT_SIZE, 0x00,         // wMaxPacketSize
+    0x01,                           // bInterval
+
+    // Endpoint descriptor
+    LEN_ENDPOINT,                   // bLength
+    DESC_ENDPOINT,                  // bDescriptorType
+    (EP_INPUT | BULK_IN_EP_NUM),    // bEndpointAddress
+    EP_BULK,                        // bmAttributes
+    EP3_MAX_PKT_SIZE, 0x00,         // wMaxPacketSize
+    0x01,                           // bInterval
+};
+
+
+/// Language descriptor
+const uint8_t languageStringDescriptor[4] =
+{
+    4,              // bLength
+    DESC_STRING,    // bDescriptorType
+    0x09, 0x04      // English (United States)
+};
+
+/// Vendor string descriptor
+const uint8_t vendorStringDescriptor[] =
+{
+    22,
+    DESC_STRING,
+    'D', 0,
+    'o', 0,
+    'u', 0,
+    'g', 0,
+    ' ', 0,
+    'B', 0,
+    'r', 0,
+    'o', 0,
+    'w', 0,
+    'n', 0,
+};
+
+/// Product string descriptor
+const uint8_t productStringDescriptor[] =
+{
+    48,             // bLength
+    DESC_STRING,    // bDescriptorType
+    'M', 0,
+    'a', 0,
+    'c', 0,
+    ' ', 0,
+    'R', 0,
+    'O', 0,
+    'M', 0,
+    ' ', 0,
+    'S', 0,
+    'I', 0,
+    'M', 0,
+    'M', 0,
+    ' ', 0,
+    'P', 0,
+    'r', 0,
+    'o', 0,
+    'g', 0,
+    'r', 0,
+    'a', 0,
+    'm', 0,
+    'm', 0,
+    'e', 0,
+    'r', 0,
+};
+
+/// Serial number string descriptor
+const uint8_t serialStringDescriptor[] =
+{
+    4,             // bLength
+    DESC_STRING,    // bDescriptorType
+    '0', 0,
+};
+
+/// Array of string descriptors
+const uint8_t * const stringDescriptors[4] =
+{
+    languageStringDescriptor,
+    vendorStringDescriptor,
+    productStringDescriptor,
+    serialStringDescriptor
+};
+
+/// Descriptor info used by usbd.c
+const S_USBD_INFO_T gsInfo =
+{
+    deviceDescriptor,
+    configDescriptor,
+    stringDescriptors,
+};
+

--- a/hal/m258ke/gpio.c
+++ b/hal/m258ke/gpio.c
@@ -1,0 +1,112 @@
+/*
+ * gpio.c
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../gpio.h"
+#include "nuvoton/NuMicro.h"
+
+/// The GPIO ports available on the M258KE
+static GPIO_T * const gpioRegs[] = {
+	PA,
+	PB,
+	PC,
+	PD,
+	PE,
+	PF
+};
+
+/** Sets the direction of a GPIO pin.
+ *
+ * @param pin The pin
+ * @param output True if it should be an output, false if it should be an input
+ */
+void GPIO_SetDirection(GPIOPin pin, bool output)
+{
+	if (output)
+	{
+		uint32_t tmp = gpioRegs[pin.port]->MODE;
+		tmp &= ~(2UL << 2*pin.pin);
+		tmp |= (1UL << 2*pin.pin);
+		gpioRegs[pin.port]->MODE = tmp;
+	}
+	else
+	{
+		gpioRegs[pin.port]->MODE &= ~(3UL << 2*pin.pin);
+	}
+}
+
+/** Sets whether an input GPIO pin is pulled up
+ *
+ * @param pin The pin
+ * @param pullup True if it should be pulled up, false if not
+ */
+void GPIO_SetPullup(GPIOPin pin, bool pullup)
+{
+	if (pullup)
+	{
+		uint32_t tmp = gpioRegs[pin.port]->PUSEL;
+		tmp &= ~(2UL << 2*pin.pin);
+		tmp |= (1UL << 2*pin.pin);
+		gpioRegs[pin.port]->PUSEL = tmp;
+	}
+	else
+	{
+		gpioRegs[pin.port]->PUSEL &= ~(3UL << 2*pin.pin);
+	}
+}
+
+/** Turns a GPIO pin on (sets it high)
+ *
+ * @param pin The pin
+ */
+void GPIO_SetOn(GPIOPin pin)
+{
+	gpioRegs[pin.port]->DOUT |= (1 << pin.pin);
+}
+
+/** Turns a GPIO pin off (sets it low)
+ *
+ * @param pin The pin
+ */
+void GPIO_SetOff(GPIOPin pin)
+{
+	gpioRegs[pin.port]->DOUT &= ~(1 << pin.pin);
+}
+
+/** Toggles a GPIO pin
+ *
+ * @param pin The pin
+ */
+void GPIO_Toggle(GPIOPin pin)
+{
+	gpioRegs[pin.port]->DOUT ^= (1 << pin.pin);
+}
+
+/** Reads the input status of a GPIO pin
+ *
+ * @param pin The pin
+ * @return True if it's high, false if it's low
+ */
+bool GPIO_Read(GPIOPin pin)
+{
+	return gpioRegs[pin.port]->PIN & (1 << pin.pin);
+}

--- a/hal/m258ke/gpio.c
+++ b/hal/m258ke/gpio.c
@@ -64,13 +64,31 @@ void GPIO_SetPullup(GPIOPin pin, bool pullup)
 	if (pullup)
 	{
 		uint32_t tmp = gpioRegs[pin.port]->PUSEL;
-		tmp &= ~(2UL << 2*pin.pin);
 		tmp |= (1UL << 2*pin.pin);
 		gpioRegs[pin.port]->PUSEL = tmp;
 	}
 	else
 	{
-		gpioRegs[pin.port]->PUSEL &= ~(3UL << 2*pin.pin);
+		gpioRegs[pin.port]->PUSEL &= ~(1UL << 2*pin.pin);
+	}
+}
+
+/** Sets whether an input GPIO pin is pulled down
+ *
+ * @param pin The pin
+ * @param pulldown True if it should be pulled down, false if not
+ */
+void GPIO_SetPulldown(GPIOPin pin, bool pulldown)
+{
+	if (pulldown)
+	{
+		uint32_t tmp = gpioRegs[pin.port]->PUSEL;
+		tmp |= (2UL << 2*pin.pin);
+		gpioRegs[pin.port]->PUSEL = tmp;
+	}
+	else
+	{
+		gpioRegs[pin.port]->PUSEL &= ~(2UL << 2*pin.pin);
 	}
 }
 

--- a/hal/m258ke/gpio_hw.h
+++ b/hal/m258ke/gpio_hw.h
@@ -1,0 +1,38 @@
+/*
+ * gpio_hw.h
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAL_M258KE_GPIO_HW_H_
+#define HAL_M258KE_GPIO_HW_H_
+
+/// Enum representing the different GPIO ports available on the M258KE.
+/// Used with the GPIOPin struct.
+enum {
+	GPIOA,
+	GPIOB,
+	GPIOC,
+	GPIOD,
+	GPIOE,
+	GPIOF
+};
+
+#endif /* HAL_M258KE_GPIO_HW_H_ */

--- a/hal/m258ke/hardware.h
+++ b/hal/m258ke/hardware.h
@@ -44,22 +44,27 @@ static inline void EnableInterrupts(void)
 	__enable_irq();
 }
 
-/** Blocks for the specified number of milliseconds
- *
- * @param ms The number of milliseconds to wait
- */
-static inline void DelayMS(uint32_t ms)
-{
-
-}
-
 /** Blocks for the specified number of microseconds
  *
  * @param us The number of microseconds to wait
  */
 static inline void DelayUS(uint32_t us)
 {
+	const uint32_t startTime = TIMER0->CNT & 0xFFFFFFUL;
+	uint32_t nowTime;
+	do
+	{
+		nowTime = TIMER0->CNT & 0xFFFFFFUL;
+	} while (((nowTime - startTime) & 0xFFFFFFUL) < us);
+}
 
+/** Blocks for the specified number of milliseconds
+ *
+ * @param ms The number of milliseconds to wait
+ */
+static inline void DelayMS(uint32_t ms)
+{
+	DelayUS(ms * 1000UL);
 }
 
 #endif /* HAL_M258KE_HARDWARE_H_ */

--- a/hal/m258ke/hardware.h
+++ b/hal/m258ke/hardware.h
@@ -1,0 +1,65 @@
+/*
+ * hardware.h
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAL_M258KE_HARDWARE_H_
+#define HAL_M258KE_HARDWARE_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "nuvoton/NuMicro.h"
+
+/** Disables interrupts
+ *
+ */
+static inline void DisableInterrupts(void)
+{
+	__disable_irq();
+}
+
+/** Enables interrupts
+ *
+ */
+static inline void EnableInterrupts(void)
+{
+	__enable_irq();
+}
+
+/** Blocks for the specified number of milliseconds
+ *
+ * @param ms The number of milliseconds to wait
+ */
+static inline void DelayMS(uint32_t ms)
+{
+
+}
+
+/** Blocks for the specified number of microseconds
+ *
+ * @param us The number of microseconds to wait
+ */
+static inline void DelayUS(uint32_t us)
+{
+
+}
+
+#endif /* HAL_M258KE_HARDWARE_H_ */

--- a/hal/m258ke/m258ke_options.cmake
+++ b/hal/m258ke/m258ke_options.cmake
@@ -1,0 +1,28 @@
+# M258KE-specific include paths
+target_include_directories(SIMMProgrammer.elf PRIVATE
+	hal/m258ke
+)
+
+# M258KE-specific compiler definitions
+target_compile_definitions(SIMMProgrammer.elf PRIVATE
+)
+
+# M258KE-specific compiler options
+target_compile_options(SIMMProgrammer.elf PRIVATE
+	-mcpu=cortex-m23 -march=armv8-m.base -mthumb
+)
+
+# M258KE-specific linker options
+target_link_options(SIMMProgrammer.elf PRIVATE
+	-mcpu=cortex-m23 -march=armv8-m.base -mthumb
+	-T ${CMAKE_SOURCE_DIR}/hal/m258ke/nuvoton/gcc_arm.ld
+	--specs=nano.specs
+)
+
+# M258KE-specific command/target to generate .bin file from the ELF file. This program
+# is flashed using a bootloader, so there's no need to generate a HEX file.
+add_custom_command(OUTPUT SIMMProgrammer.bin
+	COMMAND ${CMAKE_OBJCOPY} -O binary SIMMProgrammer.elf SIMMProgrammer.bin
+	DEPENDS SIMMProgrammer.elf
+)
+add_custom_target(SIMMProgrammer_bin ALL DEPENDS SIMMProgrammer.bin)

--- a/hal/m258ke/m258ke_sources.cmake
+++ b/hal/m258ke/m258ke_sources.cmake
@@ -1,0 +1,60 @@
+set(HWSOURCES
+	hal/m258ke/nuvoton/core_cm23.h
+	hal/m258ke/nuvoton/cmsis_armcc.h
+	hal/m258ke/nuvoton/cmsis_armclang.h
+	hal/m258ke/nuvoton/cmsis_compiler.h
+	hal/m258ke/nuvoton/cmsis_gcc.h
+	hal/m258ke/nuvoton/cmsis_version.h
+
+	hal/m258ke/nuvoton/NuMicro.h
+	hal/m258ke/nuvoton/M251.h
+	hal/m258ke/nuvoton/system_M251.c
+	hal/m258ke/nuvoton/system_M251.h
+	hal/m258ke/nuvoton/startup_M251.S
+
+	hal/m258ke/nuvoton/acmp_reg.h
+	hal/m258ke/nuvoton/bpwm_reg.h
+	hal/m258ke/nuvoton/clk_reg.h
+	hal/m258ke/nuvoton/crc_reg.h
+	hal/m258ke/nuvoton/crypto_reg.h
+	hal/m258ke/nuvoton/dac_reg.h
+	hal/m258ke/nuvoton/eadc_reg.h
+	hal/m258ke/nuvoton/ebi_reg.h
+	hal/m258ke/nuvoton/fmc_reg.h
+	hal/m258ke/nuvoton/gpio_reg.h
+	hal/m258ke/nuvoton/i2c_reg.h
+	hal/m258ke/nuvoton/lcd_reg.h
+	hal/m258ke/nuvoton/opa_reg.h
+	hal/m258ke/nuvoton/pdma_reg.h
+	hal/m258ke/nuvoton/psio_reg.h
+	hal/m258ke/nuvoton/pwm_reg.h
+	hal/m258ke/nuvoton/qspi_reg.h
+	hal/m258ke/nuvoton/rtc_reg.h
+	hal/m258ke/nuvoton/sc_reg.h
+	hal/m258ke/nuvoton/spi_reg.h
+	hal/m258ke/nuvoton/sys_reg.h
+	hal/m258ke/nuvoton/timer_reg.h
+	hal/m258ke/nuvoton/tk_reg.h
+	hal/m258ke/nuvoton/uart_reg.h
+	hal/m258ke/nuvoton/ui2c_reg.h
+	hal/m258ke/nuvoton/usbd_reg.h
+	hal/m258ke/nuvoton/uspi_reg.h
+	hal/m258ke/nuvoton/uuart_reg.h
+	hal/m258ke/nuvoton/wdt_reg.h
+	hal/m258ke/nuvoton/wwdt_reg.h
+
+	hal/m258ke/nuvoton/usbd.c
+	hal/m258ke/nuvoton/usbd.h
+
+	hal/m258ke/board.c
+	hal/m258ke/board_hw.h
+	hal/m258ke/descriptors.c
+	hal/m258ke/gpio.c
+	hal/m258ke/gpio_hw.h
+	hal/m258ke/hardware.h
+	hal/m258ke/parallel_bus.c
+	hal/m258ke/spi.c
+	hal/m258ke/spi_private.h
+	hal/m258ke/usbcdc.c
+	hal/m258ke/usbcdc_hw.h
+)

--- a/hal/m258ke/nuvoton/LDROM.ld
+++ b/hal/m258ke/nuvoton/LDROM.ld
@@ -1,0 +1,195 @@
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00100000, LENGTH = 0x1000    /* 4K */
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 0x2000    /* 8K */
+}
+
+/* Library configurations */
+GROUP(libgcc.a libc.a libm.a libnosys.a)
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __Vectors_End
+ *   __Vectors_Size
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.vectors))
+		__Vectors_End = .;
+		__Vectors_Size = __Vectors_End - __Vectors;
+		__end__ = .;
+
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+		*crtbegin.o(.ctors)
+		*crtbegin?.o(.ctors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+		*(SORT(.ctors.*))
+		*(.ctors)
+
+		/* .dtors */
+ 		*crtbegin.o(.dtors)
+ 		*crtbegin?.o(.dtors)
+ 		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+ 		*(SORT(.dtors.*))
+ 		*(.dtors)
+
+		*(.rodata*)
+
+		KEEP(*(.eh_frame*))
+	} > FLASH
+
+	.ARM.extab :
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+	} > FLASH
+	__exidx_end = .;
+
+	/* To copy multiple ROM to RAM sections,
+	 * uncomment .copy.table section and,
+	 * define __STARTUP_COPY_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.copy.table :
+	{
+		. = ALIGN(4);
+		__copy_table_start__ = .;
+		LONG (__etext)
+		LONG (__data_start__)
+		LONG (__data_end__ - __data_start__)
+		LONG (__etext2)
+		LONG (__data2_start__)
+		LONG (__data2_end__ - __data2_start__)
+		__copy_table_end__ = .;
+	} > FLASH
+	*/
+
+	/* To clear multiple BSS sections,
+	 * uncomment .zero.table section and,
+	 * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.zero.table :
+	{
+		. = ALIGN(4);
+		__zero_table_start__ = .;
+		LONG (__bss_start__)
+		LONG (__bss_end__ - __bss_start__)
+		LONG (__bss2_start__)
+		LONG (__bss2_end__ - __bss2_start__)
+		__zero_table_end__ = .;
+	} > FLASH
+	*/
+
+	__etext = .;
+
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP(*(SORT(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP(*(SORT(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		KEEP(*(.jcr*))
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+	} > RAM
+
+	.heap (COPY):
+	{
+		__HeapBase = .;
+		__end__ = .;
+		end = __end__;
+		KEEP(*(.heap*))
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		KEEP(*(.stack*))
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/hal/m258ke/nuvoton/LDROM.ld
+++ b/hal/m258ke/nuvoton/LDROM.ld
@@ -1,8 +1,8 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx) : ORIGIN = 0x00100000, LENGTH = 0x1000    /* 4K */
-  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 0x2000    /* 8K */
+  FLASH (rx) : ORIGIN = 0x00100000, LENGTH = 4*1024
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 16*1024
 }
 
 /* Library configurations */

--- a/hal/m258ke/nuvoton/LDROM.ld
+++ b/hal/m258ke/nuvoton/LDROM.ld
@@ -123,7 +123,7 @@ SECTIONS
 
 	__etext = .;
 
-	.data : AT (__etext)
+	.data : ALIGN(4)
 	{
 		__data_start__ = .;
 		*(vtable)
@@ -155,7 +155,7 @@ SECTIONS
 		/* All data end */
 		__data_end__ = .;
 
-	} > RAM
+	} > RAM AT > FLASH
 
 	.bss :
 	{

--- a/hal/m258ke/nuvoton/LDROM.ld
+++ b/hal/m258ke/nuvoton/LDROM.ld
@@ -185,8 +185,8 @@ SECTIONS
 	} > RAM
 
 	/* Set stack top to end of RAM, and stack limit move down by
-	 * size of stack_dummy section */
-	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	 * size of stack_dummy section. Reserve 4 bytes at end of RAM for magic number. */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM) - 4;
 	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
 	PROVIDE(__stack = __StackTop);
 

--- a/hal/m258ke/nuvoton/M251.h
+++ b/hal/m258ke/nuvoton/M251.h
@@ -609,42 +609,4 @@ typedef volatile uint64_t vu64;       ///< Define 64-bit unsigned volatile data 
 
 /** @} end of group Legacy_Constants */
 
-
-/******************************************************************************/
-/*                         Peripheral header files                            */
-/******************************************************************************/
-#include "bpwm.h"
-#include "sys.h"
-#include "clk.h"
-#include "uart.h"
-#include "opa.h"
-#include "acmp.h"
-#include "rtc.h"
-#include "fmc.h"
-#include "gpio.h"
-#include "i2c.h"
-#include "pdma.h"
-#include "pwm.h"
-#include "qspi.h"
-#include "spi.h"
-#include "timer.h"
-#include "timer_pwm.h"
-#include "usci_i2c.h"
-#include "usci_spi.h"
-#include "usci_uart.h"
-#include "usbd.h"
-#include "rtc.h"
-#include "crc.h"
-#include "crypto.h"
-#include "wdt.h"
-#include "wwdt.h"
-#include "eadc.h"
-#include "dac.h"
-#include "ebi.h"
-#include "psio.h"
-#include "sc.h"
-#include "scuart.h"
-#include "lcd.h"
-#include "tk.h"
-
 #endif  /* __M251_H__ */

--- a/hal/m258ke/nuvoton/M251.h
+++ b/hal/m258ke/nuvoton/M251.h
@@ -1,0 +1,650 @@
+/**************************************************************************//**
+ * @file     M251.h
+ * @version  V1.0
+ * @brief    Peripheral Access Layer Header File
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ ******************************************************************************/
+
+/**
+  \mainpage NuMicro M251/M252/M254/M256/M258 Series CMSIS BSP Driver Reference
+  *
+  * <b>Introduction</b>
+  *
+  * This user manual describes the usage of M251/M252/M254/M256/M258 Series MCU device driver
+  *
+  * <b>Disclaimer</b>
+  *
+  * The Software is furnished "AS IS", without warranty as to performance or results, and
+  * the entire risk as to performance or results is assumed by YOU. Nuvoton disclaims all
+  * warranties, express, implied or otherwise, with regard to the Software, its use, or
+  * operation, including without limitation any and all warranties of merchantability, fitness
+  * for a particular purpose, and non-infringement of intellectual property rights.
+  *
+  * <b>Important Notice</b>
+  *
+  * Nuvoton Products are neither intended nor warranted for usage in systems or equipment,
+  * any malfunction or failure of which may cause loss of human life, bodily injury or severe
+  * property damage. Such applications are deemed, "Insecure Usage".
+  *
+  * Insecure usage includes, but is not limited to: equipment for surgical implementation,
+  * atomic energy control instruments, airplane or spaceship instruments, the control or
+  * operation of dynamic, brake or safety systems designed for vehicular use, traffic signal
+  * instruments, all types of safety devices, and other applications intended to support or
+  * sustain life.
+  *
+  * All Insecure Usage shall be made at customer's risk, and in the event that third parties
+  * lay claims to Nuvoton as a result of customer's Insecure Usage, customer shall indemnify
+  * the damages and liabilities thus incurred by Nuvoton.
+  *
+  * Please note that all data and specifications are subject to change without notice. All the
+  * trademarks of products and companies mentioned in this datasheet belong to their respective
+  * owners.
+  *
+  * <b>Copyright Notice</b>
+  *
+ * SPDX-License-Identifier: Apache-2.0
+  * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+  */
+
+#ifndef __M251_H__
+#define __M251_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/******************************************************************************/
+/*                Processor and Core Peripherals                              */
+/******************************************************************************/
+/** @addtogroup CMSIS_Device CMSIS Definitions
+  Configuration of the Cortex-M23 Processor and Core Peripherals
+  @{
+*/
+
+/*
+ * ==========================================================================
+ * ---------- Interrupt Number Definition -----------------------------------
+ * ==========================================================================
+ */
+
+/**
+ * @details  Interrupt Number Definition.
+ */
+typedef enum IRQn
+{
+    /******  Cortex-M0 Processor Exceptions Numbers ***********************************************/
+    NonMaskableInt_IRQn       = -14,    /*!< 2 Non Maskable Interrupt                             */
+    HardFault_IRQn            = -13,    /*!< 3 Cortex-M0 Hard Fault Interrupt                     */
+    SVCall_IRQn               = -5,     /*!< 11 Cortex-M0 SV Call Interrupt                       */
+    PendSV_IRQn               = -2,     /*!< 14 Cortex-M0 Pend SV Interrupt                       */
+    SysTick_IRQn              = -1,     /*!< 15 Cortex-M0 System Tick Interrupt                   */
+
+    /******  ARMIKMCU Swift specific Interrupt Numbers ********************************************/
+    BOD_IRQn                  = 0,      /*!< Brown-Out Low Voltage Detected Interrupt             */
+    IRCTRIM_IRQn              = 1,      /*!< Watch Dog Timer Interrupt                            */
+    PWRWU_IRQn                = 2,      /*!< EINT0, EINT2 and EINT4 Interrupt                     */
+    RESERVE0                  = 3,      /*!< Reserve 0                                            */
+    CLKFAIL_IRQn              = 4,      /*!< Clock fail detected Interrupt                          */
+    RESERVE1                  = 5,      /*!< Reserve 1                                            */
+    RTC_IRQn                  = 6,      /*!< Real Time Clock Interrupt                            */
+    TAMPER_IRQn               = 7,      /*!< Tamper detection Interrupt                           */
+    WDT_IRQn                  = 8,      /*!< Watch Dog Timer Interrupt                            */
+    WWDT_IRQn                 = 9,      /*!< Window Watch Dog Timer Interrupt                     */
+    EINT0_IRQn                = 10,     /*!< External Input 0 Interrupt                           */
+    EINT1_IRQn                = 11,     /*!< External Input 1 Interrupt                           */
+    EINT2_IRQn                = 12,     /*!< External Input 2 Interrupt                           */
+    EINT3_IRQn                = 13,     /*!< External Input 3 Interrupt                           */
+    EINT4_IRQn                = 14,     /*!< External Input 4 Interrupt                           */
+    EINT5_IRQn                = 15,     /*!< External Input 5 Interrupt                           */
+    GPA_IRQn                  = 16,     /*!< GPIO PORT A Interrupt                                */
+    GPB_IRQn                  = 17,     /*!< GPIO PORT B Interrupt                                */
+    GPC_IRQn                  = 18,     /*!< GPIO PORT C Interrupt                                */
+    GPD_IRQn                  = 19,     /*!< GPIO PORT D Interrupt                                */
+    GPE_IRQn                  = 20,     /*!< GPIO PORT E Interrupt                                */
+    GPF_IRQn                  = 21,     /*!< GPIO PORT F Interrupt                                */
+    QSPI0_IRQn                = 22,     /*!< QSPI0 Interrupt                                      */
+    SPI0_IRQn                 = 23,     /*!< SPI0 Interrupt                                       */
+    BRAKE0_IRQn               = 24,     /*!< PWM Brake0 Interrupt                                 */
+    PWM0_P0_IRQn              = 25,     /*!< PWM0 P0 Interrupt                                    */
+    PWM0_P1_IRQn              = 26,     /*!< PWM0 P1 Interrupt                                    */
+    PWM0_P2_IRQn              = 27,     /*!< PWM0 P2 Interrupt                                    */
+    BRAKE1_IRQn               = 28,     /*!< PWM Brake1 Interrupt                                 */
+    PWM1_P0_IRQn              = 29,     /*!< PWM1 P0 Interrupt                                    */
+    PWM1_P1_IRQn              = 30,     /*!< PWM1 P1 Interrupt                                    */
+    PWM1_P2_IRQn              = 31,     /*!< PWM1 P2 Interrupt                                    */
+    TMR0_IRQn                 = 32,     /*!< TIMER0  Interrupt                                    */
+    TMR1_IRQn                 = 33,     /*!< TIMER1  Interrupt                                    */
+    TMR2_IRQn                 = 34,     /*!< TIMER2  Interrupt                                    */
+    TMR3_IRQn                 = 35,     /*!< TIMER3  Interrupt                                    */
+    UART0_IRQn                = 36,     /*!< UART0  Interrupt                                     */
+    UART1_IRQn                = 37,     /*!< UART1  Interrupt                                     */
+    I2C0_IRQn                 = 38,     /*!< I2C0  Interrupt                                      */
+    I2C1_IRQn                 = 39,     /*!< I2C1  Interrupt                                      */
+    PDMA_IRQn                 = 40,     /*!< Peripheral DMA Interrupt                             */
+    DAC_IRQn                  = 41,     /*!< DAC Interrupt                                        */
+    EADC_INT0_IRQn            = 42,     /*!< Enhance ADC Interrupt 0                              */
+    EADC_INT1_IRQn            = 43,     /*!< Enhance ADC Interrupt 1                              */
+    ACMP01_IRQn               = 44,     /*!< ACMP0 Interrupt                                      */
+    BPWM0_IRQn                = 45,     /*!< BPWM0 Interrupt                                      */
+    EADC_INT2_IRQn            = 46,     /*!< Enhance EADC Interrupt 2                             */
+    EADC_INT3_IRQn            = 47,     /*!< Enhance EADC Interrupt 3                             */
+    UART2_IRQn                = 48,     /*!< UART2 Interrupt                                      */
+    UART3_IRQn                = 49,     /*!< UART3 Interrupt                                      */
+    USCI0_IRQn                = 50,     /*!< USCI0 Interrupt                                      */
+    SPI1_IRQn                 = 51,     /*!< SPI0 Interrupt                                       */
+    USCI1_IRQn                = 52,     /*!< USCI1 Interrupt                                      */
+    USBD_IRQn                 = 53,     /*!< USB Device Interrupt                                 */
+    BPWM1_IRQn                = 54,     /*!< BPWM1 Interrupt                                      */
+    PSIO_IRQn                 = 55,     /*!< PSIO Interrupt                                       */
+    RESERVE4                  = 56,     /*!< Reserve 4                                            */
+    CRPT_IRQn                 = 57,     /*!< Crypto interrupt                                     */
+    SC0_IRQn                  = 58,     /*!< Smart Card0 Interrupt                                */
+    RESERVE5                  = 59,     /*!< Reserve 5                                            */
+    USCI2_IRQn                = 60,     /*!< USCI2 Interrupt                                      */
+    LCD_IRQn                  = 61,     /*!< LCD Interrupt                                        */
+    OPA_IRQn                  = 62,     /*!< OPA Interrupt                                        */
+    TK_IRQn                   = 63,     /*!< Touch Key Interrupt                                  */
+} IRQn_Type;
+
+/* ================================================================================ */
+/* ================      Processor and Core Peripheral Section     ================ */
+/* ================================================================================ */
+
+/* -------  Start of section using anonymous unions and disabling warnings  ------- */
+#if   defined (__CC_ARM)
+#pragma push
+#pragma anon_unions
+#elif defined (__ICCARM__)
+#pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc11-extensions"
+#pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+/* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+/* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+#pragma warning 586
+#elif defined (__CSMC__)
+/* anonymous unions are enabled by default */
+#else
+#warning Not supported compiler type
+#endif
+
+/* --------  Configuration of the Cortex-ARMv8MBL Processor and Core Peripherals  ------- */
+#define __ARMv8MBL_REV            0x0000U   /* Core revision r0p0                         */
+#define __SAU_PRESENT             0U        /* SAU present                                */
+#define __MPU_PRESENT             1U        /* MPU present                                */
+#define __VTOR_PRESENT            1U        /* VTOR present                               */
+#define __NVIC_PRIO_BITS          2U        /* Number of Bits used for Priority Levels    */
+#define __Vendor_SysTickConfig    0U        /* Set to 1 if different SysTick Config is used */
+#define USE_ASSERT                0U        /* Define to use Assert function or not       */
+
+/** @} end of group CMSIS_Device */
+
+
+#include <stdint.h>
+#include "core_cm23.h"                      /* Processor and core peripherals             */
+#include "system_M251.h"                    /* System Header                              */
+
+
+/******************************************************************************/
+/*                Device Specific Peripheral registers structures             */
+/******************************************************************************/
+
+/** @addtogroup REGISTER Control Register
+
+  @{
+
+*/
+
+#include "acmp_reg.h"
+#include "bpwm_reg.h"
+#include "clk_reg.h"
+#include "crc_reg.h"
+#include "crypto_reg.h"
+#include "dac_reg.h"
+#include "eadc_reg.h"
+#include "ebi_reg.h"
+#include "fmc_reg.h"
+#include "gpio_reg.h"
+#include "i2c_reg.h"
+#include "opa_reg.h"
+#include "pdma_reg.h"
+#include "psio_reg.h"
+#include "pwm_reg.h"
+#include "rtc_reg.h"
+#include "sc_reg.h"
+#include "qspi_reg.h"
+#include "spi_reg.h"
+#include "sys_reg.h"
+#include "timer_reg.h"
+#include "uart_reg.h"
+#include "uuart_reg.h"
+#include "ui2c_reg.h"
+#include "uspi_reg.h"
+#include "usbd_reg.h"
+#include "wdt_reg.h"
+#include "wwdt_reg.h"
+#include "lcd_reg.h"
+#include "tk_reg.h"
+
+/** @} end of REGISTER group */
+
+
+/******************************************************************************/
+/*                         Peripheral memory map                              */
+/******************************************************************************/
+
+/** @addtogroup PERIPHERAL_BASE Peripheral Memory Base
+  Memory Mapped Structure for Series Peripheral
+  @{
+ */
+
+/* Peripheral and SRAM base address */
+#define FLASH_BASE            ((uint32_t)0x00000000UL)      /*!< Flash Base Address      */
+#define SRAM_BASE             ((uint32_t)0x20000000UL)      /*!< SRAM Base Address       */
+#define PERIPH_BASE           ((uint32_t)0x40000000UL)      /*!< Peripheral Base Address */
+
+/* Peripheral memory map */
+#define AHBPERIPH_BASE         PERIPH_BASE                  /*!< AHB Base Address        */
+#define APBPERIPH_BASE        (PERIPH_BASE + 0x00040000UL)  /*!< APB Base Address        */
+
+/*!< AHB peripherals */
+#define SYS_BASE              (AHBPERIPH_BASE + 0x00000UL)
+#define CLK_BASE              (AHBPERIPH_BASE + 0x00200UL)
+#define NMI_BASE              (AHBPERIPH_BASE + 0x00300UL)
+#define GPIO_BASE             (AHBPERIPH_BASE + 0x04000UL)
+#define GPIOA_BASE            (AHBPERIPH_BASE + 0x04000UL)
+#define GPIOB_BASE            (AHBPERIPH_BASE + 0x04040UL)
+#define GPIOC_BASE            (AHBPERIPH_BASE + 0x04080UL)
+#define GPIOD_BASE            (AHBPERIPH_BASE + 0x040C0UL)
+#define GPIOE_BASE            (AHBPERIPH_BASE + 0x04100UL)
+#define GPIOF_BASE            (AHBPERIPH_BASE + 0x04140UL)
+#define GPIO_DBCTL_BASE       (AHBPERIPH_BASE + 0x04440UL)
+#define GPIO_PIN_DATA_BASE    (AHBPERIPH_BASE + 0x04800UL)
+#define PDMA_BASE             (AHBPERIPH_BASE + 0x08000UL)
+#define FMC_BASE              (AHBPERIPH_BASE + 0x0C000UL)
+#define EBI_BASE              (AHBPERIPH_BASE + 0x10000UL)
+#define CRC_BASE              (AHBPERIPH_BASE + 0x31000UL)
+#define CRPT_BASE             (AHBPERIPH_BASE + 0x32000UL)
+
+/*!< APB0 peripherals */
+#define WDT_BASE              (APBPERIPH_BASE + 0x00000UL)
+#define WWDT_BASE             (APBPERIPH_BASE + 0x00100UL)
+#define OPA_BASE              (APBPERIPH_BASE + 0x06000UL)
+#define TIMER01_BASE          (APBPERIPH_BASE + 0x10000UL)
+#define PWM0_BASE             (APBPERIPH_BASE + 0x18000UL)
+#define BPWM0_BASE            (APBPERIPH_BASE + 0x1A000UL)
+#define QSPI0_BASE            (APBPERIPH_BASE + 0x20000UL)
+#define SPI1_BASE             (APBPERIPH_BASE + 0x22000UL)
+#define UART0_BASE            (APBPERIPH_BASE + 0x30000UL)
+#define UART2_BASE            (APBPERIPH_BASE + 0x32000UL)
+#define I2C0_BASE             (APBPERIPH_BASE + 0x40000UL)
+#define SC0_BASE              (APBPERIPH_BASE + 0x50000UL)
+#define USBD_BASE             (APBPERIPH_BASE + 0x80000UL)
+#define USCI0_BASE            (APBPERIPH_BASE + 0x90000UL)
+#define USCI2_BASE            (APBPERIPH_BASE + 0x92000UL)
+#define TK_BASE               (APBPERIPH_BASE + 0x82000UL)
+
+/*!< APB1 peripherals */
+#define RTC_BASE              (APBPERIPH_BASE + 0x01000UL)
+#define EADC_BASE             (APBPERIPH_BASE + 0x03000UL)
+#define ACMP01_BASE           (APBPERIPH_BASE + 0x05000UL)
+#define DAC_BASE              (APBPERIPH_BASE + 0x07000UL)
+#define TIMER23_BASE          (APBPERIPH_BASE + 0x11000UL)
+#define PWM1_BASE             (APBPERIPH_BASE + 0x19000UL)
+#define BPWM1_BASE            (APBPERIPH_BASE + 0x1B000UL)
+#define SPI0_BASE             (APBPERIPH_BASE + 0x21000UL)
+#define UART1_BASE            (APBPERIPH_BASE + 0x31000UL)
+#define UART3_BASE            (APBPERIPH_BASE + 0x33000UL)
+#define I2C1_BASE             (APBPERIPH_BASE + 0x41000UL)
+#define PSIO_BASE             (APBPERIPH_BASE + 0x83000UL)
+#define USCI1_BASE            (APBPERIPH_BASE + 0x91000UL)
+#define LCD_BASE              (APBPERIPH_BASE + 0x7B000UL)
+
+/** @} end of group PERIPHERAL_BASE */
+
+
+/******************************************************************************/
+/*                         Peripheral declaration                             */
+/******************************************************************************/
+
+/** @addtogroup PERIPHERAL_DECLARATION Peripheral Pointer
+  The Declaration of Peripheral Pointer
+  @{
+ */
+
+/*!< AHB peripherals */
+#define SYS                  ((SYS_T *)             SYS_BASE)
+#define CLK                  ((CLK_T *)             CLK_BASE)
+#define PA                   ((GPIO_T *)            GPIOA_BASE)
+#define PB                   ((GPIO_T *)            GPIOB_BASE)
+#define PC                   ((GPIO_T *)            GPIOC_BASE)
+#define PD                   ((GPIO_T *)            GPIOD_BASE)
+#define PE                   ((GPIO_T *)            GPIOE_BASE)
+#define PF                   ((GPIO_T *)            GPIOF_BASE)
+#define GPIO                 ((GPIO_DBCTL_T *)      GPIO_DBCTL_BASE)
+#define PDMA                 ((PDMA_T *)            PDMA_BASE)
+#define FMC                  ((FMC_T *)             FMC_BASE)
+#define EBI                  ((EBI_T *)             EBI_BASE)
+#define CRC                  ((CRC_T *)             CRC_BASE)
+#define CRPT                 ((CRPT_T *)            CRPT_BASE)
+
+/*!< APB0 peripherals */
+#define WDT                  ((WDT_T *)             WDT_BASE)
+#define WWDT                 ((WWDT_T *)            WWDT_BASE)
+#define OPA                  ((OPA_T *)             OPA_BASE)
+#define TIMER0               ((TIMER_T *)           TIMER01_BASE)
+#define TIMER1               ((TIMER_T *)           (TIMER01_BASE + 0x100UL))
+#define PWM0                 ((PWM_T *)             PWM0_BASE)
+#define BPWM0                ((BPWM_T *)            BPWM0_BASE)
+#define QSPI0                ((QSPI_T *)            QSPI0_BASE)
+#define SPI1                 ((SPI_T *)             SPI1_BASE)
+#define UART0                ((UART_T *)            UART0_BASE)
+#define UART2                ((UART_T *)            UART2_BASE)
+#define I2C0                 ((I2C_T *)             I2C0_BASE)
+#define SC0                  ((SC_T *)              SC0_BASE)
+#define USBD                 ((USBD_T *)            USBD_BASE)
+#define UI2C0                ((UI2C_T *)            USCI0_BASE)
+#define USPI0                ((USPI_T *)            USCI0_BASE)
+#define UUART0               ((UUART_T *)           USCI0_BASE)
+#define UI2C2                ((UI2C_T *)            USCI2_BASE)
+#define USPI2                ((USPI_T *)            USCI2_BASE)
+#define UUART2               ((UUART_T *)           USCI2_BASE)
+#define TK                   ((TK_T *)              TK_BASE)
+
+/*!< APB1 peripherals */
+#define RTC                  ((RTC_T *)             RTC_BASE)
+#define EADC                 ((EADC_T *)            EADC_BASE)
+#define ACMP01               ((ACMP_T *)            ACMP01_BASE)
+#define DAC0                 ((DAC_T *)             DAC_BASE)
+#define DAC1                 ((DAC_T *)             (DAC_BASE+0x40UL))
+#define TIMER2               ((TIMER_T *)           TIMER23_BASE)
+#define TIMER3               ((TIMER_T *)           (TIMER23_BASE+ 0x100UL))
+#define PWM1                 ((PWM_T *)             PWM1_BASE)
+#define BPWM1                ((BPWM_T *)            BPWM1_BASE)
+#define SPI0                 ((SPI_T *)             SPI0_BASE)
+#define UART1                ((UART_T *)            UART1_BASE)
+#define UART3                ((UART_T *)            UART3_BASE)
+#define I2C1                 ((I2C_T *)             I2C1_BASE)
+#define PSIO                 ((PSIO_T *)            PSIO_BASE)
+#define UI2C1                ((UI2C_T *)            USCI1_BASE)
+#define USPI1                ((USPI_T *)            USCI1_BASE)
+#define UUART1               ((UUART_T *)           USCI1_BASE)
+#define LCD                  ((LCD_T *)             LCD_BASE)
+
+/** @} end of group PERIPHERAL_DECLARATION */
+
+
+/* --------------------  End of section using anonymous unions  ------------------- */
+#if   defined (__CC_ARM)
+#pragma pop
+#elif defined (__ICCARM__)
+/* leave anonymous unions enabled */
+#elif (__ARMCC_VERSION >= 6010050)
+#pragma clang diagnostic pop
+#elif defined (__GNUC__)
+/* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+/* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+#pragma warning restore
+#elif defined (__CSMC__)
+/* anonymous unions are enabled by default */
+#else
+#warning Not supported compiler type
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+
+/*=============================================================================*/
+
+/** @addtogroup IO_ROUTINE I/O Routines
+  The Declaration of I/O Routines
+  @{
+ */
+
+typedef volatile uint8_t  vu8;        ///< Define 8-bit unsigned volatile data type
+typedef volatile uint16_t vu16;       ///< Define 16-bit unsigned volatile data type
+typedef volatile uint32_t vu32;       ///< Define 32-bit unsigned volatile data type
+typedef volatile uint64_t vu64;       ///< Define 64-bit unsigned volatile data type
+
+/**
+  * @brief Get a 8-bit unsigned value from specified address
+  * @param[in] addr Address to get 8-bit data from
+  * @return  8-bit unsigned value stored in specified address
+  */
+#define M8(addr)  (*((vu8  *) (addr)))
+
+/**
+  * @brief Get a 16-bit unsigned value from specified address
+  * @param[in] addr Address to get 16-bit data from
+  * @return  16-bit unsigned value stored in specified address
+  * @note The input address must be 16-bit aligned
+  */
+#define M16(addr) (*((vu16 *) (addr)))
+
+/**
+  * @brief Get a 32-bit unsigned value from specified address
+  * @param[in] addr Address to get 32-bit data from
+  * @return  32-bit unsigned value stored in specified address
+  * @note The input address must be 32-bit aligned
+  */
+#define M32(addr) (*((vu32 *) (addr)))
+
+/**
+  * @brief Set a 32-bit unsigned value to specified I/O port
+  * @param[in] port Port address to set 32-bit data
+  * @param[in] value Value to write to I/O port
+  * @return  None
+  * @note The output port must be 32-bit aligned
+  */
+#define outpw(port,value)   (*((volatile unsigned int *)(port))=(value))
+
+/**
+  * @brief Get a 32-bit unsigned value from specified I/O port
+  * @param[in] port Port address to get 32-bit data from
+  * @return  32-bit unsigned value stored in specified I/O port
+  * @note The input port must be 32-bit aligned
+  */
+#define inpw(port)          ((*((volatile unsigned int *)(port))))
+
+/**
+  * @brief Set a 16-bit unsigned value to specified I/O port
+  * @param[in] port Port address to set 16-bit data
+  * @param[in] value Value to write to I/O port
+  * @return  None
+  * @note The output port must be 16-bit aligned
+  */
+#define outps(port,value)   (*((volatile unsigned short *)(port))=(value))
+
+/**
+  * @brief Get a 16-bit unsigned value from specified I/O port
+  * @param[in] port Port address to get 16-bit data from
+  * @return  16-bit unsigned value stored in specified I/O port
+  * @note The input port must be 16-bit aligned
+  */
+#define inps(port)          ((*((volatile unsigned short *)(port))))
+
+/**
+  * @brief Set a 8-bit unsigned value to specified I/O port
+  * @param[in] port Port address to set 8-bit data
+  * @param[in] value Value to write to I/O port
+  * @return  None
+  */
+#define outpb(port,value)   (*((volatile unsigned char *)(port))=(value))
+
+/**
+  * @brief Get a 8-bit unsigned value from specified I/O port
+  * @param[in] port Port address to get 8-bit data from
+  * @return  8-bit unsigned value stored in specified I/O port
+  */
+#define inpb(port)          ((*((volatile unsigned char *)(port))))
+
+/**
+  * @brief Set a 32-bit unsigned value to specified I/O port
+  * @param[in] port Port address to set 32-bit data
+  * @param[in] value Value to write to I/O port
+  * @return  None
+  * @note The output port must be 32-bit aligned
+  */
+#define outp32(port,value)  (*((volatile unsigned int *)(port))=(value))
+
+/**
+  * @brief Get a 32-bit unsigned value from specified I/O port
+  * @param[in] port Port address to get 32-bit data from
+  * @return  32-bit unsigned value stored in specified I/O port
+  * @note The input port must be 32-bit aligned
+  */
+#define inp32(port)         ((*((volatile unsigned int *)(port))))
+
+/**
+  * @brief Set a 16-bit unsigned value to specified I/O port
+  * @param[in] port Port address to set 16-bit data
+  * @param[in] value Value to write to I/O port
+  * @return  None
+  * @note The output port must be 16-bit aligned
+  */
+#define outp16(port,value)  (*((volatile unsigned short *)(port))=(value))
+
+/**
+  * @brief Get a 16-bit unsigned value from specified I/O port
+  * @param[in] port Port address to get 16-bit data from
+  * @return  16-bit unsigned value stored in specified I/O port
+  * @note The input port must be 16-bit aligned
+  */
+#define inp16(port)         ((*((volatile unsigned short *)(port))))
+
+/**
+  * @brief Set a 8-bit unsigned value to specified I/O port
+  * @param[in] port Port address to set 8-bit data
+  * @param[in] value Value to write to I/O port
+  * @return  None
+  */
+#define outp8(port,value)   (*((volatile unsigned char *)(port))=(value))
+
+/**
+  * @brief Get a 8-bit unsigned value from specified I/O port
+  * @param[in] port Port address to get 8-bit data from
+  * @return  8-bit unsigned value stored in specified I/O port
+  */
+#define inp8(port)          ((*((volatile unsigned char *)(port))))
+
+/** @} end of group IO_ROUTINE */
+
+
+/******************************************************************************/
+/*                Legacy Constants                                            */
+/******************************************************************************/
+
+/** @addtogroup Legacy_Constants Legacy Constants
+  Legacy Constants
+  @{
+*/
+
+#define E_SUCCESS     (0)
+
+#ifndef NULL
+    #define NULL      (0)                  ///< NULL pointer
+#endif
+
+#define TRUE          (1UL)                ///< Boolean true, define to use in API parameters or return value
+#define FALSE         (0UL)                ///< Boolean false, define to use in API parameters or return value
+
+#define ENABLE        (1UL)                ///< Enable, define to use in API parameters
+#define DISABLE       (0UL)                ///< Disable, define to use in API parameters
+
+/* Define one bit mask */
+#define BIT0          (0x00000001UL)       ///< Bit 0 mask of an 32 bit integer
+#define BIT1          (0x00000002UL)       ///< Bit 1 mask of an 32 bit integer
+#define BIT2          (0x00000004UL)       ///< Bit 2 mask of an 32 bit integer
+#define BIT3          (0x00000008UL)       ///< Bit 3 mask of an 32 bit integer
+#define BIT4          (0x00000010UL)       ///< Bit 4 mask of an 32 bit integer
+#define BIT5          (0x00000020UL)       ///< Bit 5 mask of an 32 bit integer
+#define BIT6          (0x00000040UL)       ///< Bit 6 mask of an 32 bit integer
+#define BIT7          (0x00000080UL)       ///< Bit 7 mask of an 32 bit integer
+#define BIT8          (0x00000100UL)       ///< Bit 8 mask of an 32 bit integer
+#define BIT9          (0x00000200UL)       ///< Bit 9 mask of an 32 bit integer
+#define BIT10         (0x00000400UL)       ///< Bit 10 mask of an 32 bit integer
+#define BIT11         (0x00000800UL)       ///< Bit 11 mask of an 32 bit integer
+#define BIT12         (0x00001000UL)       ///< Bit 12 mask of an 32 bit integer
+#define BIT13         (0x00002000UL)       ///< Bit 13 mask of an 32 bit integer
+#define BIT14         (0x00004000UL)       ///< Bit 14 mask of an 32 bit integer
+#define BIT15         (0x00008000UL)       ///< Bit 15 mask of an 32 bit integer
+#define BIT16         (0x00010000UL)       ///< Bit 16 mask of an 32 bit integer
+#define BIT17         (0x00020000UL)       ///< Bit 17 mask of an 32 bit integer
+#define BIT18         (0x00040000UL)       ///< Bit 18 mask of an 32 bit integer
+#define BIT19         (0x00080000UL)       ///< Bit 19 mask of an 32 bit integer
+#define BIT20         (0x00100000UL)       ///< Bit 20 mask of an 32 bit integer
+#define BIT21         (0x00200000UL)       ///< Bit 21 mask of an 32 bit integer
+#define BIT22         (0x00400000UL)       ///< Bit 22 mask of an 32 bit integer
+#define BIT23         (0x00800000UL)       ///< Bit 23 mask of an 32 bit integer
+#define BIT24         (0x01000000UL)       ///< Bit 24 mask of an 32 bit integer
+#define BIT25         (0x02000000UL)       ///< Bit 25 mask of an 32 bit integer
+#define BIT26         (0x04000000UL)       ///< Bit 26 mask of an 32 bit integer
+#define BIT27         (0x08000000UL)       ///< Bit 27 mask of an 32 bit integer
+#define BIT28         (0x10000000UL)       ///< Bit 28 mask of an 32 bit integer
+#define BIT29         (0x20000000UL)       ///< Bit 29 mask of an 32 bit integer
+#define BIT30         (0x40000000UL)       ///< Bit 30 mask of an 32 bit integer
+#define BIT31         (0x80000000UL)       ///< Bit 31 mask of an 32 bit integer
+
+/* Byte Mask Definitions */
+#define BYTE0_Msk     (0x000000FFUL)       ///< Mask to get bit0~bit7 from a 32 bit integer
+#define BYTE1_Msk     (0x0000FF00UL)       ///< Mask to get bit8~bit15 from a 32 bit integer
+#define BYTE2_Msk     (0x00FF0000UL)       ///< Mask to get bit16~bit23 from a 32 bit integer
+#define BYTE3_Msk     (0xFF000000UL)       ///< Mask to get bit24~bit31 from a 32 bit integer
+
+#define GET_BYTE0(u32Param)    (((u32Param) & BYTE0_Msk)      ) /*!< Extract Byte 0 (Bit  0~ 7) from parameter u32Param */
+#define GET_BYTE1(u32Param)    (((u32Param) & BYTE1_Msk) >>  8) /*!< Extract Byte 1 (Bit  8~15) from parameter u32Param */
+#define GET_BYTE2(u32Param)    (((u32Param) & BYTE2_Msk) >> 16) /*!< Extract Byte 2 (Bit 16~23) from parameter u32Param */
+#define GET_BYTE3(u32Param)    (((u32Param) & BYTE3_Msk) >> 24) /*!< Extract Byte 3 (Bit 24~31) from parameter u32Param */
+
+/** @} end of group Legacy_Constants */
+
+
+/******************************************************************************/
+/*                         Peripheral header files                            */
+/******************************************************************************/
+#include "bpwm.h"
+#include "sys.h"
+#include "clk.h"
+#include "uart.h"
+#include "opa.h"
+#include "acmp.h"
+#include "rtc.h"
+#include "fmc.h"
+#include "gpio.h"
+#include "i2c.h"
+#include "pdma.h"
+#include "pwm.h"
+#include "qspi.h"
+#include "spi.h"
+#include "timer.h"
+#include "timer_pwm.h"
+#include "usci_i2c.h"
+#include "usci_spi.h"
+#include "usci_uart.h"
+#include "usbd.h"
+#include "rtc.h"
+#include "crc.h"
+#include "crypto.h"
+#include "wdt.h"
+#include "wwdt.h"
+#include "eadc.h"
+#include "dac.h"
+#include "ebi.h"
+#include "psio.h"
+#include "sc.h"
+#include "scuart.h"
+#include "lcd.h"
+#include "tk.h"
+
+#endif  /* __M251_H__ */

--- a/hal/m258ke/nuvoton/NuMicro.h
+++ b/hal/m258ke/nuvoton/NuMicro.h
@@ -1,0 +1,15 @@
+/**************************************************************************//**
+ * @file     NuMicro.h
+ * @version  V1.00
+ * @brief    NuMicro peripheral access layer header file.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __NUMICRO_H__
+#define __NUMICRO_H__
+
+#include "M251.h"
+
+#endif  /* __NUMICRO_H__ */

--- a/hal/m258ke/nuvoton/README.md
+++ b/hal/m258ke/nuvoton/README.md
@@ -1,0 +1,5 @@
+# Nuvoton/CMSIS files
+
+These files came from [Nuvoton's M251 BSP](https://github.com/OpenNuvoton/M251BSP/). They provide register defines, structs, startup code, the vector table, and linker scripts.
+
+I've tried to avoid using Nuvoton's BSP driver code for various peripherals as much as possible, but I did use their USBD driver because it would be too difficult to reimplement from scratch.

--- a/hal/m258ke/nuvoton/acmp_reg.h
+++ b/hal/m258ke/nuvoton/acmp_reg.h
@@ -1,0 +1,236 @@
+/**************************************************************************//**
+ * @file     acmp_reg.h
+ * @version  V1.00
+ * @brief    ACMP register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __ACMP_REG_H__
+#define __ACMP_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup ACMP Analog Comparator Controller (ACMP)
+    Memory Mapped Structure for ACMP Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var ACMP_T::CTL
+     * Offset: 0x00~0x04  Analog Comparator 0/1 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ACMPEN    |Comparator Enable Bit
+     * |        |          |0 = Comparator x Disabled.
+     * |        |          |1 = Comparator x Enabled.
+     * |[1]     |ACMPIE    |Comparator Interrupt Enable Bit
+     * |        |          |0 = Comparator x interrupt Disabled.
+     * |        |          |1 = Comparator x interrupt Enabled
+     * |        |          |If WKEN (ACMP_CTL0[16]) is set to 1, the wake-up interrupt function will be enabled as well.
+     * |[3]     |ACMPOINV  |Comparator Output Inverse
+     * |        |          |0 = Comparator x output inverse Disabled.
+     * |        |          |1 = Comparator x output inverse Enabled.
+     * |[5:4]   |NEGSEL    |Comparator Negative Input Selection
+     * |        |          |00 = ACMPx_N pin.
+     * |        |          |01 = Internal comparator reference voltage (CRV).
+     * |        |          |10 = Band-gap voltage.
+     * |        |          |11 = DAC output.
+     * |[7:6]   |POSSEL    |Comparator Positive Input Selection
+     * |        |          |00 = Input from ACMPx_P0.
+     * |        |          |01 = Input from ACMPx_P1.
+     * |        |          |10 = Input from ACMPx_P2.
+     * |        |          |11 = Input from ACMPx_P3.
+     * |[9:8]   |INTPOL    |Interrupt Condition Polarity Selection
+     * |        |          |ACMPIFx will be set to 1 when comparator output edge condition is detected.
+     * |        |          |00 = Rising edge or falling edge.
+     * |        |          |01 = Rising edge.
+     * |        |          |10 = Falling edge.
+     * |        |          |11 = Reserved.
+     * |[12]    |OUTSEL    |Comparator Output Select
+     * |        |          |0 = Comparator x output to ACMPx_O pin is unfiltered comparator output.
+     * |        |          |1 = Comparator x output to ACMPx_O pin is from filter output.
+     * |[15:13] |FILTSEL   |Comparator Output Filter Count Selection
+     * |        |          |000 = Filter function is Disabled.
+     * |        |          |001 = ACMPx output is sampled 1 consecutive PCLK.
+     * |        |          |010 = ACMPx output is sampled 2 consecutive PCLKs.
+     * |        |          |011 = ACMPx output is sampled 4 consecutive PCLKs.
+     * |        |          |100 = ACMPx output is sampled 8 consecutive PCLKs.
+     * |        |          |101 = ACMPx output is sampled 16 consecutive PCLKs.
+     * |        |          |110 = ACMPx output is sampled 32 consecutive PCLKs.
+     * |        |          |111 = ACMPx output is sampled 64 consecutive PCLKs.
+     * |[16]    |WKEN      |Power-down Wake-up Enable Bit
+     * |        |          |0 = Wake-up function Disabled.
+     * |        |          |1 = Wake-up function Enabled.
+     * |[17]    |WLATEN    |Window Latch Mode Enable Bit
+     * |        |          |0 = Window Latch Mode Disabled.
+     * |        |          |1 = Window Latch Mode Enabled.
+     * |[18]    |WCMPSEL   |Window Compare Mode Selection
+     * |        |          |0 = Window Compare Mode Disabled.
+     * |        |          |1 = Window Compare Mode is Selected.
+     * |[25:24] |HYSSEL    |Hysteresis Mode Selection
+     * |        |          |00 = Hysteresis is 0mV.
+     * |        |          |01 = Hysteresis is 10mV.
+     * |        |          |10 = Hysteresis is 20mV.
+     * |        |          |11 = Hysteresis is 30mV.
+     * |[29:28] |MODESEL   |Propagation Delay Mode Selection
+     * |        |          |00 = Max propagation delay is 4.5uS, operation current is 1.2uA.
+     * |        |          |01 = Max propagation delay is 2uS, operation current is 3uA.
+     * |        |          |10 = Max propagation delay is 600nS, operation current is 10uA.
+     * |        |          |11 = Max propagation delay is 200nS, operation current is 75uA.
+     * @var ACMP_T::STATUS
+     * Offset: 0x08  Analog Comparator Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ACMPIF0   |Comparator 0 Interrupt Flag
+     * |        |          |This bit is set by hardware when the edge condition defined by INTPOL (ACMP_CTL0[9:8]) is detected on comparator 0 output.
+     * |        |          |This will generate an interrupt if ACMPIE (ACMP_CTL0[1]) is set to 1.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[1]     |ACMPIF1   |Comparator 1 Interrupt Flag
+     * |        |          |This bit is set by hardware when the edge condition defined by INTPOL (ACMP_CTL1[9:8]) is detected on comparator 1 output.
+     * |        |          |This will cause an interrupt if ACMPIE (ACMP_CTL1[1]) is set to 1.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[4]     |ACMPO0    |Comparator 0 Output
+     * |        |          |Synchronized to the PCLK to allow reading by software.
+     * |        |          |Cleared when the comparator 0 is disabled, i.e. ACMPEN (ACMP_CTL0[0]) is cleared to 0.
+     * |[5]     |ACMPO1    |Comparator 1 Output
+     * |        |          |Synchronized to the PCLK to allow reading by software.
+     * |        |          |Cleared when the comparator 1 is disabled, i.e. ACMPEN (ACMP_CTL1[0]) is cleared to 0.
+     * |[8]     |WKIF0     |Comparator 0 Power-down Wake-up Interrupt Flag
+     * |        |          |This bit will be set to 1 when ACMP0 wake-up interrupt event occurs.
+     * |        |          |0 = No power-down wake-up occurred.
+     * |        |          |1 = Power-down wake-up occurred.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[9]     |WKIF1     |Comparator 1 Power-down Wake-up Interrupt Flag
+     * |        |          |This bit will be set to 1 when ACMP1 wake-up interrupt event occurs.
+     * |        |          |0 = No power-down wake-up occurred.
+     * |        |          |1 = Power-down wake-up occurred.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[12]    |ACMPS0    |Comparator 0 Status
+     * |        |          |Synchronized to the PCLK to allow reading by software.
+     * |        |          |Cleared when the comparator 0 is disabled, i.e. ACMPEN (ACMP_CTL0[0]) is cleared to 0.
+     * |[13]    |ACMPS1    |Comparator 1 Status
+     * |        |          |Synchronized to the PCLK to allow reading by software
+     * |        |          |Cleared when the comparator 1 is disabled, i.e. ACMPEN (ACMP_CTL1[0]) is cleared to 0.
+     * |[16]    |ACMPWO    |Comparator Window Output
+     * |        |          |This bit shows the output status of window compare mode
+     * |        |          |0 = The positive input voltage is outside the window.
+     * |        |          |1 = The positive input voltage is in the window.
+     * @var ACMP_T::VREF
+     * Offset: 0x0C  Analog Comparator Reference Voltage Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |CRVCTL    |Comparator Reference Voltage Setting
+     * |        |          |CRV = CRV source voltage * (1/6+CRVCTL/24).
+     * |[6]     |CRVSSEL   |CRV Source Voltage Selection
+     * |        |          |0 = AVDD is selected as CRV source voltage.
+     * |        |          |1 = The reference voltage defined by SYS_VREFCTL register is selected as CRV source voltage.
+     */
+    __IO uint32_t CTL[2];                /*!< [0x0000~0x0004] Analog Comparator 0/1 Control Register                    */
+    __IO uint32_t STATUS;                /*!< [0x0008] Analog Comparator Status Register                                */
+    __IO uint32_t VREF;                  /*!< [0x000c] Analog Comparator Reference Voltage Control Register             */
+} ACMP_T;
+
+/**
+    @addtogroup ACMP_CONST ACMP Bit Field Definition
+    Constant Definitions for ACMP Controller
+@{ */
+
+#define ACMP_CTL_ACMPEN_Pos              (0)                                               /*!< ACMP_T::CTL: ACMPEN Position          */
+#define ACMP_CTL_ACMPEN_Msk              (0x1ul << ACMP_CTL_ACMPEN_Pos)                    /*!< ACMP_T::CTL: ACMPEN Mask              */
+
+#define ACMP_CTL_ACMPIE_Pos              (1)                                               /*!< ACMP_T::CTL: ACMPIE Position          */
+#define ACMP_CTL_ACMPIE_Msk              (0x1ul << ACMP_CTL_ACMPIE_Pos)                    /*!< ACMP_T::CTL: ACMPIE Mask              */
+
+#define ACMP_CTL_ACMPOINV_Pos            (3)                                               /*!< ACMP_T::CTL: ACMPOINV Position        */
+#define ACMP_CTL_ACMPOINV_Msk            (0x1ul << ACMP_CTL_ACMPOINV_Pos)                  /*!< ACMP_T::CTL: ACMPOINV Mask            */
+
+#define ACMP_CTL_NEGSEL_Pos              (4)                                               /*!< ACMP_T::CTL: NEGSEL Position          */
+#define ACMP_CTL_NEGSEL_Msk              (0x3ul << ACMP_CTL_NEGSEL_Pos)                    /*!< ACMP_T::CTL: NEGSEL Mask              */
+
+#define ACMP_CTL_POSSEL_Pos              (6)                                               /*!< ACMP_T::CTL: POSSEL Position          */
+#define ACMP_CTL_POSSEL_Msk              (0x3ul << ACMP_CTL_POSSEL_Pos)                    /*!< ACMP_T::CTL: POSSEL Mask              */
+
+#define ACMP_CTL_INTPOL_Pos              (8)                                               /*!< ACMP_T::CTL: INTPOL Position          */
+#define ACMP_CTL_INTPOL_Msk              (0x3ul << ACMP_CTL_INTPOL_Pos)                    /*!< ACMP_T::CTL: INTPOL Mask              */
+
+#define ACMP_CTL_OUTSEL_Pos              (12)                                              /*!< ACMP_T::CTL: OUTSEL Position          */
+#define ACMP_CTL_OUTSEL_Msk              (0x1ul << ACMP_CTL_OUTSEL_Pos)                    /*!< ACMP_T::CTL: OUTSEL Mask              */
+
+#define ACMP_CTL_FILTSEL_Pos             (13)                                              /*!< ACMP_T::CTL: FILTSEL Position         */
+#define ACMP_CTL_FILTSEL_Msk             (0x7ul << ACMP_CTL_FILTSEL_Pos)                   /*!< ACMP_T::CTL: FILTSEL Mask             */
+
+#define ACMP_CTL_WKEN_Pos                (16)                                              /*!< ACMP_T::CTL: WKEN Position            */
+#define ACMP_CTL_WKEN_Msk                (0x1ul << ACMP_CTL_WKEN_Pos)                      /*!< ACMP_T::CTL: WKEN Mask                */
+
+#define ACMP_CTL_WLATEN_Pos              (17)                                              /*!< ACMP_T::CTL: WLATEN Position          */
+#define ACMP_CTL_WLATEN_Msk              (0x1ul << ACMP_CTL_WLATEN_Pos)                    /*!< ACMP_T::CTL: WLATEN Mask              */
+
+#define ACMP_CTL_WCMPSEL_Pos             (18)                                              /*!< ACMP_T::CTL: WCMPSEL Position         */
+#define ACMP_CTL_WCMPSEL_Msk             (0x1ul << ACMP_CTL_WCMPSEL_Pos)                   /*!< ACMP_T::CTL: WCMPSEL Mask             */
+
+#define ACMP_CTL_HYSSEL_Pos              (24)                                              /*!< ACMP_T::CTL: HYSSEL Position          */
+#define ACMP_CTL_HYSSEL_Msk              (0x3ul << ACMP_CTL_HYSSEL_Pos)                    /*!< ACMP_T::CTL: HYSSEL Mask              */
+
+#define ACMP_CTL_MODESEL_Pos             (28)                                              /*!< ACMP_T::CTL: MODESEL Position         */
+#define ACMP_CTL_MODESEL_Msk             (0x3ul << ACMP_CTL_MODESEL_Pos)                   /*!< ACMP_T::CTL: MODESEL Mask             */
+
+#define ACMP_STATUS_ACMPIF0_Pos          (0)                                               /*!< ACMP_T::STATUS: ACMPIF0 Position      */
+#define ACMP_STATUS_ACMPIF0_Msk          (0x1ul << ACMP_STATUS_ACMPIF0_Pos)                /*!< ACMP_T::STATUS: ACMPIF0 Mask          */
+
+#define ACMP_STATUS_ACMPIF1_Pos          (1)                                               /*!< ACMP_T::STATUS: ACMPIF1 Position      */
+#define ACMP_STATUS_ACMPIF1_Msk          (0x1ul << ACMP_STATUS_ACMPIF1_Pos)                /*!< ACMP_T::STATUS: ACMPIF1 Mask          */
+
+#define ACMP_STATUS_ACMPO0_Pos           (4)                                               /*!< ACMP_T::STATUS: ACMPO0 Position       */
+#define ACMP_STATUS_ACMPO0_Msk           (0x1ul << ACMP_STATUS_ACMPO0_Pos)                 /*!< ACMP_T::STATUS: ACMPO0 Mask           */
+
+#define ACMP_STATUS_ACMPO1_Pos           (5)                                               /*!< ACMP_T::STATUS: ACMPO1 Position       */
+#define ACMP_STATUS_ACMPO1_Msk           (0x1ul << ACMP_STATUS_ACMPO1_Pos)                 /*!< ACMP_T::STATUS: ACMPO1 Mask           */
+
+#define ACMP_STATUS_WKIF0_Pos            (8)                                               /*!< ACMP_T::STATUS: WKIF0 Position        */
+#define ACMP_STATUS_WKIF0_Msk            (0x1ul << ACMP_STATUS_WKIF0_Pos)                  /*!< ACMP_T::STATUS: WKIF0 Mask            */
+
+#define ACMP_STATUS_WKIF1_Pos            (9)                                               /*!< ACMP_T::STATUS: WKIF1 Position        */
+#define ACMP_STATUS_WKIF1_Msk            (0x1ul << ACMP_STATUS_WKIF1_Pos)                  /*!< ACMP_T::STATUS: WKIF1 Mask            */
+
+#define ACMP_STATUS_ACMPS0_Pos           (12)                                              /*!< ACMP_T::STATUS: ACMPS0 Position       */
+#define ACMP_STATUS_ACMPS0_Msk           (0x1ul << ACMP_STATUS_ACMPS0_Pos)                 /*!< ACMP_T::STATUS: ACMPS0 Mask           */
+
+#define ACMP_STATUS_ACMPS1_Pos           (13)                                              /*!< ACMP_T::STATUS: ACMPS1 Position       */
+#define ACMP_STATUS_ACMPS1_Msk           (0x1ul << ACMP_STATUS_ACMPS1_Pos)                 /*!< ACMP_T::STATUS: ACMPS1 Mask           */
+
+#define ACMP_STATUS_ACMPWO_Pos           (16)                                              /*!< ACMP_T::STATUS: ACMPWO Position       */
+#define ACMP_STATUS_ACMPWO_Msk           (0x1ul << ACMP_STATUS_ACMPWO_Pos)                 /*!< ACMP_T::STATUS: ACMPWO Mask           */
+
+#define ACMP_VREF_CRVCTL_Pos             (0)                                               /*!< ACMP_T::VREF: CRVCTL Position         */
+#define ACMP_VREF_CRVCTL_Msk             (0xful << ACMP_VREF_CRVCTL_Pos)                   /*!< ACMP_T::VREF: CRVCTL Mask             */
+
+#define ACMP_VREF_CRVSSEL_Pos            (6)                                               /*!< ACMP_T::VREF: CRVSSEL Position        */
+#define ACMP_VREF_CRVSSEL_Msk            (0x1ul << ACMP_VREF_CRVSSEL_Pos)                  /*!< ACMP_T::VREF: CRVSSEL Mask            */
+
+
+/** @} ACMP_CONST */
+/** @} end of ACMP register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __ACMP_REG_H__ */

--- a/hal/m258ke/nuvoton/bpwm_reg.h
+++ b/hal/m258ke/nuvoton/bpwm_reg.h
@@ -1,0 +1,1777 @@
+/**************************************************************************//**
+ * @file     bpwm_reg.h
+ * @version  V1.00
+ * @brief    BPWM register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __BPWM_REG_H__
+#define __BPWM_REG_H__
+
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup BPWM Basic Pulse Width Modulation Controller (BPWM)
+    Memory Mapped Structure for BPWM Controller
+    @{
+*/
+
+typedef struct
+{
+    /**
+     * @var BCAPDAT_T::RCAPDAT
+     * Offset: 0x20C~0x238  BPWM Rising Capture Data Register 0~5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |RCAPDAT   |BPWM Rising Capture Data (Read Only)
+     * |        |          |When rising capture condition happened, the BPWM counter value will be saved in this register.
+     * @var BCAPDAT_T::FCAPDAT
+     * Offset: 0x210  BPWM Falling Capture Data Register 0~5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |FCAPDAT   |BPWM Falling Capture Data (Read Only)
+     * |        |          |When falling capture condition happened, the BPWM counter value will be saved in this register.
+     */
+    __IO uint32_t RCAPDAT; /*!< [0x20C/0x214/0x21C/0x224/0x22C/0x234] BPWM Rising Capture Data Register 0~5 */
+    __IO uint32_t FCAPDAT; /*!< [0x210/0x218/0x220/0x228/0x230/0x238] BPWM Falling Capture Data Register 0~5 */
+} BCAPDAT_T;
+
+typedef struct
+{
+
+
+    /**
+     * @var BPWM_T::CTL0
+     * Offset: 0x00  BPWM Control Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CTRLD0    |Center Re-load
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |In up-down counter type, PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the center point of a period
+     * |[1]     |CTRLD1    |Center Re-load
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |In up-down counter type, PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the center point of a period
+     * |[2]     |CTRLD2    |Center Re-load
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |In up-down counter type, PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the center point of a period
+     * |[3]     |CTRLD3    |Center Re-load
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |In up-down counter type, PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the center point of a period
+     * |[4]     |CTRLD4    |Center Re-load
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |In up-down counter type, PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the center point of a period
+     * |[5]     |CTRLD5    |Center Re-load
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |In up-down counter type, PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the center point of a period
+     * |[16]    |IMMLDEN0  |Immediately Load Enable Bit(S)
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the end point or center point of each period by setting CTRLD bit.
+     * |        |          |1 = PERIOD/CMPDAT will load to PBUF and CMPBUF immediately when software update PERIOD/CMPDAT.
+     * |        |          |Note: If IMMLDENn is Enabled, WINLDENn and CTRLDn will be invalid.
+     * |[17]    |IMMLDEN1  |Immediately Load Enable Bit(S)
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the end point or center point of each period by setting CTRLD bit.
+     * |        |          |1 = PERIOD/CMPDAT will load to PBUF and CMPBUF immediately when software update PERIOD/CMPDAT.
+     * |        |          |Note: If IMMLDENn is Enabled, WINLDENn and CTRLDn will be invalid.
+     * |[18]    |IMMLDEN2  |Immediately Load Enable Bit(S)
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the end point or center point of each period by setting CTRLD bit.
+     * |        |          |1 = PERIOD/CMPDAT will load to PBUF and CMPBUF immediately when software update PERIOD/CMPDAT.
+     * |        |          |Note: If IMMLDENn is Enabled, WINLDENn and CTRLDn will be invalid.
+     * |[19]    |IMMLDEN3  |Immediately Load Enable Bit(S)
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the end point or center point of each period by setting CTRLD bit.
+     * |        |          |1 = PERIOD/CMPDAT will load to PBUF and CMPBUF immediately when software update PERIOD/CMPDAT.
+     * |        |          |Note: If IMMLDENn is Enabled, WINLDENn and CTRLDn will be invalid.
+     * |[20]    |IMMLDEN4  |Immediately Load Enable Bit(S)
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the end point or center point of each period by setting CTRLD bit.
+     * |        |          |1 = PERIOD/CMPDAT will load to PBUF and CMPBUF immediately when software update PERIOD/CMPDAT.
+     * |        |          |Note: If IMMLDENn is Enabled, WINLDENn and CTRLDn will be invalid.
+     * |[21]    |IMMLDEN5  |Immediately Load Enable Bit(S)
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the end point or center point of each period by setting CTRLD bit.
+     * |        |          |1 = PERIOD/CMPDAT will load to PBUF and CMPBUF immediately when software update PERIOD/CMPDAT.
+     * |        |          |Note: If IMMLDENn is Enabled, WINLDENn and CTRLDn will be invalid.
+     * |[30]    |DBGHALT   |ICE Debug Mode Counter Halt (Write Protect)
+     * |        |          |If counter halt is enabled, BPWM all counters will keep current value until exit ICE debug mode.
+     * |        |          |0 = ICE debug mode counter halt Disabled.
+     * |        |          |1 = ICE debug mode counter halt Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[31]    |DBGTRIOFF |ICE Debug Mode Acknowledge Disable (Write Protect)
+     * |        |          |0 = ICE debug mode acknowledgement effects BPWM output.
+     * |        |          |BPWM pin will be forced as tri-state while ICE debug mode acknowledged.
+     * |        |          |1 = ICE debug mode acknowledgement Disabled.
+     * |        |          |BPWM pin will keep output no matter ICE debug mode acknowledged or not.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * @var BPWM_T::CTL1
+     * Offset: 0x04  BPWM Control Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |CNTTYPE0  |BPWM Counter Behavior Type 0
+     * |        |          |Each bit n controls corresponding BPWM channel n.
+     * |        |          |00 = Up counter type (supports in capture mode).
+     * |        |          |01 = Down count type (supports in capture mode).
+     * |        |          |10 = Up-down counter type.
+     * |        |          |11 = Reserved.
+     * @var BPWM_T::CLKSRC
+     * Offset: 0x10  BPWM Clock Source Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |ECLKSRC0  |BPWM_CH01 External Clock Source Select
+     * |        |          |000 = BPWMx_CLK, x denotes 0 or 1.
+     * |        |          |001 = TIMER0 overflow.
+     * |        |          |010 = TIMER1 overflow.
+     * |        |          |011 = TIMER2 overflow.
+     * |        |          |100 = TIMER3 overflow.
+     * |        |          |Others = Reserved.
+     * @var BPWM_T::CLKPSC
+     * Offset: 0x14  BPWM Clock Prescale Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[11:0]  |CLKPSC    |BPWM Counter Clock Prescale
+     * |        |          |The clock of BPWM counter is decided by clock prescaler
+     * |        |          |Each BPWM pair share one BPWM counter clock prescaler
+     * |        |          |The clock of BPWM counter is divided by (CLKPSC+ 1)
+     * @var BPWM_T::CNTEN
+     * Offset: 0x20  BPWM Counter Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTEN0    |BPWM Counter 0 Enable Bit
+     * |        |          |0 = BPWM Counter and clock prescaler stop running.
+     * |        |          |1 = BPWM Counter and clock prescaler start running.
+     * @var BPWM_T::CNTCLR
+     * Offset: 0x24  BPWM Clear Counter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTCLR0   |Clear BPWM Counter Control Bit 0
+     * |        |          |It is automatically cleared by hardware.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear 16-bit BPWM counter to 0000H.
+     * @var BPWM_T::PERIOD
+     * Offset: 0x30  BPWM Period Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |PERIOD    |BPWM Period Register
+     * |        |          |Up-Count mode: In this mode, BPWM counter counts from 0 to PERIOD, and restarts from 0.
+     * |        |          |Down-Count mode: In this mode, BPWM counter counts from PERIOD to 0, and restarts from PERIOD.
+     * |        |          |BPWM period time = (PERIOD+1) * BPWM_CLK period.
+     * |        |          |Up-Down-Count mode: In this mode, BPWM counter counts from 0 to PERIOD, then decrements to 0 and repeats again.
+     * |        |          |BPWM period time = 2 * PERIOD * BPWM_CLK period.
+     * @var BPWM_T::CMPDAT[6]
+     * Offset: 0x50~0x64  BPWM Comparator Register 0~5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CMPDAT    |BPWM Comparator Register
+     * |        |          |CMPDAT use to compare with CNTR to generate BPWM waveform, interrupt and trigger EADC.
+     * |        |          |In independent mode, CMPDAT0~5 denote as 6 independent BPWM_CH0~5 compared point.
+     * @var BPWM_T::CNT
+     * Offset: 0x90  BPWM Counter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CNT       |BPWM Data Register (Read Only)
+     * |        |          |User can monitor CNTR to know the current value in 16-bit period counter.
+     * |[16]    |DIRF      |BPWM Direction Indicator Flag (Read Only)
+     * |        |          |0 = Counter is Down count.
+     * |        |          |1 = Counter is UP count.
+     * @var BPWM_T::WGCTL0
+     * Offset: 0xB0  BPWM Generation Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |ZPCTL0    |BPWM Zero Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM zero point output Low.
+     * |        |          |10 = BPWM zero point output High.
+     * |        |          |11 = BPWM zero point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to zero.
+     * |[3:2]   |ZPCTL1    |BPWM Zero Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM zero point output Low.
+     * |        |          |10 = BPWM zero point output High.
+     * |        |          |11 = BPWM zero point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to zero.
+     * |[5:4]   |ZPCTL2    |BPWM Zero Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM zero point output Low.
+     * |        |          |10 = BPWM zero point output High.
+     * |        |          |11 = BPWM zero point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to zero.
+     * |[7:6]   |ZPCTL3    |BPWM Zero Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM zero point output Low.
+     * |        |          |10 = BPWM zero point output High.
+     * |        |          |11 = BPWM zero point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to zero.
+     * |[9:8]   |ZPCTL4    |BPWM Zero Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM zero point output Low.
+     * |        |          |10 = BPWM zero point output High.
+     * |        |          |11 = BPWM zero point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to zero.
+     * |[11:10] |ZPCTL5    |BPWM Zero Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM zero point output Low.
+     * |        |          |10 = BPWM zero point output High.
+     * |        |          |11 = BPWM zero point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to zero.
+     * |[17:16] |PRDPCTL0  |BPWM Period (Center) Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM period (center) point output Low.
+     * |        |          |10 = BPWM period (center) point output High.
+     * |        |          |11 = BPWM period (center) point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to (PERIOD+1).
+     * |        |          |Note: This bit is center point control when BPWM counter operating in up-down counter type.
+     * |[19:18] |PRDPCTL1  |BPWM Period (Center) Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM period (center) point output Low.
+     * |        |          |10 = BPWM period (center) point output High.
+     * |        |          |11 = BPWM period (center) point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to (PERIOD+1).
+     * |        |          |Note: This bit is center point control when BPWM counter operating in up-down counter type.
+     * |[21:20] |PRDPCTL2  |BPWM Period (Center) Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM period (center) point output Low.
+     * |        |          |10 = BPWM period (center) point output High.
+     * |        |          |11 = BPWM period (center) point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to (PERIOD+1).
+     * |        |          |Note: This bit is center point control when BPWM counter operating in up-down counter type.
+     * |[23:22] |PRDPCTL3  |BPWM Period (Center) Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM period (center) point output Low.
+     * |        |          |10 = BPWM period (center) point output High.
+     * |        |          |11 = BPWM period (center) point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to (PERIOD+1).
+     * |        |          |Note: This bit is center point control when BPWM counter operating in up-down counter type.
+     * |[25:24] |PRDPCTL4  |BPWM Period (Center) Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM period (center) point output Low.
+     * |        |          |10 = BPWM period (center) point output High.
+     * |        |          |11 = BPWM period (center) point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to (PERIOD+1).
+     * |        |          |Note: This bit is center point control when BPWM counter operating in up-down counter type.
+     * |[27:26] |PRDPCTL5  |BPWM Period (Center) Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM period (center) point output Low.
+     * |        |          |10 = BPWM period (center) point output High.
+     * |        |          |11 = BPWM period (center) point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter count to (PERIOD+1).
+     * |        |          |Note: This bit is center point control when BPWM counter operating in up-down counter type.
+     * @var BPWM_T::WGCTL1
+     * Offset: 0xB4  BPWM Generation Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |CMPUCTL0  |BPWM Compare Up Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare up point output Low.
+     * |        |          |10 = BPWM compare up point output High.
+     * |        |          |11 = BPWM compare up point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter up count to CMPDAT.
+     * |[3:2]   |CMPUCTL1  |BPWM Compare Up Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare up point output Low.
+     * |        |          |10 = BPWM compare up point output High.
+     * |        |          |11 = BPWM compare up point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter up count to CMPDAT.
+     * |[5:4]   |CMPUCTL2  |BPWM Compare Up Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare up point output Low.
+     * |        |          |10 = BPWM compare up point output High.
+     * |        |          |11 = BPWM compare up point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter up count to CMPDAT.
+     * |[7:6]   |CMPUCTL3  |BPWM Compare Up Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare up point output Low.
+     * |        |          |10 = BPWM compare up point output High.
+     * |        |          |11 = BPWM compare up point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter up count to CMPDAT.
+     * |[9:8]   |CMPUCTL4  |BPWM Compare Up Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare up point output Low.
+     * |        |          |10 = BPWM compare up point output High.
+     * |        |          |11 = BPWM compare up point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter up count to CMPDAT.
+     * |[11:10] |CMPUCTL5  |BPWM Compare Up Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare up point output Low.
+     * |        |          |10 = BPWM compare up point output High.
+     * |        |          |11 = BPWM compare up point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter up count to CMPDAT.
+     * |[17:16] |CMPDCTL0  |BPWM Compare Down Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare down point output Low.
+     * |        |          |10 = BPWM compare down point output High.
+     * |        |          |11 = BPWM compare down point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter down count to CMPDAT.
+     * |[19:18] |CMPDCTL1  |BPWM Compare Down Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare down point output Low.
+     * |        |          |10 = BPWM compare down point output High.
+     * |        |          |11 = BPWM compare down point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter down count to CMPDAT.
+     * |[21:20] |CMPDCTL2  |BPWM Compare Down Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare down point output Low.
+     * |        |          |10 = BPWM compare down point output High.
+     * |        |          |11 = BPWM compare down point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter down count to CMPDAT.
+     * |[23:22] |CMPDCTL3  |BPWM Compare Down Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare down point output Low.
+     * |        |          |10 = BPWM compare down point output High.
+     * |        |          |11 = BPWM compare down point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter down count to CMPDAT.
+     * |[25:24] |CMPDCTL4  |BPWM Compare Down Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare down point output Low.
+     * |        |          |10 = BPWM compare down point output High.
+     * |        |          |11 = BPWM compare down point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter down count to CMPDAT.
+     * |[27:26] |CMPDCTL5  |BPWM Compare Down Point Control
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = BPWM compare down point output Low.
+     * |        |          |10 = BPWM compare down point output High.
+     * |        |          |11 = BPWM compare down point output Toggle.
+     * |        |          |BPWM can control output level when BPWM counter down count to CMPDAT.
+     * @var BPWM_T::MSKEN
+     * Offset: 0xB8  BPWM Mask Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MSKEN0    |BPWM Mask Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |The BPWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding BPWM channel n will output MSKDATn (BPWM_MSK[5:0]) data.
+     * |        |          |0 = BPWM output signal is non-masked.
+     * |        |          |1 = BPWM output signal is masked and output MSKDATn data.
+     * |[1]     |MSKEN1    |BPWM Mask Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |The BPWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding BPWM channel n will output MSKDATn (BPWM_MSK[5:0]) data.
+     * |        |          |0 = BPWM output signal is non-masked.
+     * |        |          |1 = BPWM output signal is masked and output MSKDATn data.
+     * |[2]     |MSKEN2    |BPWM Mask Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |The BPWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding BPWM channel n will output MSKDATn (BPWM_MSK[5:0]) data.
+     * |        |          |0 = BPWM output signal is non-masked.
+     * |        |          |1 = BPWM output signal is masked and output MSKDATn data.
+     * |[3]     |MSKEN3    |BPWM Mask Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |The BPWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding BPWM channel n will output MSKDATn (BPWM_MSK[5:0]) data.
+     * |        |          |0 = BPWM output signal is non-masked.
+     * |        |          |1 = BPWM output signal is masked and output MSKDATn data.
+     * |[4]     |MSKEN4    |BPWM Mask Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |The BPWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding BPWM channel n will output MSKDATn (BPWM_MSK[5:0]) data.
+     * |        |          |0 = BPWM output signal is non-masked.
+     * |        |          |1 = BPWM output signal is masked and output MSKDATn data.
+     * |[5]     |MSKEN5    |BPWM Mask Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |The BPWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding BPWM channel n will output MSKDATn (BPWM_MSK[5:0]) data.
+     * |        |          |0 = BPWM output signal is non-masked.
+     * |        |          |1 = BPWM output signal is masked and output MSKDATn data.
+     * @var BPWM_T::MSK
+     * Offset: 0xBC  BPWM Mask Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MSKDAT0   |BPWM Mask Data Bit
+     * |        |          |This data bit control the state of BPWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Output logic low to BPWMn.
+     * |        |          |1 = Output logic high to BPWMn.
+     * |[1]     |MSKDAT1   |BPWM Mask Data Bit
+     * |        |          |This data bit control the state of BPWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Output logic low to BPWMn.
+     * |        |          |1 = Output logic high to BPWMn.
+     * |[2]     |MSKDAT2   |BPWM Mask Data Bit
+     * |        |          |This data bit control the state of BPWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Output logic low to BPWMn.
+     * |        |          |1 = Output logic high to BPWMn.
+     * |[3]     |MSKDAT3   |BPWM Mask Data Bit
+     * |        |          |This data bit control the state of BPWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Output logic low to BPWMn.
+     * |        |          |1 = Output logic high to BPWMn.
+     * |[4]     |MSKDAT4   |BPWM Mask Data Bit
+     * |        |          |This data bit control the state of BPWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Output logic low to BPWMn.
+     * |        |          |1 = Output logic high to BPWMn.
+     * |[5]     |MSKDAT5   |BPWM Mask Data Bit
+     * |        |          |This data bit control the state of BPWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Output logic low to BPWMn.
+     * |        |          |1 = Output logic high to BPWMn.
+     * @var BPWM_T::POLCTL
+     * Offset: 0xD4  BPWM Pin Polar Inverse Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PINV0     |BPWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of BPWM output
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM output polar inverse Disabled.
+     * |        |          |1 = BPWM output polar inverse Enabled.
+     * |[1]     |PINV1     |BPWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of BPWM output
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM output polar inverse Disabled.
+     * |        |          |1 = BPWM output polar inverse Enabled.
+     * |[2]     |PINV2     |BPWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of BPWM output
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM output polar inverse Disabled.
+     * |        |          |1 = BPWM output polar inverse Enabled.
+     * |[3]     |PINV3     |BPWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of BPWM output
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM output polar inverse Disabled.
+     * |        |          |1 = BPWM output polar inverse Enabled.
+     * |[4]     |PINV4     |BPWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of BPWM output
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM output polar inverse Disabled.
+     * |        |          |1 = BPWM output polar inverse Enabled.
+     * |[5]     |PINV5     |BPWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of BPWM output
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM output polar inverse Disabled.
+     * |        |          |1 = BPWM output polar inverse Enabled.
+     * @var BPWM_T::POEN
+     * Offset: 0xD8  BPWM Output Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |POEN0     |BPWM Pin Output Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM pin at tri-state.
+     * |        |          |1 = BPWM pin in output mode.
+     * |[1]     |POEN1     |BPWM Pin Output Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM pin at tri-state.
+     * |        |          |1 = BPWM pin in output mode.
+     * |[2]     |POEN2     |BPWM Pin Output Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM pin at tri-state.
+     * |        |          |1 = BPWM pin in output mode.
+     * |[3]     |POEN3     |BPWM Pin Output Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM pin at tri-state.
+     * |        |          |1 = BPWM pin in output mode.
+     * |[4]     |POEN4     |BPWM Pin Output Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM pin at tri-state.
+     * |        |          |1 = BPWM pin in output mode.
+     * |[5]     |POEN5     |BPWM Pin Output Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM pin at tri-state.
+     * |        |          |1 = BPWM pin in output mode.
+     * @var BPWM_T::INTEN
+     * Offset: 0xE0  BPWM Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ZIEN0     |BPWM Zero Point Interrupt 0 Enable Bit
+     * |        |          |0 = Zero point interrupt Disabled.
+     * |        |          |1 = Zero point interrupt Enabled.
+     * |[8]     |PIEN0     |BPWM Period Point Interrupt 0 Enable Bit
+     * |        |          |0 = Period point interrupt Disabled.
+     * |        |          |1 = Period point interrupt Enabled.
+     * |        |          |Note: When up-down counter type period point means center point.
+     * |[16]    |CMPUIEN0  |BPWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |[17]    |CMPUIEN1  |BPWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |[18]    |CMPUIEN2  |BPWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |[19]    |CMPUIEN3  |BPWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |[20]    |CMPUIEN4  |BPWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |[21]    |CMPUIEN5  |BPWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |[24]    |CMPDIEN0  |BPWM Compare Down Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |[25]    |CMPDIEN1  |BPWM Compare Down Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |[26]    |CMPDIEN2  |BPWM Compare Down Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |[27]    |CMPDIEN3  |BPWM Compare Down Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |[28]    |CMPDIEN4  |BPWM Compare Down Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |[29]    |CMPDIEN5  |BPWM Compare Down Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * @var BPWM_T::INTSTS
+     * Offset: 0xE8  BPWM Interrupt Flag Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ZIF0      |BPWM Zero Point Interrupt Flag 0
+     * |        |          |This bit is set by hardware when BPWM_CH0 counter reaches 0, software can write 1 to clear this bit to 0.
+     * |[8]     |PIF0      |BPWM Period Point Interrupt Flag 0
+     * |        |          |This bit is set by hardware when BPWM_CH0 counter reaches BPWM_PERIOD0, software can write 1 to clear this bit to 0.
+     * |[16]    |CMPUIF0   |BPWM Compare Up Count Interrupt Flag
+     * |        |          |Flag is set by hardware when BPWM counter up count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in up counter type selection.
+     * |[17]    |CMPUIF1   |BPWM Compare Up Count Interrupt Flag
+     * |        |          |Flag is set by hardware when BPWM counter up count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in up counter type selection.
+     * |[18]    |CMPUIF2   |BPWM Compare Up Count Interrupt Flag
+     * |        |          |Flag is set by hardware when BPWM counter up count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in up counter type selection.
+     * |[19]    |CMPUIF3   |BPWM Compare Up Count Interrupt Flag
+     * |        |          |Flag is set by hardware when BPWM counter up count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in up counter type selection.
+     * |[20]    |CMPUIF4   |BPWM Compare Up Count Interrupt Flag
+     * |        |          |Flag is set by hardware when BPWM counter up count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in up counter type selection.
+     * |[21]    |CMPUIF5   |BPWM Compare Up Count Interrupt Flag
+     * |        |          |Flag is set by hardware when BPWM counter up count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in up counter type selection.
+     * |[24]    |CMPDIF0   |BPWM Compare Down Count Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Flag is set by hardware when BPWM counter down count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in down counter type selection.
+     * |[25]    |CMPDIF1   |BPWM Compare Down Count Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Flag is set by hardware when BPWM counter down count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in down counter type selection.
+     * |[26]    |CMPDIF2   |BPWM Compare Down Count Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Flag is set by hardware when BPWM counter down count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in down counter type selection.
+     * |[27]    |CMPDIF3   |BPWM Compare Down Count Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Flag is set by hardware when BPWM counter down count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in down counter type selection.
+     * |[28]    |CMPDIF4   |BPWM Compare Down Count Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Flag is set by hardware when BPWM counter down count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in down counter type selection.
+     * |[29]    |CMPDIF5   |BPWM Compare Down Count Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Flag is set by hardware when BPWM counter down count and reaches BPWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: If CMPDAT equal to PERIOD, this flag is not working in down counter type selection.
+     * @var BPWM_T::EADCTS0
+     * Offset: 0xF8  BPWM Trigger EADC Source Select Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |TRGSEL0   |BPWM_CH0 Trigger EADC Source Select
+     * |        |          |0000 = BPWM_CH0 zero point.
+     * |        |          |0001 = BPWM_CH0 period point.
+     * |        |          |0010 = BPWM_CH0 zero or period point.
+     * |        |          |0011 = BPWM_CH0 up-count CMPDAT point.
+     * |        |          |0100 = BPWM_CH0 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = BPWM_CH1 up-count CMPDAT point.
+     * |        |          |1001 = BPWM_CH1 down-count CMPDAT point.
+     * |        |          |Others reserved
+     * |[7]     |TRGEN0    |BPWM_CH0 Trigger EADC Enable Bit
+     * |[11:8]  |TRGSEL1   |BPWM_CH1 Trigger EADC Source Select
+     * |        |          |0000 = BPWM_CH0 zero point.
+     * |        |          |0001 = BPWM_CH0 period point.
+     * |        |          |0010 = BPWM_CH0 zero or period point.
+     * |        |          |0011 = BPWM_CH0 up-count CMPDAT point.
+     * |        |          |0100 = BPWM_CH0 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = BPWM_CH1 up-count CMPDAT point.
+     * |        |          |1001 = BPWM_CH1 down-count CMPDAT point.
+     * |        |          |Others reserved
+     * |[15]    |TRGEN1    |BPWM_CH1 Trigger EADC Enable Bit
+     * |[19:16] |TRGSEL2   |BPWM_CH2 Trigger EADC Source Select
+     * |        |          |0000 = BPWM_CH2 zero point.
+     * |        |          |0001 = BPWM_CH2 period point.
+     * |        |          |0010 = BPWM_CH2 zero or period point.
+     * |        |          |0011 = BPWM_CH2 up-count CMPDAT point.
+     * |        |          |0100 = BPWM_CH2 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = BPWM_CH3 up-count CMPDAT point.
+     * |        |          |1001 = BPWM_CH3 down-count CMPDAT point.
+     * |        |          |Others reserved
+     * |[23]    |TRGEN2    |BPWM_CH2 Trigger EADC Enable Bit
+     * |[27:24] |TRGSEL3   |BPWM_CH3 Trigger EADC Source Select
+     * |        |          |0000 = BPWM_CH2 zero point.
+     * |        |          |0001 = BPWM_CH2 period point.
+     * |        |          |0010 = BPWM_CH2 zero or period point.
+     * |        |          |0011 = BPWM_CH2 up-count CMPDAT point.
+     * |        |          |0100 = BPWM_CH2 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = BPWM_CH3 up-count CMPDAT point.
+     * |        |          |1001 = BPWM_CH3 down-count CMPDAT point.
+     * |        |          |Others reserved.
+     * |[31]    |TRGEN3    |BPWM_CH3 Trigger EADC Enable Bit
+     * @var BPWM_T::EADCTS1
+     * Offset: 0xFC  BPWM Trigger EADC Source Select Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |TRGSEL4   |BPWM_CH4 Trigger EADC Source Select
+     * |        |          |0000 = BPWM_CH4 zero point.
+     * |        |          |0001 = BPWM_CH4 period point.
+     * |        |          |0010 = BPWM_CH4 zero or period point.
+     * |        |          |0011 = BPWM_CH4 up-count CMPDAT point.
+     * |        |          |0100 = BPWM_CH4 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = BPWM_CH5 up-count CMPDAT point.
+     * |        |          |1001 = BPWM_CH5 down-count CMPDAT point.
+     * |        |          |Others reserved
+     * |[7]     |TRGEN4    |BPWM_CH4 Trigger EADC Enable Bit
+     * |[11:8]  |TRGSEL5   |BPWM_CH5 Trigger EADC Source Select
+     * |        |          |0000 = BPWM_CH4 zero point.
+     * |        |          |0001 = BPWM_CH4 period point.
+     * |        |          |0010 = BPWM_CH4 zero or period point.
+     * |        |          |0011 = BPWM_CH4 up-count CMPDAT point.
+     * |        |          |0100 = BPWM_CH4 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = BPWM_CH5 up-count CMPDAT point.
+     * |        |          |1001 = BPWM_CH5 down-count CMPDAT point.
+     * |        |          |Others reserved
+     * |[15]    |TRGEN5    |BPWM_CH5 Trigger EADC Enable Bit
+     * @var BPWM_T::SSCTL
+     * Offset: 0x110  BPWM Synchronous Start Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SSEN0     |BPWM Synchronous Start Function 0 Enable Bit
+     * |        |          |When synchronous start function is enabled, the BPWM_CH0 counter enable bit (CNTEN0) can be enabled by writing BPWM synchronous start trigger bit (CNTSEN).
+     * |        |          |0 = BPWM synchronous start function Disabled.
+     * |        |          |1 = BPWM synchronous start function Enabled.
+     * |[9:8]   |SSRC      |BPWM Synchronous Start Source Select
+     * |        |          |00 = Synchronous start source come from PWM0.
+     * |        |          |01 = Synchronous start source come from PWM1.
+     * |        |          |10 = Synchronous start source come from BPWM0.
+     * |        |          |11 = Synchronous start source come from BPWM1.
+     * @var BPWM_T::SSTRG
+     * Offset: 0x114  BPWM Synchronous Start Trigger Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTSEN    |BPWM Counter Synchronous Start Enable Bit(Write Only)
+     * |        |          |BPMW counter synchronous enable function is used to make PWM or BPWM channels start counting at the same time.
+     * |        |          |Writing this bit to 1 will also set the counter enable bit if correlated BPWM channel counter synchronous start function is enabled.
+     * @var BPWM_T::STATUS
+     * Offset: 0x120  BPWM Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTMAX0   |Time-base Counter 0 Equal to 0xFFFF Latched Status
+     * |        |          |0 = The time-base counter never reached its maximum value 0xFFFF.
+     * |        |          |1 = The time-base counter reached its maximum value. Software can write 1 to clear this bit.
+     * |[16]    |EADCTRG0  |EADC Start of Conversion Status
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred. Software can write 1 to clear this bit.
+     * |[17]    |EADCTRG1  |EADC Start of Conversion Status
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred. Software can write 1 to clear this bit.
+     * |[18]    |EADCTRG2  |EADC Start of Conversion Status
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred. Software can write 1 to clear this bit.
+     * |[19]    |EADCTRG3  |EADC Start of Conversion Status
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred. Software can write 1 to clear this bit.
+     * |[20]    |EADCTRG4  |EADC Start of Conversion Status
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred. Software can write 1 to clear this bit.
+     * |[21]    |EADCTRG5  |EADC Start of Conversion Status
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred. Software can write 1 to clear this bit.
+     * @var BPWM_T::CAPINEN
+     * Offset: 0x200  BPWM Capture Input Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CAPINEN0  |Capture Input Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM Channel capture input path Disabled
+     * |        |          |The input of BPWM channel capture function is always regarded as 0.
+     * |        |          |1 = BPWM Channel capture input path Enabled
+     * |        |          |The input of BPWM channel capture function comes from correlative multifunction pin.
+     * |[1]     |CAPINEN1  |Capture Input Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM Channel capture input path Disabled
+     * |        |          |The input of BPWM channel capture function is always regarded as 0.
+     * |        |          |1 = BPWM Channel capture input path Enabled
+     * |        |          |The input of BPWM channel capture function comes from correlative multifunction pin.
+     * |[2]     |CAPINEN2  |Capture Input Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM Channel capture input path Disabled
+     * |        |          |The input of BPWM channel capture function is always regarded as 0.
+     * |        |          |1 = BPWM Channel capture input path Enabled
+     * |        |          |The input of BPWM channel capture function comes from correlative multifunction pin.
+     * |[3]     |CAPINEN3  |Capture Input Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM Channel capture input path Disabled
+     * |        |          |The input of BPWM channel capture function is always regarded as 0.
+     * |        |          |1 = BPWM Channel capture input path Enabled
+     * |        |          |The input of BPWM channel capture function comes from correlative multifunction pin.
+     * |[4]     |CAPINEN4  |Capture Input Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM Channel capture input path Disabled
+     * |        |          |The input of BPWM channel capture function is always regarded as 0.
+     * |        |          |1 = BPWM Channel capture input path Enabled
+     * |        |          |The input of BPWM channel capture function comes from correlative multifunction pin.
+     * |[5]     |CAPINEN5  |Capture Input Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = BPWM Channel capture input path Disabled
+     * |        |          |The input of BPWM channel capture function is always regarded as 0.
+     * |        |          |1 = BPWM Channel capture input path Enabled
+     * |        |          |The input of BPWM channel capture function comes from correlative multifunction pin.
+     * @var BPWM_T::CAPCTL
+     * Offset: 0x204  BPWM Capture Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CAPEN0    |Capture Function Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the BPWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[1]     |CAPEN1    |Capture Function Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the BPWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[2]     |CAPEN2    |Capture Function Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the BPWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[3]     |CAPEN3    |Capture Function Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the BPWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[4]     |CAPEN4    |Capture Function Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the BPWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[5]     |CAPEN5    |Capture Function Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the BPWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[8]     |CAPINV0   |Capture Inverter Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[9]     |CAPINV1   |Capture Inverter Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[10]    |CAPINV2   |Capture Inverter Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[11]    |CAPINV3   |Capture Inverter Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[12]    |CAPINV4   |Capture Inverter Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[13]    |CAPINV5   |Capture Inverter Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[16]    |RCRLDEN0  |Rising Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[17]    |RCRLDEN1  |Rising Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[18]    |RCRLDEN2  |Rising Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[19]    |RCRLDEN3  |Rising Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[20]    |RCRLDEN4  |Rising Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[21]    |RCRLDEN5  |Rising Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[24]    |FCRLDEN0  |Falling Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[25]    |FCRLDEN1  |Falling Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[26]    |FCRLDEN2  |Falling Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[27]    |FCRLDEN3  |Falling Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[28]    |FCRLDEN4  |Falling Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[29]    |FCRLDEN5  |Falling Capture Reload Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * @var BPWM_T::CAPSTS
+     * Offset: 0x208  BPWM Capture Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CRIFOV0   |Capture Rising Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CAPRIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPRIF.
+     * |[1]     |CRIFOV1   |Capture Rising Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CAPRIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPRIF.
+     * |[2]     |CRIFOV2   |Capture Rising Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CAPRIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPRIF.
+     * |[3]     |CRIFOV3   |Capture Rising Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CAPRIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPRIF.
+     * |[4]     |CRIFOV4   |Capture Rising Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CAPRIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPRIF.
+     * |[5]     |CRIFOV5   |Capture Rising Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CAPRIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPRIF.
+     * |[8]     |CFIFOV0   |Capture Falling Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CAPFIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPFIF.
+     * |[9]     |CFIFOV1   |Capture Falling Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CAPFIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPFIF.
+     * |[10]    |CFIFOV2   |Capture Falling Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CAPFIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPFIF.
+     * |[11]    |CFIFOV3   |Capture Falling Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CAPFIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPFIF.
+     * |[12]    |CFIFOV4   |Capture Falling Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CAPFIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPFIF.
+     * |[13]    |CFIFOV5   |Capture Falling Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CAPFIF is 1
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CAPFIF.
+     * @var BPWM_T::CAPIEN
+     * Offset: 0x250  BPWM Capture Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[5:0]   |CAPRIENn  |BPWM Capture Rising Latch Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture rising edge latch interrupt Disabled.
+     * |        |          |1 = Capture rising edge latch interrupt Enabled.
+     * |[13:8]  |CAPFIENn  |BPWM Capture Falling Latch Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = Capture falling edge latch interrupt Disabled.
+     * |        |          |1 = Capture falling edge latch interrupt Enabled.
+     * @var BPWM_T::CAPIF
+     * Offset: 0x254  BPWM Capture Interrupt Flag Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CAPRIF0   |BPWM Capture Rising Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[1]     |CAPRIF1   |BPWM Capture Rising Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[2]     |CAPRIF2   |BPWM Capture Rising Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[3]     |CAPRIF3   |BPWM Capture Rising Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[4]     |CAPRIF4   |BPWM Capture Rising Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[5]     |CAPRIF5   |BPWM Capture Rising Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[8]     |CAPFIF0   |BPWM Capture Falling Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[9]     |CAPFIF1   |BPWM Capture Falling Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[10]    |CAPFIF2   |BPWM Capture Falling Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[11]    |CAPFIF3   |BPWM Capture Falling Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[12]    |CAPFIF4   |BPWM Capture Falling Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[13]    |CAPFIF5   |BPWM Capture Falling Latch Interrupt Flag
+     * |        |          |Each bit n controls the corresponding BPWM channel n.
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * @var BPWM_T::PBUF
+     * Offset: 0x304  BPWM PERIOD Buffer
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |PBUF      |BPWM Period Buffer (Read Only)
+     * |        |          |Used as PERIOD active register.
+     * @var BPWM_T::CMPBUF[6]
+     * Offset: 0x31C~0x330  BPWM CMPDAT 0~5 Buffer
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CMPBUF    |BPWM Comparator Buffer (Read Only)
+     * |        |          |Used as CMP active register.
+     */
+    __IO uint32_t CTL0;                  /*!< [0x0000] BPWM Control Register 0                                          */
+    __IO uint32_t CTL1;                  /*!< [0x0004] BPWM Control Register 1                                          */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CLKSRC;                /*!< [0x0010] BPWM Clock Source Register                                       */
+    __IO uint32_t CLKPSC;                /*!< [0x0014] BPWM Clock Prescale Register                                     */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CNTEN;                 /*!< [0x0020] BPWM Counter Enable Register                                     */
+    __IO uint32_t CNTCLR;                /*!< [0x0024] BPWM Clear Counter Register                                      */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PERIOD;                /*!< [0x0030] BPWM Period Register                                             */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[7];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CMPDAT[6];             /*!< [0x0050 ~ 0x0064] BPWM Comparator Register 0 ~ 6                          */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE4[10];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t CNT;                   /*!< [0x0090] BPWM Counter Register                                            */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE5[7];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t WGCTL0;                /*!< [0x00b0] BPWM Generation Register 0                                       */
+    __IO uint32_t WGCTL1;                /*!< [0x00b4] BPWM Generation Register 1                                       */
+    __IO uint32_t MSKEN;                 /*!< [0x00b8] BPWM Mask Enable Register                                        */
+    __IO uint32_t MSK;                   /*!< [0x00bc] BPWM Mask Data Register                                          */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE6[5];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t POLCTL;                /*!< [0x00d4] BPWM Pin Polar Inverse Register                                  */
+    __IO uint32_t POEN;                  /*!< [0x00d8] BPWM Output Enable Register                                      */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE7[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t INTEN;                 /*!< [0x00e0] BPWM Interrupt Enable Register                                   */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE8[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t INTSTS;                /*!< [0x00e8] BPWM Interrupt Flag Register                                     */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE9[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t EADCTS0;               /*!< [0x00f8] BPWM Trigger EADC Source Select Register 0                       */
+    __IO uint32_t EADCTS1;               /*!< [0x00fc] BPWM Trigger EADC Source Select Register 1                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE10[4];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t SSCTL;                 /*!< [0x0110] BPWM Synchronous Start Control Register                          */
+    __O  uint32_t SSTRG;                 /*!< [0x0114] BPWM Synchronous Start Trigger Register                          */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE11[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t STATUS;                /*!< [0x0120] BPWM Status Register                                             */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE12[55];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CAPINEN;               /*!< [0x0200] BPWM Capture Input Enable Register                               */
+    __IO uint32_t CAPCTL;                /*!< [0x0204] BPWM Capture Control Register                                    */
+    __I  uint32_t CAPSTS;                /*!< [0x0208] BPWM Capture Status Register                                     */
+    BCAPDAT_T CAPDAT[6];                 /*!< [0x020C ~ 0x0238] BPWM Rising and Falling Capture Data Register 0~5       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE13[5];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CAPIEN;                /*!< [0x0250] BPWM Capture Interrupt Enable Register                           */
+    __IO uint32_t CAPIF;                 /*!< [0x0254] BPWM Capture Interrupt Flag Register                             */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE14[43];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t PBUF;                  /*!< [0x0304] BPWM PERIOD Buffer                                               */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE15[5];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t CMPBUF[6];             /*!< [0x031c ~ 0x0330] BPWM CMPDAT 0 ~ 5 Buffer                                */
+} BPWM_T;
+
+/**
+    @addtogroup BPWM_CONST BPWM Bit Field Definition
+    Constant Definitions for BPWM Controller
+@{ */
+
+#define BPWM_CTL0_CTRLD0_Pos            (0)                                               /*!< BPWM_T::CTL0: CTRLD0 Position         */
+#define BPWM_CTL0_CTRLD0_Msk            (0x1ul << BPWM_CTL0_CTRLD0_Pos)                   /*!< BPWM_T::CTL0: CTRLD0 Mask             */
+
+#define BPWM_CTL0_CTRLD1_Pos            (1)                                               /*!< BPWM_T::CTL0: CTRLD1 Position         */
+#define BPWM_CTL0_CTRLD1_Msk            (0x1ul << BPWM_CTL0_CTRLD1_Pos)                   /*!< BPWM_T::CTL0: CTRLD1 Mask             */
+
+#define BPWM_CTL0_CTRLD2_Pos            (2)                                               /*!< BPWM_T::CTL0: CTRLD2 Position         */
+#define BPWM_CTL0_CTRLD2_Msk            (0x1ul << BPWM_CTL0_CTRLD2_Pos)                   /*!< BPWM_T::CTL0: CTRLD2 Mask             */
+
+#define BPWM_CTL0_CTRLD3_Pos            (3)                                               /*!< BPWM_T::CTL0: CTRLD3 Position         */
+#define BPWM_CTL0_CTRLD3_Msk            (0x1ul << BPWM_CTL0_CTRLD3_Pos)                   /*!< BPWM_T::CTL0: CTRLD3 Mask             */
+
+#define BPWM_CTL0_CTRLD4_Pos            (4)                                               /*!< BPWM_T::CTL0: CTRLD4 Position         */
+#define BPWM_CTL0_CTRLD4_Msk            (0x1ul << BPWM_CTL0_CTRLD4_Pos)                   /*!< BPWM_T::CTL0: CTRLD4 Mask             */
+
+#define BPWM_CTL0_CTRLD5_Pos            (5)                                               /*!< BPWM_T::CTL0: CTRLD5 Position         */
+#define BPWM_CTL0_CTRLD5_Msk            (0x1ul << BPWM_CTL0_CTRLD5_Pos)                   /*!< BPWM_T::CTL0: CTRLD5 Mask             */
+
+#define BPWM_CTL0_IMMLDEN0_Pos          (16)                                              /*!< BPWM_T::CTL0: IMMLDEN0 Position       */
+#define BPWM_CTL0_IMMLDEN0_Msk          (0x1ul << BPWM_CTL0_IMMLDEN0_Pos)                 /*!< BPWM_T::CTL0: IMMLDEN0 Mask           */
+
+#define BPWM_CTL0_IMMLDEN1_Pos          (17)                                              /*!< BPWM_T::CTL0: IMMLDEN1 Position       */
+#define BPWM_CTL0_IMMLDEN1_Msk          (0x1ul << BPWM_CTL0_IMMLDEN1_Pos)                 /*!< BPWM_T::CTL0: IMMLDEN1 Mask           */
+
+#define BPWM_CTL0_IMMLDEN2_Pos          (18)                                              /*!< BPWM_T::CTL0: IMMLDEN2 Position       */
+#define BPWM_CTL0_IMMLDEN2_Msk          (0x1ul << BPWM_CTL0_IMMLDEN2_Pos)                 /*!< BPWM_T::CTL0: IMMLDEN2 Mask           */
+
+#define BPWM_CTL0_IMMLDEN3_Pos          (19)                                              /*!< BPWM_T::CTL0: IMMLDEN3 Position       */
+#define BPWM_CTL0_IMMLDEN3_Msk          (0x1ul << BPWM_CTL0_IMMLDEN3_Pos)                 /*!< BPWM_T::CTL0: IMMLDEN3 Mask           */
+
+#define BPWM_CTL0_IMMLDEN4_Pos          (20)                                              /*!< BPWM_T::CTL0: IMMLDEN4 Position       */
+#define BPWM_CTL0_IMMLDEN4_Msk          (0x1ul << BPWM_CTL0_IMMLDEN4_Pos)                 /*!< BPWM_T::CTL0: IMMLDEN4 Mask           */
+
+#define BPWM_CTL0_IMMLDEN5_Pos          (21)                                              /*!< BPWM_T::CTL0: IMMLDEN5 Position       */
+#define BPWM_CTL0_IMMLDEN5_Msk          (0x1ul << BPWM_CTL0_IMMLDEN5_Pos)                 /*!< BPWM_T::CTL0: IMMLDEN5 Mask           */
+
+#define BPWM_CTL0_DBGHALT_Pos           (30)                                              /*!< BPWM_T::CTL0: DBGHALT Position        */
+#define BPWM_CTL0_DBGHALT_Msk           (0x1ul << BPWM_CTL0_DBGHALT_Pos)                  /*!< BPWM_T::CTL0: DBGHALT Mask            */
+
+#define BPWM_CTL0_DBGTRIOFF_Pos         (31)                                              /*!< BPWM_T::CTL0: DBGTRIOFF Position      */
+#define BPWM_CTL0_DBGTRIOFF_Msk         (0x1ul << BPWM_CTL0_DBGTRIOFF_Pos)                /*!< BPWM_T::CTL0: DBGTRIOFF Mask          */
+
+#define BPWM_CTL1_CNTTYPE0_Pos          (0)                                               /*!< BPWM_T::CTL1: CNTTYPE0 Position       */
+#define BPWM_CTL1_CNTTYPE0_Msk          (0x3ul << BPWM_CTL1_CNTTYPE0_Pos)                 /*!< BPWM_T::CTL1: CNTTYPE0 Mask           */
+
+#define BPWM_CLKSRC_ECLKSRC0_Pos        (0)                                               /*!< BPWM_T::CLKSRC: ECLKSRC0 Position     */
+#define BPWM_CLKSRC_ECLKSRC0_Msk        (0x7ul << BPWM_CLKSRC_ECLKSRC0_Pos)               /*!< BPWM_T::CLKSRC: ECLKSRC0 Mask         */
+
+#define BPWM_CLKPSC_CLKPSC_Pos          (0)                                               /*!< BPWM_T::CLKPSC: CLKPSC Position       */
+#define BPWM_CLKPSC_CLKPSC_Msk          (0xffful << BPWM_CLKPSC_CLKPSC_Pos)               /*!< BPWM_T::CLKPSC: CLKPSC Mask           */
+
+#define BPWM_CNTEN_CNTEN0_Pos           (0)                                               /*!< BPWM_T::CNTEN: CNTEN0 Position        */
+#define BPWM_CNTEN_CNTEN0_Msk           (0x1ul << BPWM_CNTEN_CNTEN0_Pos)                  /*!< BPWM_T::CNTEN: CNTEN0 Mask            */
+
+#define BPWM_CNTCLR_CNTCLR0_Pos         (0)                                               /*!< BPWM_T::CNTCLR: CNTCLR0 Position      */
+#define BPWM_CNTCLR_CNTCLR0_Msk         (0x1ul << BPWM_CNTCLR_CNTCLR0_Pos)                /*!< BPWM_T::CNTCLR: CNTCLR0 Mask          */
+
+#define BPWM_PERIOD_PERIOD_Pos          (0)                                               /*!< BPWM_T::PERIOD: PERIOD Position       */
+#define BPWM_PERIOD_PERIOD_Msk          (0xfffful << BPWM_PERIOD_PERIOD_Pos)              /*!< BPWM_T::PERIOD: PERIOD Mask           */
+
+#define BPWM_CMPDAT_CMPDAT_Pos          (0)                                               /*!< BPWM_T::CMPDAT0: CMPDAT Position      */
+#define BPWM_CMPDAT_CMPDAT_Msk          (0xfffful << BPWM_CMPDAT_CMPDAT_Pos)              /*!< BPWM_T::CMPDAT0: CMPDAT Mask          */
+
+#define BPWM_CNT_CNT_Pos                (0)                                               /*!< BPWM_T::CNT: CNT Position             */
+#define BPWM_CNT_CNT_Msk                (0xfffful << BPWM_CNT_CNT_Pos)                    /*!< BPWM_T::CNT: CNT Mask                 */
+
+#define BPWM_CNT_DIRF_Pos               (16)                                              /*!< BPWM_T::CNT: DIRF Position            */
+#define BPWM_CNT_DIRF_Msk               (0x1ul << BPWM_CNT_DIRF_Pos)                      /*!< BPWM_T::CNT: DIRF Mask                */
+
+#define BPWM_WGCTL0_ZPCTL0_Pos          (0)                                               /*!< BPWM_T::WGCTL0: ZPCTL0 Position       */
+#define BPWM_WGCTL0_ZPCTL0_Msk          (0x3ul << BPWM_WGCTL0_ZPCTL0_Pos)                 /*!< BPWM_T::WGCTL0: ZPCTL0 Mask           */
+
+#define BPWM_WGCTL0_ZPCTL1_Pos          (2)                                               /*!< BPWM_T::WGCTL0: ZPCTL1 Position       */
+#define BPWM_WGCTL0_ZPCTL1_Msk          (0x3ul << BPWM_WGCTL0_ZPCTL1_Pos)                 /*!< BPWM_T::WGCTL0: ZPCTL1 Mask           */
+
+#define BPWM_WGCTL0_ZPCTL2_Pos          (4)                                               /*!< BPWM_T::WGCTL0: ZPCTL2 Position       */
+#define BPWM_WGCTL0_ZPCTL2_Msk          (0x3ul << BPWM_WGCTL0_ZPCTL2_Pos)                 /*!< BPWM_T::WGCTL0: ZPCTL2 Mask           */
+
+#define BPWM_WGCTL0_ZPCTL3_Pos          (6)                                               /*!< BPWM_T::WGCTL0: ZPCTL3 Position       */
+#define BPWM_WGCTL0_ZPCTL3_Msk          (0x3ul << BPWM_WGCTL0_ZPCTL3_Pos)                 /*!< BPWM_T::WGCTL0: ZPCTL3 Mask           */
+
+#define BPWM_WGCTL0_ZPCTL4_Pos          (8)                                               /*!< BPWM_T::WGCTL0: ZPCTL4 Position       */
+#define BPWM_WGCTL0_ZPCTL4_Msk          (0x3ul << BPWM_WGCTL0_ZPCTL4_Pos)                 /*!< BPWM_T::WGCTL0: ZPCTL4 Mask           */
+
+#define BPWM_WGCTL0_ZPCTL5_Pos          (10)                                              /*!< BPWM_T::WGCTL0: ZPCTL5 Position       */
+#define BPWM_WGCTL0_ZPCTL5_Msk          (0x3ul << BPWM_WGCTL0_ZPCTL5_Pos)                 /*!< BPWM_T::WGCTL0: ZPCTL5 Mask           */
+
+#define BPWM_WGCTL0_PRDPCTL0_Pos        (16)                                              /*!< BPWM_T::WGCTL0: PRDPCTL0 Position     */
+#define BPWM_WGCTL0_PRDPCTL0_Msk        (0x3ul << BPWM_WGCTL0_PRDPCTL0_Pos)               /*!< BPWM_T::WGCTL0: PRDPCTL0 Mask         */
+
+#define BPWM_WGCTL0_PRDPCTL1_Pos        (18)                                              /*!< BPWM_T::WGCTL0: PRDPCTL1 Position     */
+#define BPWM_WGCTL0_PRDPCTL1_Msk        (0x3ul << BPWM_WGCTL0_PRDPCTL1_Pos)               /*!< BPWM_T::WGCTL0: PRDPCTL1 Mask         */
+
+#define BPWM_WGCTL0_PRDPCTL2_Pos        (20)                                              /*!< BPWM_T::WGCTL0: PRDPCTL2 Position     */
+#define BPWM_WGCTL0_PRDPCTL2_Msk        (0x3ul << BPWM_WGCTL0_PRDPCTL2_Pos)               /*!< BPWM_T::WGCTL0: PRDPCTL2 Mask         */
+
+#define BPWM_WGCTL0_PRDPCTL3_Pos        (22)                                              /*!< BPWM_T::WGCTL0: PRDPCTL3 Position     */
+#define BPWM_WGCTL0_PRDPCTL3_Msk        (0x3ul << BPWM_WGCTL0_PRDPCTL3_Pos)               /*!< BPWM_T::WGCTL0: PRDPCTL3 Mask         */
+
+#define BPWM_WGCTL0_PRDPCTL4_Pos        (24)                                              /*!< BPWM_T::WGCTL0: PRDPCTL4 Position     */
+#define BPWM_WGCTL0_PRDPCTL4_Msk        (0x3ul << BPWM_WGCTL0_PRDPCTL4_Pos)               /*!< BPWM_T::WGCTL0: PRDPCTL4 Mask         */
+
+#define BPWM_WGCTL0_PRDPCTL5_Pos        (26)                                              /*!< BPWM_T::WGCTL0: PRDPCTL5 Position     */
+#define BPWM_WGCTL0_PRDPCTL5_Msk        (0x3ul << BPWM_WGCTL0_PRDPCTL5_Pos)               /*!< BPWM_T::WGCTL0: PRDPCTL5 Mask         */
+
+#define BPWM_WGCTL1_CMPUCTL0_Pos        (0)                                               /*!< BPWM_T::WGCTL1: CMPUCTL0 Position     */
+#define BPWM_WGCTL1_CMPUCTL0_Msk        (0x3ul << BPWM_WGCTL1_CMPUCTL0_Pos)               /*!< BPWM_T::WGCTL1: CMPUCTL0 Mask         */
+
+#define BPWM_WGCTL1_CMPUCTL1_Pos        (2)                                               /*!< BPWM_T::WGCTL1: CMPUCTL1 Position     */
+#define BPWM_WGCTL1_CMPUCTL1_Msk        (0x3ul << BPWM_WGCTL1_CMPUCTL1_Pos)               /*!< BPWM_T::WGCTL1: CMPUCTL1 Mask         */
+
+#define BPWM_WGCTL1_CMPUCTL2_Pos        (4)                                               /*!< BPWM_T::WGCTL1: CMPUCTL2 Position     */
+#define BPWM_WGCTL1_CMPUCTL2_Msk        (0x3ul << BPWM_WGCTL1_CMPUCTL2_Pos)               /*!< BPWM_T::WGCTL1: CMPUCTL2 Mask         */
+
+#define BPWM_WGCTL1_CMPUCTL3_Pos        (6)                                               /*!< BPWM_T::WGCTL1: CMPUCTL3 Position     */
+#define BPWM_WGCTL1_CMPUCTL3_Msk        (0x3ul << BPWM_WGCTL1_CMPUCTL3_Pos)               /*!< BPWM_T::WGCTL1: CMPUCTL3 Mask         */
+
+#define BPWM_WGCTL1_CMPUCTL4_Pos        (8)                                               /*!< BPWM_T::WGCTL1: CMPUCTL4 Position     */
+#define BPWM_WGCTL1_CMPUCTL4_Msk        (0x3ul << BPWM_WGCTL1_CMPUCTL4_Pos)               /*!< BPWM_T::WGCTL1: CMPUCTL4 Mask         */
+
+#define BPWM_WGCTL1_CMPUCTL5_Pos        (10)                                              /*!< BPWM_T::WGCTL1: CMPUCTL5 Position     */
+#define BPWM_WGCTL1_CMPUCTL5_Msk        (0x3ul << BPWM_WGCTL1_CMPUCTL5_Pos)               /*!< BPWM_T::WGCTL1: CMPUCTL5 Mask         */
+
+#define BPWM_WGCTL1_CMPDCTL0_Pos        (16)                                              /*!< BPWM_T::WGCTL1: CMPDCTL0 Position     */
+#define BPWM_WGCTL1_CMPDCTL0_Msk        (0x3ul << BPWM_WGCTL1_CMPDCTL0_Pos)               /*!< BPWM_T::WGCTL1: CMPDCTL0 Mask         */
+
+#define BPWM_WGCTL1_CMPDCTL1_Pos        (18)                                              /*!< BPWM_T::WGCTL1: CMPDCTL1 Position     */
+#define BPWM_WGCTL1_CMPDCTL1_Msk        (0x3ul << BPWM_WGCTL1_CMPDCTL1_Pos)               /*!< BPWM_T::WGCTL1: CMPDCTL1 Mask         */
+
+#define BPWM_WGCTL1_CMPDCTL2_Pos        (20)                                              /*!< BPWM_T::WGCTL1: CMPDCTL2 Position     */
+#define BPWM_WGCTL1_CMPDCTL2_Msk        (0x3ul << BPWM_WGCTL1_CMPDCTL2_Pos)               /*!< BPWM_T::WGCTL1: CMPDCTL2 Mask         */
+
+#define BPWM_WGCTL1_CMPDCTL3_Pos        (22)                                              /*!< BPWM_T::WGCTL1: CMPDCTL3 Position     */
+#define BPWM_WGCTL1_CMPDCTL3_Msk        (0x3ul << BPWM_WGCTL1_CMPDCTL3_Pos)               /*!< BPWM_T::WGCTL1: CMPDCTL3 Mask         */
+
+#define BPWM_WGCTL1_CMPDCTL4_Pos        (24)                                              /*!< BPWM_T::WGCTL1: CMPDCTL4 Position     */
+#define BPWM_WGCTL1_CMPDCTL4_Msk        (0x3ul << BPWM_WGCTL1_CMPDCTL4_Pos)               /*!< BPWM_T::WGCTL1: CMPDCTL4 Mask         */
+
+#define BPWM_WGCTL1_CMPDCTL5_Pos        (26)                                              /*!< BPWM_T::WGCTL1: CMPDCTL5 Position     */
+#define BPWM_WGCTL1_CMPDCTL5_Msk        (0x3ul << BPWM_WGCTL1_CMPDCTL5_Pos)               /*!< BPWM_T::WGCTL1: CMPDCTL5 Mask         */
+
+#define BPWM_MSKEN_MSKEN0_Pos           (0)                                               /*!< BPWM_T::MSKEN: MSKEN0 Position        */
+#define BPWM_MSKEN_MSKEN0_Msk           (0x1ul << BPWM_MSKEN_MSKEN0_Pos)                  /*!< BPWM_T::MSKEN: MSKEN0 Mask            */
+
+#define BPWM_MSKEN_MSKEN1_Pos           (1)                                               /*!< BPWM_T::MSKEN: MSKEN1 Position        */
+#define BPWM_MSKEN_MSKEN1_Msk           (0x1ul << BPWM_MSKEN_MSKEN1_Pos)                  /*!< BPWM_T::MSKEN: MSKEN1 Mask            */
+
+#define BPWM_MSKEN_MSKEN2_Pos           (2)                                               /*!< BPWM_T::MSKEN: MSKEN2 Position        */
+#define BPWM_MSKEN_MSKEN2_Msk           (0x1ul << BPWM_MSKEN_MSKEN2_Pos)                  /*!< BPWM_T::MSKEN: MSKEN2 Mask            */
+
+#define BPWM_MSKEN_MSKEN3_Pos           (3)                                               /*!< BPWM_T::MSKEN: MSKEN3 Position        */
+#define BPWM_MSKEN_MSKEN3_Msk           (0x1ul << BPWM_MSKEN_MSKEN3_Pos)                  /*!< BPWM_T::MSKEN: MSKEN3 Mask            */
+
+#define BPWM_MSKEN_MSKEN4_Pos           (4)                                               /*!< BPWM_T::MSKEN: MSKEN4 Position        */
+#define BPWM_MSKEN_MSKEN4_Msk           (0x1ul << BPWM_MSKEN_MSKEN4_Pos)                  /*!< BPWM_T::MSKEN: MSKEN4 Mask            */
+
+#define BPWM_MSKEN_MSKEN5_Pos           (5)                                               /*!< BPWM_T::MSKEN: MSKEN5 Position        */
+#define BPWM_MSKEN_MSKEN5_Msk           (0x1ul << BPWM_MSKEN_MSKEN5_Pos)                  /*!< BPWM_T::MSKEN: MSKEN5 Mask            */
+
+#define BPWM_MSK_MSKDAT0_Pos            (0)                                               /*!< BPWM_T::MSK: MSKDAT0 Position         */
+#define BPWM_MSK_MSKDAT0_Msk            (0x1ul << BPWM_MSK_MSKDAT0_Pos)                   /*!< BPWM_T::MSK: MSKDAT0 Mask             */
+
+#define BPWM_MSK_MSKDAT1_Pos            (1)                                               /*!< BPWM_T::MSK: MSKDAT1 Position         */
+#define BPWM_MSK_MSKDAT1_Msk            (0x1ul << BPWM_MSK_MSKDAT1_Pos)                   /*!< BPWM_T::MSK: MSKDAT1 Mask             */
+
+#define BPWM_MSK_MSKDAT2_Pos            (2)                                               /*!< BPWM_T::MSK: MSKDAT2 Position         */
+#define BPWM_MSK_MSKDAT2_Msk            (0x1ul << BPWM_MSK_MSKDAT2_Pos)                   /*!< BPWM_T::MSK: MSKDAT2 Mask             */
+
+#define BPWM_MSK_MSKDAT3_Pos            (3)                                               /*!< BPWM_T::MSK: MSKDAT3 Position         */
+#define BPWM_MSK_MSKDAT3_Msk            (0x1ul << BPWM_MSK_MSKDAT3_Pos)                   /*!< BPWM_T::MSK: MSKDAT3 Mask             */
+
+#define BPWM_MSK_MSKDAT4_Pos            (4)                                               /*!< BPWM_T::MSK: MSKDAT4 Position         */
+#define BPWM_MSK_MSKDAT4_Msk            (0x1ul << BPWM_MSK_MSKDAT4_Pos)                   /*!< BPWM_T::MSK: MSKDAT4 Mask             */
+
+#define BPWM_MSK_MSKDAT5_Pos            (5)                                               /*!< BPWM_T::MSK: MSKDAT5 Position         */
+#define BPWM_MSK_MSKDAT5_Msk            (0x1ul << BPWM_MSK_MSKDAT5_Pos)                   /*!< BPWM_T::MSK: MSKDAT5 Mask             */
+
+#define BPWM_POLCTL_PINV0_Pos           (0)                                               /*!< BPWM_T::POLCTL: PINV0 Position        */
+#define BPWM_POLCTL_PINV0_Msk           (0x1ul << BPWM_POLCTL_PINV0_Pos)                  /*!< BPWM_T::POLCTL: PINV0 Mask            */
+
+#define BPWM_POLCTL_PINV1_Pos           (1)                                               /*!< BPWM_T::POLCTL: PINV1 Position        */
+#define BPWM_POLCTL_PINV1_Msk           (0x1ul << BPWM_POLCTL_PINV1_Pos)                  /*!< BPWM_T::POLCTL: PINV1 Mask            */
+
+#define BPWM_POLCTL_PINV2_Pos           (2)                                               /*!< BPWM_T::POLCTL: PINV2 Position        */
+#define BPWM_POLCTL_PINV2_Msk           (0x1ul << BPWM_POLCTL_PINV2_Pos)                  /*!< BPWM_T::POLCTL: PINV2 Mask            */
+
+#define BPWM_POLCTL_PINV3_Pos           (3)                                               /*!< BPWM_T::POLCTL: PINV3 Position        */
+#define BPWM_POLCTL_PINV3_Msk           (0x1ul << BPWM_POLCTL_PINV3_Pos)                  /*!< BPWM_T::POLCTL: PINV3 Mask            */
+
+#define BPWM_POLCTL_PINV4_Pos           (4)                                               /*!< BPWM_T::POLCTL: PINV4 Position        */
+#define BPWM_POLCTL_PINV4_Msk           (0x1ul << BPWM_POLCTL_PINV4_Pos)                  /*!< BPWM_T::POLCTL: PINV4 Mask            */
+
+#define BPWM_POLCTL_PINV5_Pos           (5)                                               /*!< BPWM_T::POLCTL: PINV5 Position        */
+#define BPWM_POLCTL_PINV5_Msk           (0x1ul << BPWM_POLCTL_PINV5_Pos)                  /*!< BPWM_T::POLCTL: PINV5 Mask            */
+
+#define BPWM_POEN_POEN0_Pos             (0)                                               /*!< BPWM_T::POEN: POEN0 Position          */
+#define BPWM_POEN_POEN0_Msk             (0x1ul << BPWM_POEN_POEN0_Pos)                    /*!< BPWM_T::POEN: POEN0 Mask              */
+
+#define BPWM_POEN_POEN1_Pos             (1)                                               /*!< BPWM_T::POEN: POEN1 Position          */
+#define BPWM_POEN_POEN1_Msk             (0x1ul << BPWM_POEN_POEN1_Pos)                    /*!< BPWM_T::POEN: POEN1 Mask              */
+
+#define BPWM_POEN_POEN2_Pos             (2)                                               /*!< BPWM_T::POEN: POEN2 Position          */
+#define BPWM_POEN_POEN2_Msk             (0x1ul << BPWM_POEN_POEN2_Pos)                    /*!< BPWM_T::POEN: POEN2 Mask              */
+
+#define BPWM_POEN_POEN3_Pos             (3)                                               /*!< BPWM_T::POEN: POEN3 Position          */
+#define BPWM_POEN_POEN3_Msk             (0x1ul << BPWM_POEN_POEN3_Pos)                    /*!< BPWM_T::POEN: POEN3 Mask              */
+
+#define BPWM_POEN_POEN4_Pos             (4)                                               /*!< BPWM_T::POEN: POEN4 Position          */
+#define BPWM_POEN_POEN4_Msk             (0x1ul << BPWM_POEN_POEN4_Pos)                    /*!< BPWM_T::POEN: POEN4 Mask              */
+
+#define BPWM_POEN_POEN5_Pos             (5)                                               /*!< BPWM_T::POEN: POEN5 Position          */
+#define BPWM_POEN_POEN5_Msk             (0x1ul << BPWM_POEN_POEN5_Pos)                    /*!< BPWM_T::POEN: POEN5 Mask              */
+
+#define BPWM_INTEN_ZIEN0_Pos            (0)                                               /*!< BPWM_T::INTEN: ZIEN0 Position         */
+#define BPWM_INTEN_ZIEN0_Msk            (0x1ul << BPWM_INTEN_ZIEN0_Pos)                   /*!< BPWM_T::INTEN: ZIEN0 Mask             */
+
+#define BPWM_INTEN_PIEN0_Pos            (8)                                               /*!< BPWM_T::INTEN: PIEN0 Position         */
+#define BPWM_INTEN_PIEN0_Msk            (0x1ul << BPWM_INTEN_PIEN0_Pos)                   /*!< BPWM_T::INTEN: PIEN0 Mask             */
+
+#define BPWM_INTEN_CMPUIEN0_Pos         (16)                                              /*!< BPWM_T::INTEN: CMPUIEN0 Position      */
+#define BPWM_INTEN_CMPUIEN0_Msk         (0x1ul << BPWM_INTEN_CMPUIEN0_Pos)                /*!< BPWM_T::INTEN: CMPUIEN0 Mask          */
+
+#define BPWM_INTEN_CMPUIEN1_Pos         (17)                                              /*!< BPWM_T::INTEN: CMPUIEN1 Position      */
+#define BPWM_INTEN_CMPUIEN1_Msk         (0x1ul << BPWM_INTEN_CMPUIEN1_Pos)                /*!< BPWM_T::INTEN: CMPUIEN1 Mask          */
+
+#define BPWM_INTEN_CMPUIEN2_Pos         (18)                                              /*!< BPWM_T::INTEN: CMPUIEN2 Position      */
+#define BPWM_INTEN_CMPUIEN2_Msk         (0x1ul << BPWM_INTEN_CMPUIEN2_Pos)                /*!< BPWM_T::INTEN: CMPUIEN2 Mask          */
+
+#define BPWM_INTEN_CMPUIEN3_Pos         (19)                                              /*!< BPWM_T::INTEN: CMPUIEN3 Position      */
+#define BPWM_INTEN_CMPUIEN3_Msk         (0x1ul << BPWM_INTEN_CMPUIEN3_Pos)                /*!< BPWM_T::INTEN: CMPUIEN3 Mask          */
+
+#define BPWM_INTEN_CMPUIEN4_Pos         (20)                                              /*!< BPWM_T::INTEN: CMPUIEN4 Position      */
+#define BPWM_INTEN_CMPUIEN4_Msk         (0x1ul << BPWM_INTEN_CMPUIEN4_Pos)                /*!< BPWM_T::INTEN: CMPUIEN4 Mask          */
+
+#define BPWM_INTEN_CMPUIEN5_Pos         (21)                                              /*!< BPWM_T::INTEN: CMPUIEN5 Position      */
+#define BPWM_INTEN_CMPUIEN5_Msk         (0x1ul << BPWM_INTEN_CMPUIEN5_Pos)                /*!< BPWM_T::INTEN: CMPUIEN5 Mask          */
+
+#define BPWM_INTEN_CMPDIEN0_Pos         (24)                                              /*!< BPWM_T::INTEN: CMPDIEN0 Position      */
+#define BPWM_INTEN_CMPDIEN0_Msk         (0x1ul << BPWM_INTEN_CMPDIEN0_Pos)                /*!< BPWM_T::INTEN: CMPDIEN0 Mask          */
+
+#define BPWM_INTEN_CMPDIEN1_Pos         (25)                                              /*!< BPWM_T::INTEN: CMPDIEN1 Position      */
+#define BPWM_INTEN_CMPDIEN1_Msk         (0x1ul << BPWM_INTEN_CMPDIEN1_Pos)                /*!< BPWM_T::INTEN: CMPDIEN1 Mask          */
+
+#define BPWM_INTEN_CMPDIEN2_Pos         (26)                                              /*!< BPWM_T::INTEN: CMPDIEN2 Position      */
+#define BPWM_INTEN_CMPDIEN2_Msk         (0x1ul << BPWM_INTEN_CMPDIEN2_Pos)                /*!< BPWM_T::INTEN: CMPDIEN2 Mask          */
+
+#define BPWM_INTEN_CMPDIEN3_Pos         (27)                                              /*!< BPWM_T::INTEN: CMPDIEN3 Position      */
+#define BPWM_INTEN_CMPDIEN3_Msk         (0x1ul << BPWM_INTEN_CMPDIEN3_Pos)                /*!< BPWM_T::INTEN: CMPDIEN3 Mask          */
+
+#define BPWM_INTEN_CMPDIEN4_Pos         (28)                                              /*!< BPWM_T::INTEN: CMPDIEN4 Position      */
+#define BPWM_INTEN_CMPDIEN4_Msk         (0x1ul << BPWM_INTEN_CMPDIEN4_Pos)                /*!< BPWM_T::INTEN: CMPDIEN4 Mask          */
+
+#define BPWM_INTEN_CMPDIEN5_Pos         (29)                                              /*!< BPWM_T::INTEN: CMPDIEN5 Position      */
+#define BPWM_INTEN_CMPDIEN5_Msk         (0x1ul << BPWM_INTEN_CMPDIEN5_Pos)                /*!< BPWM_T::INTEN: CMPDIEN5 Mask          */
+
+#define BPWM_INTSTS_ZIF0_Pos            (0)                                               /*!< BPWM_T::INTSTS: ZIF0 Position         */
+#define BPWM_INTSTS_ZIF0_Msk            (0x1ul << BPWM_INTSTS_ZIF0_Pos)                   /*!< BPWM_T::INTSTS: ZIF0 Mask             */
+
+#define BPWM_INTSTS_PIF0_Pos            (8)                                               /*!< BPWM_T::INTSTS: PIF0 Position         */
+#define BPWM_INTSTS_PIF0_Msk            (0x1ul << BPWM_INTSTS_PIF0_Pos)                   /*!< BPWM_T::INTSTS: PIF0 Mask             */
+
+#define BPWM_INTSTS_CMPUIF0_Pos         (16)                                              /*!< BPWM_T::INTSTS: CMPUIF0 Position      */
+#define BPWM_INTSTS_CMPUIF0_Msk         (0x1ul << BPWM_INTSTS_CMPUIF0_Pos)                /*!< BPWM_T::INTSTS: CMPUIF0 Mask          */
+
+#define BPWM_INTSTS_CMPUIF1_Pos         (17)                                              /*!< BPWM_T::INTSTS: CMPUIF1 Position      */
+#define BPWM_INTSTS_CMPUIF1_Msk         (0x1ul << BPWM_INTSTS_CMPUIF1_Pos)                /*!< BPWM_T::INTSTS: CMPUIF1 Mask          */
+
+#define BPWM_INTSTS_CMPUIF2_Pos         (18)                                              /*!< BPWM_T::INTSTS: CMPUIF2 Position      */
+#define BPWM_INTSTS_CMPUIF2_Msk         (0x1ul << BPWM_INTSTS_CMPUIF2_Pos)                /*!< BPWM_T::INTSTS: CMPUIF2 Mask          */
+
+#define BPWM_INTSTS_CMPUIF3_Pos         (19)                                              /*!< BPWM_T::INTSTS: CMPUIF3 Position      */
+#define BPWM_INTSTS_CMPUIF3_Msk         (0x1ul << BPWM_INTSTS_CMPUIF3_Pos)                /*!< BPWM_T::INTSTS: CMPUIF3 Mask          */
+
+#define BPWM_INTSTS_CMPUIF4_Pos         (20)                                              /*!< BPWM_T::INTSTS: CMPUIF4 Position      */
+#define BPWM_INTSTS_CMPUIF4_Msk         (0x1ul << BPWM_INTSTS_CMPUIF4_Pos)                /*!< BPWM_T::INTSTS: CMPUIF4 Mask          */
+
+#define BPWM_INTSTS_CMPUIF5_Pos         (21)                                              /*!< BPWM_T::INTSTS: CMPUIF5 Position      */
+#define BPWM_INTSTS_CMPUIF5_Msk         (0x1ul << BPWM_INTSTS_CMPUIF5_Pos)                /*!< BPWM_T::INTSTS: CMPUIF5 Mask          */
+
+#define BPWM_INTSTS_CMPDIF0_Pos         (24)                                              /*!< BPWM_T::INTSTS: CMPDIF0 Position      */
+#define BPWM_INTSTS_CMPDIF0_Msk         (0x1ul << BPWM_INTSTS_CMPDIF0_Pos)                /*!< BPWM_T::INTSTS: CMPDIF0 Mask          */
+
+#define BPWM_INTSTS_CMPDIF1_Pos         (25)                                              /*!< BPWM_T::INTSTS: CMPDIF1 Position      */
+#define BPWM_INTSTS_CMPDIF1_Msk         (0x1ul << BPWM_INTSTS_CMPDIF1_Pos)                /*!< BPWM_T::INTSTS: CMPDIF1 Mask          */
+
+#define BPWM_INTSTS_CMPDIF2_Pos         (26)                                              /*!< BPWM_T::INTSTS: CMPDIF2 Position      */
+#define BPWM_INTSTS_CMPDIF2_Msk         (0x1ul << BPWM_INTSTS_CMPDIF2_Pos)                /*!< BPWM_T::INTSTS: CMPDIF2 Mask          */
+
+#define BPWM_INTSTS_CMPDIF3_Pos         (27)                                              /*!< BPWM_T::INTSTS: CMPDIF3 Position      */
+#define BPWM_INTSTS_CMPDIF3_Msk         (0x1ul << BPWM_INTSTS_CMPDIF3_Pos)                /*!< BPWM_T::INTSTS: CMPDIF3 Mask          */
+
+#define BPWM_INTSTS_CMPDIF4_Pos         (28)                                              /*!< BPWM_T::INTSTS: CMPDIF4 Position      */
+#define BPWM_INTSTS_CMPDIF4_Msk         (0x1ul << BPWM_INTSTS_CMPDIF4_Pos)                /*!< BPWM_T::INTSTS: CMPDIF4 Mask          */
+
+#define BPWM_INTSTS_CMPDIF5_Pos         (29)                                              /*!< BPWM_T::INTSTS: CMPDIF5 Position      */
+#define BPWM_INTSTS_CMPDIF5_Msk         (0x1ul << BPWM_INTSTS_CMPDIF5_Pos)                /*!< BPWM_T::INTSTS: CMPDIF5 Mask          */
+
+#define BPWM_EADCTS0_TRGSEL0_Pos        (0)                                               /*!< BPWM_T::EADCTS0: TRGSEL0 Position     */
+#define BPWM_EADCTS0_TRGSEL0_Msk        (0xful << BPWM_EADCTS0_TRGSEL0_Pos)               /*!< BPWM_T::EADCTS0: TRGSEL0 Mask         */
+
+#define BPWM_EADCTS0_TRGEN0_Pos         (7)                                               /*!< BPWM_T::EADCTS0: TRGEN0 Position      */
+#define BPWM_EADCTS0_TRGEN0_Msk         (0x1ul << BPWM_EADCTS0_TRGEN0_Pos)                /*!< BPWM_T::EADCTS0: TRGEN0 Mask          */
+
+#define BPWM_EADCTS0_TRGSEL1_Pos        (8)                                               /*!< BPWM_T::EADCTS0: TRGSEL1 Position     */
+#define BPWM_EADCTS0_TRGSEL1_Msk        (0xful << BPWM_EADCTS0_TRGSEL1_Pos)               /*!< BPWM_T::EADCTS0: TRGSEL1 Mask         */
+
+#define BPWM_EADCTS0_TRGEN1_Pos         (15)                                              /*!< BPWM_T::EADCTS0: TRGEN1 Position      */
+#define BPWM_EADCTS0_TRGEN1_Msk         (0x1ul << BPWM_EADCTS0_TRGEN1_Pos)                /*!< BPWM_T::EADCTS0: TRGEN1 Mask          */
+
+#define BPWM_EADCTS0_TRGSEL2_Pos        (16)                                              /*!< BPWM_T::EADCTS0: TRGSEL2 Position     */
+#define BPWM_EADCTS0_TRGSEL2_Msk        (0xful << BPWM_EADCTS0_TRGSEL2_Pos)               /*!< BPWM_T::EADCTS0: TRGSEL2 Mask         */
+
+#define BPWM_EADCTS0_TRGEN2_Pos         (23)                                              /*!< BPWM_T::EADCTS0: TRGEN2 Position      */
+#define BPWM_EADCTS0_TRGEN2_Msk         (0x1ul << BPWM_EADCTS0_TRGEN2_Pos)                /*!< BPWM_T::EADCTS0: TRGEN2 Mask          */
+
+#define BPWM_EADCTS0_TRGSEL3_Pos        (24)                                              /*!< BPWM_T::EADCTS0: TRGSEL3 Position     */
+#define BPWM_EADCTS0_TRGSEL3_Msk        (0xful << BPWM_EADCTS0_TRGSEL3_Pos)               /*!< BPWM_T::EADCTS0: TRGSEL3 Mask         */
+
+#define BPWM_EADCTS0_TRGEN3_Pos         (31)                                              /*!< BPWM_T::EADCTS0: TRGEN3 Position      */
+#define BPWM_EADCTS0_TRGEN3_Msk         (0x1ul << BPWM_EADCTS0_TRGEN3_Pos)                /*!< BPWM_T::EADCTS0: TRGEN3 Mask          */
+
+#define BPWM_EADCTS1_TRGSEL4_Pos        (0)                                               /*!< BPWM_T::EADCTS1: TRGSEL4 Position     */
+#define BPWM_EADCTS1_TRGSEL4_Msk        (0xful << BPWM_EADCTS1_TRGSEL4_Pos)               /*!< BPWM_T::EADCTS1: TRGSEL4 Mask         */
+
+#define BPWM_EADCTS1_TRGEN4_Pos         (7)                                               /*!< BPWM_T::EADCTS1: TRGEN4 Position      */
+#define BPWM_EADCTS1_TRGEN4_Msk         (0x1ul << BPWM_EADCTS1_TRGEN4_Pos)                /*!< BPWM_T::EADCTS1: TRGEN4 Mask          */
+
+#define BPWM_EADCTS1_TRGSEL5_Pos        (8)                                               /*!< BPWM_T::EADCTS1: TRGSEL5 Position     */
+#define BPWM_EADCTS1_TRGSEL5_Msk        (0xful << BPWM_EADCTS1_TRGSEL5_Pos)               /*!< BPWM_T::EADCTS1: TRGSEL5 Mask         */
+
+#define BPWM_EADCTS1_TRGEN5_Pos         (15)                                              /*!< BPWM_T::EADCTS1: TRGEN5 Position      */
+#define BPWM_EADCTS1_TRGEN5_Msk         (0x1ul << BPWM_EADCTS1_TRGEN5_Pos)                /*!< BPWM_T::EADCTS1: TRGEN5 Mask          */
+
+#define BPWM_SSCTL_SSEN0_Pos            (0)                                               /*!< BPWM_T::SSCTL: SSEN0 Position         */
+#define BPWM_SSCTL_SSEN0_Msk            (0x1ul << BPWM_SSCTL_SSEN0_Pos)                   /*!< BPWM_T::SSCTL: SSEN0 Mask             */
+
+#define BPWM_SSCTL_SSRC_Pos             (8)                                               /*!< BPWM_T::SSCTL: SSRC Position          */
+#define BPWM_SSCTL_SSRC_Msk             (0x3ul << BPWM_SSCTL_SSRC_Pos)                    /*!< BPWM_T::SSCTL: SSRC Mask              */
+
+#define BPWM_SSTRG_CNTSEN_Pos           (0)                                               /*!< BPWM_T::SSTRG: CNTSEN Position        */
+#define BPWM_SSTRG_CNTSEN_Msk           (0x1ul << BPWM_SSTRG_CNTSEN_Pos)                  /*!< BPWM_T::SSTRG: CNTSEN Mask            */
+
+#define BPWM_STATUS_CNTMAX0_Pos         (0)                                               /*!< BPWM_T::STATUS: CNTMAX0 Position      */
+#define BPWM_STATUS_CNTMAX0_Msk         (0x1ul << BPWM_STATUS_CNTMAX0_Pos)                /*!< BPWM_T::STATUS: CNTMAX0 Mask          */
+
+#define BPWM_STATUS_EADCTRG0_Pos        (16)                                              /*!< BPWM_T::STATUS: EADCTRG0 Position     */
+#define BPWM_STATUS_EADCTRG0_Msk        (0x1ul << BPWM_STATUS_EADCTRG0_Pos)               /*!< BPWM_T::STATUS: EADCTRG0 Mask         */
+
+#define BPWM_STATUS_EADCTRG1_Pos        (17)                                              /*!< BPWM_T::STATUS: EADCTRG1 Position     */
+#define BPWM_STATUS_EADCTRG1_Msk        (0x1ul << BPWM_STATUS_EADCTRG1_Pos)               /*!< BPWM_T::STATUS: EADCTRG1 Mask         */
+
+#define BPWM_STATUS_EADCTRG2_Pos        (18)                                              /*!< BPWM_T::STATUS: EADCTRG2 Position     */
+#define BPWM_STATUS_EADCTRG2_Msk        (0x1ul << BPWM_STATUS_EADCTRG2_Pos)               /*!< BPWM_T::STATUS: EADCTRG2 Mask         */
+
+#define BPWM_STATUS_EADCTRG3_Pos        (19)                                              /*!< BPWM_T::STATUS: EADCTRG3 Position     */
+#define BPWM_STATUS_EADCTRG3_Msk        (0x1ul << BPWM_STATUS_EADCTRG3_Pos)               /*!< BPWM_T::STATUS: EADCTRG3 Mask         */
+
+#define BPWM_STATUS_EADCTRG4_Pos        (20)                                              /*!< BPWM_T::STATUS: EADCTRG4 Position     */
+#define BPWM_STATUS_EADCTRG4_Msk        (0x1ul << BPWM_STATUS_EADCTRG4_Pos)               /*!< BPWM_T::STATUS: EADCTRG4 Mask         */
+
+#define BPWM_STATUS_EADCTRG5_Pos        (21)                                              /*!< BPWM_T::STATUS: EADCTRG5 Position     */
+#define BPWM_STATUS_EADCTRG5_Msk        (0x1ul << BPWM_STATUS_EADCTRG5_Pos)               /*!< BPWM_T::STATUS: EADCTRG5 Mask         */
+
+#define BPWM_CAPINEN_CAPINEN0_Pos       (0)                                               /*!< BPWM_T::CAPINEN: CAPINEN0 Position    */
+#define BPWM_CAPINEN_CAPINEN0_Msk       (0x1ul << BPWM_CAPINEN_CAPINEN0_Pos)              /*!< BPWM_T::CAPINEN: CAPINEN0 Mask        */
+
+#define BPWM_CAPINEN_CAPINEN1_Pos       (1)                                               /*!< BPWM_T::CAPINEN: CAPINEN1 Position    */
+#define BPWM_CAPINEN_CAPINEN1_Msk       (0x1ul << BPWM_CAPINEN_CAPINEN1_Pos)              /*!< BPWM_T::CAPINEN: CAPINEN1 Mask        */
+
+#define BPWM_CAPINEN_CAPINEN2_Pos       (2)                                               /*!< BPWM_T::CAPINEN: CAPINEN2 Position    */
+#define BPWM_CAPINEN_CAPINEN2_Msk       (0x1ul << BPWM_CAPINEN_CAPINEN2_Pos)              /*!< BPWM_T::CAPINEN: CAPINEN2 Mask        */
+
+#define BPWM_CAPINEN_CAPINEN3_Pos       (3)                                               /*!< BPWM_T::CAPINEN: CAPINEN3 Position    */
+#define BPWM_CAPINEN_CAPINEN3_Msk       (0x1ul << BPWM_CAPINEN_CAPINEN3_Pos)              /*!< BPWM_T::CAPINEN: CAPINEN3 Mask        */
+
+#define BPWM_CAPINEN_CAPINEN4_Pos       (4)                                               /*!< BPWM_T::CAPINEN: CAPINEN4 Position    */
+#define BPWM_CAPINEN_CAPINEN4_Msk       (0x1ul << BPWM_CAPINEN_CAPINEN4_Pos)              /*!< BPWM_T::CAPINEN: CAPINEN4 Mask        */
+
+#define BPWM_CAPINEN_CAPINEN5_Pos       (5)                                               /*!< BPWM_T::CAPINEN: CAPINEN5 Position    */
+#define BPWM_CAPINEN_CAPINEN5_Msk       (0x1ul << BPWM_CAPINEN_CAPINEN5_Pos)              /*!< BPWM_T::CAPINEN: CAPINEN5 Mask        */
+
+#define BPWM_CAPCTL_CAPEN0_Pos          (0)                                               /*!< BPWM_T::CAPCTL: CAPEN0 Position       */
+#define BPWM_CAPCTL_CAPEN0_Msk          (0x1ul << BPWM_CAPCTL_CAPEN0_Pos)                 /*!< BPWM_T::CAPCTL: CAPEN0 Mask           */
+
+#define BPWM_CAPCTL_CAPEN1_Pos          (1)                                               /*!< BPWM_T::CAPCTL: CAPEN1 Position       */
+#define BPWM_CAPCTL_CAPEN1_Msk          (0x1ul << BPWM_CAPCTL_CAPEN1_Pos)                 /*!< BPWM_T::CAPCTL: CAPEN1 Mask           */
+
+#define BPWM_CAPCTL_CAPEN2_Pos          (2)                                               /*!< BPWM_T::CAPCTL: CAPEN2 Position       */
+#define BPWM_CAPCTL_CAPEN2_Msk          (0x1ul << BPWM_CAPCTL_CAPEN2_Pos)                 /*!< BPWM_T::CAPCTL: CAPEN2 Mask           */
+
+#define BPWM_CAPCTL_CAPEN3_Pos          (3)                                               /*!< BPWM_T::CAPCTL: CAPEN3 Position       */
+#define BPWM_CAPCTL_CAPEN3_Msk          (0x1ul << BPWM_CAPCTL_CAPEN3_Pos)                 /*!< BPWM_T::CAPCTL: CAPEN3 Mask           */
+
+#define BPWM_CAPCTL_CAPEN4_Pos          (4)                                               /*!< BPWM_T::CAPCTL: CAPEN4 Position       */
+#define BPWM_CAPCTL_CAPEN4_Msk          (0x1ul << BPWM_CAPCTL_CAPEN4_Pos)                 /*!< BPWM_T::CAPCTL: CAPEN4 Mask           */
+
+#define BPWM_CAPCTL_CAPEN5_Pos          (5)                                               /*!< BPWM_T::CAPCTL: CAPEN5 Position       */
+#define BPWM_CAPCTL_CAPEN5_Msk          (0x1ul << BPWM_CAPCTL_CAPEN5_Pos)                 /*!< BPWM_T::CAPCTL: CAPEN5 Mask           */
+
+#define BPWM_CAPCTL_CAPINV0_Pos         (8)                                               /*!< BPWM_T::CAPCTL: CAPINV0 Position      */
+#define BPWM_CAPCTL_CAPINV0_Msk         (0x1ul << BPWM_CAPCTL_CAPINV0_Pos)                /*!< BPWM_T::CAPCTL: CAPINV0 Mask          */
+
+#define BPWM_CAPCTL_CAPINV1_Pos         (9)                                               /*!< BPWM_T::CAPCTL: CAPINV1 Position      */
+#define BPWM_CAPCTL_CAPINV1_Msk         (0x1ul << BPWM_CAPCTL_CAPINV1_Pos)                /*!< BPWM_T::CAPCTL: CAPINV1 Mask          */
+
+#define BPWM_CAPCTL_CAPINV2_Pos         (10)                                              /*!< BPWM_T::CAPCTL: CAPINV2 Position      */
+#define BPWM_CAPCTL_CAPINV2_Msk         (0x1ul << BPWM_CAPCTL_CAPINV2_Pos)                /*!< BPWM_T::CAPCTL: CAPINV2 Mask          */
+
+#define BPWM_CAPCTL_CAPINV3_Pos         (11)                                              /*!< BPWM_T::CAPCTL: CAPINV3 Position      */
+#define BPWM_CAPCTL_CAPINV3_Msk         (0x1ul << BPWM_CAPCTL_CAPINV3_Pos)                /*!< BPWM_T::CAPCTL: CAPINV3 Mask          */
+
+#define BPWM_CAPCTL_CAPINV4_Pos         (12)                                              /*!< BPWM_T::CAPCTL: CAPINV4 Position      */
+#define BPWM_CAPCTL_CAPINV4_Msk         (0x1ul << BPWM_CAPCTL_CAPINV4_Pos)                /*!< BPWM_T::CAPCTL: CAPINV4 Mask          */
+
+#define BPWM_CAPCTL_CAPINV5_Pos         (13)                                              /*!< BPWM_T::CAPCTL: CAPINV5 Position      */
+#define BPWM_CAPCTL_CAPINV5_Msk         (0x1ul << BPWM_CAPCTL_CAPINV5_Pos)                /*!< BPWM_T::CAPCTL: CAPINV5 Mask          */
+
+#define BPWM_CAPCTL_RCRLDEN0_Pos        (16)                                              /*!< BPWM_T::CAPCTL: RCRLDEN0 Position     */
+#define BPWM_CAPCTL_RCRLDEN0_Msk        (0x1ul << BPWM_CAPCTL_RCRLDEN0_Pos)               /*!< BPWM_T::CAPCTL: RCRLDEN0 Mask         */
+
+#define BPWM_CAPCTL_RCRLDEN1_Pos        (17)                                              /*!< BPWM_T::CAPCTL: RCRLDEN1 Position     */
+#define BPWM_CAPCTL_RCRLDEN1_Msk        (0x1ul << BPWM_CAPCTL_RCRLDEN1_Pos)               /*!< BPWM_T::CAPCTL: RCRLDEN1 Mask         */
+
+#define BPWM_CAPCTL_RCRLDEN2_Pos        (18)                                              /*!< BPWM_T::CAPCTL: RCRLDEN2 Position     */
+#define BPWM_CAPCTL_RCRLDEN2_Msk        (0x1ul << BPWM_CAPCTL_RCRLDEN2_Pos)               /*!< BPWM_T::CAPCTL: RCRLDEN2 Mask         */
+
+#define BPWM_CAPCTL_RCRLDEN3_Pos        (19)                                              /*!< BPWM_T::CAPCTL: RCRLDEN3 Position     */
+#define BPWM_CAPCTL_RCRLDEN3_Msk        (0x1ul << BPWM_CAPCTL_RCRLDEN3_Pos)               /*!< BPWM_T::CAPCTL: RCRLDEN3 Mask         */
+
+#define BPWM_CAPCTL_RCRLDEN4_Pos        (20)                                              /*!< BPWM_T::CAPCTL: RCRLDEN4 Position     */
+#define BPWM_CAPCTL_RCRLDEN4_Msk        (0x1ul << BPWM_CAPCTL_RCRLDEN4_Pos)               /*!< BPWM_T::CAPCTL: RCRLDEN4 Mask         */
+
+#define BPWM_CAPCTL_RCRLDEN5_Pos        (21)                                              /*!< BPWM_T::CAPCTL: RCRLDEN5 Position     */
+#define BPWM_CAPCTL_RCRLDEN5_Msk        (0x1ul << BPWM_CAPCTL_RCRLDEN5_Pos)               /*!< BPWM_T::CAPCTL: RCRLDEN5 Mask         */
+
+#define BPWM_CAPCTL_FCRLDEN0_Pos        (24)                                              /*!< BPWM_T::CAPCTL: FCRLDEN0 Position     */
+#define BPWM_CAPCTL_FCRLDEN0_Msk        (0x1ul << BPWM_CAPCTL_FCRLDEN0_Pos)               /*!< BPWM_T::CAPCTL: FCRLDEN0 Mask         */
+
+#define BPWM_CAPCTL_FCRLDEN1_Pos        (25)                                              /*!< BPWM_T::CAPCTL: FCRLDEN1 Position     */
+#define BPWM_CAPCTL_FCRLDEN1_Msk        (0x1ul << BPWM_CAPCTL_FCRLDEN1_Pos)               /*!< BPWM_T::CAPCTL: FCRLDEN1 Mask         */
+
+#define BPWM_CAPCTL_FCRLDEN2_Pos        (26)                                              /*!< BPWM_T::CAPCTL: FCRLDEN2 Position     */
+#define BPWM_CAPCTL_FCRLDEN2_Msk        (0x1ul << BPWM_CAPCTL_FCRLDEN2_Pos)               /*!< BPWM_T::CAPCTL: FCRLDEN2 Mask         */
+
+#define BPWM_CAPCTL_FCRLDEN3_Pos        (27)                                              /*!< BPWM_T::CAPCTL: FCRLDEN3 Position     */
+#define BPWM_CAPCTL_FCRLDEN3_Msk        (0x1ul << BPWM_CAPCTL_FCRLDEN3_Pos)               /*!< BPWM_T::CAPCTL: FCRLDEN3 Mask         */
+
+#define BPWM_CAPCTL_FCRLDEN4_Pos        (28)                                              /*!< BPWM_T::CAPCTL: FCRLDEN4 Position     */
+#define BPWM_CAPCTL_FCRLDEN4_Msk        (0x1ul << BPWM_CAPCTL_FCRLDEN4_Pos)               /*!< BPWM_T::CAPCTL: FCRLDEN4 Mask         */
+
+#define BPWM_CAPCTL_FCRLDEN5_Pos        (29)                                              /*!< BPWM_T::CAPCTL: FCRLDEN5 Position     */
+#define BPWM_CAPCTL_FCRLDEN5_Msk        (0x1ul << BPWM_CAPCTL_FCRLDEN5_Pos)               /*!< BPWM_T::CAPCTL: FCRLDEN5 Mask         */
+
+#define BPWM_CAPSTS_CRIFOV0_Pos         (0)                                               /*!< BPWM_T::CAPSTS: CRIFOV0 Position      */
+#define BPWM_CAPSTS_CRIFOV0_Msk         (0x1ul << BPWM_CAPSTS_CRIFOV0_Pos)                /*!< BPWM_T::CAPSTS: CRIFOV0 Mask          */
+
+#define BPWM_CAPSTS_CRIFOV1_Pos         (1)                                               /*!< BPWM_T::CAPSTS: CRIFOV1 Position      */
+#define BPWM_CAPSTS_CRIFOV1_Msk         (0x1ul << BPWM_CAPSTS_CRIFOV1_Pos)                /*!< BPWM_T::CAPSTS: CRIFOV1 Mask          */
+
+#define BPWM_CAPSTS_CRIFOV2_Pos         (2)                                               /*!< BPWM_T::CAPSTS: CRIFOV2 Position      */
+#define BPWM_CAPSTS_CRIFOV2_Msk         (0x1ul << BPWM_CAPSTS_CRIFOV2_Pos)                /*!< BPWM_T::CAPSTS: CRIFOV2 Mask          */
+
+#define BPWM_CAPSTS_CRIFOV3_Pos         (3)                                               /*!< BPWM_T::CAPSTS: CRIFOV3 Position      */
+#define BPWM_CAPSTS_CRIFOV3_Msk         (0x1ul << BPWM_CAPSTS_CRIFOV3_Pos)                /*!< BPWM_T::CAPSTS: CRIFOV3 Mask          */
+
+#define BPWM_CAPSTS_CRIFOV4_Pos         (4)                                               /*!< BPWM_T::CAPSTS: CRIFOV4 Position      */
+#define BPWM_CAPSTS_CRIFOV4_Msk         (0x1ul << BPWM_CAPSTS_CRIFOV4_Pos)                /*!< BPWM_T::CAPSTS: CRIFOV4 Mask          */
+
+#define BPWM_CAPSTS_CRIFOV5_Pos         (5)                                               /*!< BPWM_T::CAPSTS: CRIFOV5 Position      */
+#define BPWM_CAPSTS_CRIFOV5_Msk         (0x1ul << BPWM_CAPSTS_CRIFOV5_Pos)                /*!< BPWM_T::CAPSTS: CRIFOV5 Mask          */
+
+#define BPWM_CAPSTS_CFIFOV0_Pos         (8)                                               /*!< BPWM_T::CAPSTS: CFIFOV0 Position      */
+#define BPWM_CAPSTS_CFIFOV0_Msk         (0x1ul << BPWM_CAPSTS_CFIFOV0_Pos)                /*!< BPWM_T::CAPSTS: CFIFOV0 Mask          */
+
+#define BPWM_CAPSTS_CFIFOV1_Pos         (9)                                               /*!< BPWM_T::CAPSTS: CFIFOV1 Position      */
+#define BPWM_CAPSTS_CFIFOV1_Msk         (0x1ul << BPWM_CAPSTS_CFIFOV1_Pos)                /*!< BPWM_T::CAPSTS: CFIFOV1 Mask          */
+
+#define BPWM_CAPSTS_CFIFOV2_Pos         (10)                                              /*!< BPWM_T::CAPSTS: CFIFOV2 Position      */
+#define BPWM_CAPSTS_CFIFOV2_Msk         (0x1ul << BPWM_CAPSTS_CFIFOV2_Pos)                /*!< BPWM_T::CAPSTS: CFIFOV2 Mask          */
+
+#define BPWM_CAPSTS_CFIFOV3_Pos         (11)                                              /*!< BPWM_T::CAPSTS: CFIFOV3 Position      */
+#define BPWM_CAPSTS_CFIFOV3_Msk         (0x1ul << BPWM_CAPSTS_CFIFOV3_Pos)                /*!< BPWM_T::CAPSTS: CFIFOV3 Mask          */
+
+#define BPWM_CAPSTS_CFIFOV4_Pos         (12)                                              /*!< BPWM_T::CAPSTS: CFIFOV4 Position      */
+#define BPWM_CAPSTS_CFIFOV4_Msk         (0x1ul << BPWM_CAPSTS_CFIFOV4_Pos)                /*!< BPWM_T::CAPSTS: CFIFOV4 Mask          */
+
+#define BPWM_CAPSTS_CFIFOV5_Pos         (13)                                              /*!< BPWM_T::CAPSTS: CFIFOV5 Position      */
+#define BPWM_CAPSTS_CFIFOV5_Msk         (0x1ul << BPWM_CAPSTS_CFIFOV5_Pos)                /*!< BPWM_T::CAPSTS: CFIFOV5 Mask          */
+
+#define BPWM_RCAPDAT_RCAPDAT_Pos        (0)                                               /*!< BPWM_T::RCAPDAT: RCAPDAT Position     */
+#define BPWM_RCAPDAT_RCAPDAT_Msk        (0xfffful << BPWM_RCAPDAT_RCAPDAT_Pos)            /*!< BPWM_T::RCAPDAT: RCAPDAT Mask         */
+
+#define BPWM_FCAPDAT_FCAPDAT_Pos        (0)                                               /*!< BPWM_T::FCAPDAT: FCAPDAT Position     */
+#define BPWM_FCAPDAT_FCAPDAT_Msk        (0xfffful << BPWM_FCAPDAT_FCAPDAT_Pos)            /*!< BPWM_T::FCAPDAT: FCAPDAT Mask         */
+
+#define BPWM_RCAPDAT0_RCAPDAT_Pos       (0)                                               /*!< BPWM_T::RCAPDAT0: RCAPDAT Position    */
+#define BPWM_RCAPDAT0_RCAPDAT_Msk       (0xfffful << BPWM_RCAPDAT0_RCAPDAT_Pos)           /*!< BPWM_T::RCAPDAT0: RCAPDAT Mask        */
+
+#define BPWM_FCAPDAT0_FCAPDAT_Pos       (0)                                               /*!< BPWM_T::FCAPDAT0: FCAPDAT Position    */
+#define BPWM_FCAPDAT0_FCAPDAT_Msk       (0xfffful << BPWM_FCAPDAT0_FCAPDAT_Pos)           /*!< BPWM_T::FCAPDAT0: FCAPDAT Mask        */
+
+#define BPWM_RCAPDAT1_RCAPDAT_Pos       (0)                                               /*!< BPWM_T::RCAPDAT1: RCAPDAT Position    */
+#define BPWM_RCAPDAT1_RCAPDAT_Msk       (0xfffful << BPWM_RCAPDAT1_RCAPDAT_Pos)           /*!< BPWM_T::RCAPDAT1: RCAPDAT Mask        */
+
+#define BPWM_FCAPDAT1_FCAPDAT_Pos       (0)                                               /*!< BPWM_T::FCAPDAT1: FCAPDAT Position    */
+#define BPWM_FCAPDAT1_FCAPDAT_Msk       (0xfffful << BPWM_FCAPDAT1_FCAPDAT_Pos)           /*!< BPWM_T::FCAPDAT1: FCAPDAT Mask        */
+
+#define BPWM_RCAPDAT2_RCAPDAT_Pos       (0)                                               /*!< BPWM_T::RCAPDAT2: RCAPDAT Position    */
+#define BPWM_RCAPDAT2_RCAPDAT_Msk       (0xfffful << BPWM_RCAPDAT2_RCAPDAT_Pos)           /*!< BPWM_T::RCAPDAT2: RCAPDAT Mask        */
+
+#define BPWM_FCAPDAT2_FCAPDAT_Pos       (0)                                               /*!< BPWM_T::FCAPDAT2: FCAPDAT Position    */
+#define BPWM_FCAPDAT2_FCAPDAT_Msk       (0xfffful << BPWM_FCAPDAT2_FCAPDAT_Pos)           /*!< BPWM_T::FCAPDAT2: FCAPDAT Mask        */
+
+#define BPWM_RCAPDAT3_RCAPDAT_Pos       (0)                                               /*!< BPWM_T::RCAPDAT3: RCAPDAT Position    */
+#define BPWM_RCAPDAT3_RCAPDAT_Msk       (0xfffful << BPWM_RCAPDAT3_RCAPDAT_Pos)           /*!< BPWM_T::RCAPDAT3: RCAPDAT Mask        */
+
+#define BPWM_FCAPDAT3_FCAPDAT_Pos       (0)                                               /*!< BPWM_T::FCAPDAT3: FCAPDAT Position    */
+#define BPWM_FCAPDAT3_FCAPDAT_Msk       (0xfffful << BPWM_FCAPDAT3_FCAPDAT_Pos)           /*!< BPWM_T::FCAPDAT3: FCAPDAT Mask        */
+
+#define BPWM_RCAPDAT4_RCAPDAT_Pos       (0)                                               /*!< BPWM_T::RCAPDAT4: RCAPDAT Position    */
+#define BPWM_RCAPDAT4_RCAPDAT_Msk       (0xfffful << BPWM_RCAPDAT4_RCAPDAT_Pos)           /*!< BPWM_T::RCAPDAT4: RCAPDAT Mask        */
+
+#define BPWM_FCAPDAT4_FCAPDAT_Pos       (0)                                               /*!< BPWM_T::FCAPDAT4: FCAPDAT Position    */
+#define BPWM_FCAPDAT4_FCAPDAT_Msk       (0xfffful << BPWM_FCAPDAT4_FCAPDAT_Pos)           /*!< BPWM_T::FCAPDAT4: FCAPDAT Mask        */
+
+#define BPWM_RCAPDAT5_RCAPDAT_Pos       (0)                                               /*!< BPWM_T::RCAPDAT5: RCAPDAT Position    */
+#define BPWM_RCAPDAT5_RCAPDAT_Msk       (0xfffful << BPWM_RCAPDAT5_RCAPDAT_Pos)           /*!< BPWM_T::RCAPDAT5: RCAPDAT Mask        */
+
+#define BPWM_FCAPDAT5_FCAPDAT_Pos       (0)                                               /*!< BPWM_T::FCAPDAT5: FCAPDAT Position    */
+#define BPWM_FCAPDAT5_FCAPDAT_Msk       (0xfffful << BPWM_FCAPDAT5_FCAPDAT_Pos)           /*!< BPWM_T::FCAPDAT5: FCAPDAT Mask        */
+
+#define BPWM_CAPIEN_CAPRIENn_Pos        (0)                                               /*!< BPWM_T::CAPIEN: CAPRIENn Position     */
+#define BPWM_CAPIEN_CAPRIENn_Msk        (0x3ful << BPWM_CAPIEN_CAPRIENn_Pos)              /*!< BPWM_T::CAPIEN: CAPRIENn Mask         */
+
+#define BPWM_CAPIEN_CAPFIENn_Pos        (8)                                               /*!< BPWM_T::CAPIEN: CAPFIENn Position     */
+#define BPWM_CAPIEN_CAPFIENn_Msk        (0x3ful << BPWM_CAPIEN_CAPFIENn_Pos)              /*!< BPWM_T::CAPIEN: CAPFIENn Mask         */
+
+#define BPWM_CAPIF_CAPRIF0_Pos          (0)                                               /*!< BPWM_T::CAPIF: CAPRIF0 Position       */
+#define BPWM_CAPIF_CAPRIF0_Msk          (0x1ul << BPWM_CAPIF_CAPRIF0_Pos)                 /*!< BPWM_T::CAPIF: CAPRIF0 Mask           */
+
+#define BPWM_CAPIF_CAPRIF1_Pos          (1)                                               /*!< BPWM_T::CAPIF: CAPRIF1 Position       */
+#define BPWM_CAPIF_CAPRIF1_Msk          (0x1ul << BPWM_CAPIF_CAPRIF1_Pos)                 /*!< BPWM_T::CAPIF: CAPRIF1 Mask           */
+
+#define BPWM_CAPIF_CAPRIF2_Pos          (2)                                               /*!< BPWM_T::CAPIF: CAPRIF2 Position       */
+#define BPWM_CAPIF_CAPRIF2_Msk          (0x1ul << BPWM_CAPIF_CAPRIF2_Pos)                 /*!< BPWM_T::CAPIF: CAPRIF2 Mask           */
+
+#define BPWM_CAPIF_CAPRIF3_Pos          (3)                                               /*!< BPWM_T::CAPIF: CAPRIF3 Position       */
+#define BPWM_CAPIF_CAPRIF3_Msk          (0x1ul << BPWM_CAPIF_CAPRIF3_Pos)                 /*!< BPWM_T::CAPIF: CAPRIF3 Mask           */
+
+#define BPWM_CAPIF_CAPRIF4_Pos          (4)                                               /*!< BPWM_T::CAPIF: CAPRIF4 Position       */
+#define BPWM_CAPIF_CAPRIF4_Msk          (0x1ul << BPWM_CAPIF_CAPRIF4_Pos)                 /*!< BPWM_T::CAPIF: CAPRIF4 Mask           */
+
+#define BPWM_CAPIF_CAPRIF5_Pos          (5)                                               /*!< BPWM_T::CAPIF: CAPRIF5 Position       */
+#define BPWM_CAPIF_CAPRIF5_Msk          (0x1ul << BPWM_CAPIF_CAPRIF5_Pos)                 /*!< BPWM_T::CAPIF: CAPRIF5 Mask           */
+
+#define BPWM_CAPIF_CAPFIF0_Pos          (8)                                               /*!< BPWM_T::CAPIF: CAPFIF0 Position       */
+#define BPWM_CAPIF_CAPFIF0_Msk          (0x1ul << BPWM_CAPIF_CAPFIF0_Pos)                 /*!< BPWM_T::CAPIF: CAPFIF0 Mask           */
+
+#define BPWM_CAPIF_CAPFIF1_Pos          (9)                                               /*!< BPWM_T::CAPIF: CAPFIF1 Position       */
+#define BPWM_CAPIF_CAPFIF1_Msk          (0x1ul << BPWM_CAPIF_CAPFIF1_Pos)                 /*!< BPWM_T::CAPIF: CAPFIF1 Mask           */
+
+#define BPWM_CAPIF_CAPFIF2_Pos          (10)                                              /*!< BPWM_T::CAPIF: CAPFIF2 Position       */
+#define BPWM_CAPIF_CAPFIF2_Msk          (0x1ul << BPWM_CAPIF_CAPFIF2_Pos)                 /*!< BPWM_T::CAPIF: CAPFIF2 Mask           */
+
+#define BPWM_CAPIF_CAPFIF3_Pos          (11)                                              /*!< BPWM_T::CAPIF: CAPFIF3 Position       */
+#define BPWM_CAPIF_CAPFIF3_Msk          (0x1ul << BPWM_CAPIF_CAPFIF3_Pos)                 /*!< BPWM_T::CAPIF: CAPFIF3 Mask           */
+
+#define BPWM_CAPIF_CAPFIF4_Pos          (12)                                              /*!< BPWM_T::CAPIF: CAPFIF4 Position       */
+#define BPWM_CAPIF_CAPFIF4_Msk          (0x1ul << BPWM_CAPIF_CAPFIF4_Pos)                 /*!< BPWM_T::CAPIF: CAPFIF4 Mask           */
+
+#define BPWM_CAPIF_CAPFIF5_Pos          (13)                                              /*!< BPWM_T::CAPIF: CAPFIF5 Position       */
+#define BPWM_CAPIF_CAPFIF5_Msk          (0x1ul << BPWM_CAPIF_CAPFIF5_Pos)                 /*!< BPWM_T::CAPIF: CAPFIF5 Mask           */
+
+#define BPWM_PBUF_PBUF_Pos              (0)                                               /*!< BPWM_T::PBUF: PBUF Position           */
+#define BPWM_PBUF_PBUF_Msk              (0xfffful << BPWM_PBUF_PBUF_Pos)                  /*!< BPWM_T::PBUF: PBUF Mask               */
+
+#define BPWM_CMPBUF_CMPBUF_Pos          (0)                                               /*!< BPWM_T::CMPBUF0: CMPBUF Position      */
+#define BPWM_CMPBUF_CMPBUF_Msk          (0xfffful << BPWM_CMPBUFn_CMPBUF_Pos)             /*!< BPWM_T::CMPBUF0: CMPBUF Mask          */
+
+#define BPWM_CMPBUF0_CMPBUF_Pos         (0)                                               /*!< BPWM_T::CMPBUF0: CMPBUF Position      */
+#define BPWM_CMPBUF0_CMPBUF_Msk         (0xfffful << BPWM_CMPBUF0_CMPBUF_Pos)             /*!< BPWM_T::CMPBUF0: CMPBUF Mask          */
+
+#define BPWM_CMPBUF1_CMPBUF_Pos         (0)                                               /*!< BPWM_T::CMPBUF1: CMPBUF Position      */
+#define BPWM_CMPBUF1_CMPBUF_Msk         (0xfffful << BPWM_CMPBUF1_CMPBUF_Pos)             /*!< BPWM_T::CMPBUF1: CMPBUF Mask          */
+
+#define BPWM_CMPBUF2_CMPBUF_Pos         (0)                                               /*!< BPWM_T::CMPBUF2: CMPBUF Position      */
+#define BPWM_CMPBUF2_CMPBUF_Msk         (0xfffful << BPWM_CMPBUF2_CMPBUF_Pos)             /*!< BPWM_T::CMPBUF2: CMPBUF Mask          */
+
+#define BPWM_CMPBUF3_CMPBUF_Pos         (0)                                               /*!< BPWM_T::CMPBUF3: CMPBUF Position      */
+#define BPWM_CMPBUF3_CMPBUF_Msk         (0xfffful << BPWM_CMPBUF3_CMPBUF_Pos)             /*!< BPWM_T::CMPBUF3: CMPBUF Mask          */
+
+#define BPWM_CMPBUF4_CMPBUF_Pos         (0)                                               /*!< BPWM_T::CMPBUF4: CMPBUF Position      */
+#define BPWM_CMPBUF4_CMPBUF_Msk         (0xfffful << BPWM_CMPBUF4_CMPBUF_Pos)             /*!< BPWM_T::CMPBUF4: CMPBUF Mask          */
+
+#define BPWM_CMPBUF5_CMPBUF_Pos         (0)                                               /*!< BPWM_T::CMPBUF5: CMPBUF Position      */
+#define BPWM_CMPBUF5_CMPBUF_Msk         (0xfffful << BPWM_CMPBUF5_CMPBUF_Pos)             /*!< BPWM_T::CMPBUF5: CMPBUF Mask          */
+
+/** @} BPWM_CONST */
+/** @} end of BPWM register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __BPWM_REG_H__ */

--- a/hal/m258ke/nuvoton/clk_reg.h
+++ b/hal/m258ke/nuvoton/clk_reg.h
@@ -1,0 +1,1219 @@
+/**************************************************************************//**
+ * @file     clk_reg.h
+ * @version  V1.00
+ * @brief    CLK register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __CLK_REG_H__
+#define __CLK_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup CLK System Clock Controller (CLK)
+    Memory Mapped Structure for CLK Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var CLK_T::PWRCTL
+     * Offset: 0x00  System Power-down Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |HXTEN     |HXT Enable Bit (Write Protect)
+     * |        |          |The bit default value is set by flash controller user configuration register CONFIG0 [26]
+     * |        |          |When the default clock source is from HXT, this bit is set to 1 automatically.
+     * |        |          |0 = 4~32 MHz external high speed crystal (HXT) Disabled.
+     * |        |          |1 = 4~32 MHz external high speed crystal (HXT) Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[1]     |LXTEN     |LXT Enable Bit (Write Protect)
+     * |        |          |0 = 32.768 kHz external low speed crystal (LXT) Disabled.
+     * |        |          |1 = 32.768 kHz external low speed crystal (LXT) Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[2]     |HIRCEN    |HIRC Enable Bit (Write Protect)
+     * |        |          |0 = 48MHz internal high speed RC oscillator (HIRC) Disabled.
+     * |        |          |1 = 48 MHz internal high speed RC oscillator (HIRC) Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[3]     |LIRCEN    |LIRC Enable Bit (Write Protect)
+     * |        |          |0 = 38.4 kHz internal low speed RC oscillator (LIRC) Disabled.
+     * |        |          |1 = 38.4 kHz internal low speed RC oscillator (LIRC) Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note : LIRC will also be forced on when 1
+     * |        |          |Power down and ~(cfg0[3] & cfg0[4] & ~cfg0[31] & cfg0[30]) 2
+     * |        |          |Not power down and ~(cfg0[3] & cfg0[4] & cfg0[31])
+     * |[4]     |PDWKDLY   |Enable the Wake-up Delay Counter (Write Protect)
+     * |        |          |When the chip wakes up from Power-down mode, the clock control will delay certain clock cycles to wait system clock stable.
+     * |        |          |The delayed clock cycle is 4096 clock cycles when chip works at 4~32 MHz external high speed crystal oscillator (HXT), HIRC and MIRC see HIRCSTBS and MIRCSTBS
+     * |        |          |0 = Clock cycles delay Disabled.
+     * |        |          |1 = Clock cycles delay Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[5]     |PDWKIEN   |Power-down Mode Wake-up Interrupt Enable Bit (Write Protect)
+     * |        |          |0 = Power-down mode wake-up interrupt Disabled.
+     * |        |          |1 = Power-down mode wake-up interrupt Enabled.
+     * |        |          |Note1: The interrupt will occur when both PDWKIF and PDWKIEN are high.
+     * |        |          |Note2: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[6]     |PDWKIF    |Power-down Mode Wake-up Interrupt Status
+     * |        |          |Set by "Power-down wake-up event", it indicates that resume from Power-down mode.
+     * |        |          |The flag is set if any wake-up source is occurred. Refer Power Modes and Wake-up Sources chapter.
+     * |        |          |Note1: Write 1 to clear the bit to 0.
+     * |        |          |Note2: This bit works only if PDWKIEN (CLK_PWRCTL[5]) set to 1.
+     * |[7]     |PDEN      |System Power-down Enable (Write Protect)
+     * |        |          |When this bit is set to 1, Power-down mode is enabled and chip Power-down behavior will depend on the PDWTCPU bit.
+     * |        |          |(a) If the PDWTCPU is 0, then the chip enters Power-down mode immediately after the PDEN bit set
+     * |        |          |(default)
+     * |        |          |(b) if the PDWTCPU is 1, then the chip keeps active till the CPU sleep mode is also active and then the chip enters Power-down mode.
+     * |        |          |When chip wakes up from Power-down mode, this bit is auto cleared
+     * |        |          |Users need to set this bit again for next Power-down.
+     * |        |          |In Power-down mode, HXT and the HIRC will be disabled in this mode, but LXT and LIRC are not controlled by Power-down mode.
+     * |        |          |In Power-down mode, the PLL and system clock are disabled, and ignored the clock source selection
+     * |        |          |The clocks of peripheral are not controlled by Power-down mode, if the peripheral clock source is from LXT or LIRC.
+     * |        |          |0 = Chip operating normally or chip in idle mode because of WFI command.
+     * |        |          |1 = Chip enters Power-down mode instant or wait CPU sleep command WFI.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[19]    |MIRCEN    |MIRC Enable Bit (Write Protect)
+     * |        |          |0 = 4MHz internal high speed RC oscillator (MIRC) Disabled.
+     * |        |          |1 = 4 MHz internal high speed RC oscillator (MIRC) Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note: Will be forced on when CLKSEL0[2:0] = 0x101b.
+     * |[22:20] |HXTGAIN   |HXT Gain Control Bit (Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |Gain control is used to enlarge the gain of crystal to make sure crystal work normally
+     * |        |          |If gain control is enabled, crystal will consume more power than gain control off.
+     * |        |          |000 = HXT frequency 1~4 MHz.
+     * |        |          |001 = HXT frequency  4~8 MHz.
+     * |        |          |010 = HXT frequency  8~12 MHz.
+     * |        |          |011 = HXT frequency 12~16 MHz.
+     * |        |          |100 = HXT frequency 12~24 MHz.
+     * |        |          |101 = HXT frequency 16~32 MHz.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note : reset by power on reset
+     * @var CLK_T::AHBCLK
+     * Offset: 0x04  AHB Devices Clock Enable Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |PDMACKEN  |PDMA Controller Clock Enable Bit
+     * |        |          |0 = PDMA peripheral clock Disabled.
+     * |        |          |1 = PDMA peripheral clock Enabled.
+     * |[2]     |ISPCKEN   |Flash ISP Controller Clock Enable Bit
+     * |        |          |0 = Flash ISP peripheral clock Disabled.
+     * |        |          |1 = Flash ISP peripheral clock Enabled.
+     * |[3]     |EBICKEN   |EBI Controller Clock Enable Bit
+     * |        |          |0 = EBI peripheral clock Disabled.
+     * |        |          |1 = EBI peripheral clock Enabled.
+     * |[4]     |EXSTCKEN  |External System Tick Clock Enable Bit
+     * |        |          |0 = External System tick clock Disabled.
+     * |        |          |1 = External System tick clock Enabled.
+     * |[7]     |CRCCKEN   |CRC Generator Controller Clock Enable Bit
+     * |        |          |0 = CRC peripheral clock Disabled.
+     * |        |          |1 = CRC peripheral clock Enabled.
+     * |[12]    |CRPTCKEN  |Cryptographic Accelerator Clock Enable Bit
+     * |        |          |0 = Cryptographic Accelerator clock Disabled.
+     * |        |          |1 = Cryptographic Accelerator clock Enabled.
+     * |[15]    |FMCIDLE   |Flash Memory Controller Clock Enable Bit in IDLE Mode
+     * |        |          |0 = FMC clock Disabled when chip is under IDLE mode.
+     * |        |          |1 = FMC clock Enabled when chip is under IDLE mode.
+     * |[24]    |GPACKEN   |GPIOA Clock Enable Bit
+     * |        |          |0 = GPIOA port clock Disabled.
+     * |        |          |1 = GPIOA port clock Enabled.
+     * |[25]    |GPBCKEN   |GPIOB Clock Enable Bit
+     * |        |          |0 = GPIOB port clock Disabled.
+     * |        |          |1 = GPIOB port clock Enabled.
+     * |[26]    |GPCCKEN   |GPIOC Clock Enable Bit
+     * |        |          |0 = GPIOC port clock Disabled.
+     * |        |          |1 = GPIOC port clock Enabled.
+     * |[27]    |GPDCKEN   |GPIOD Clock Enable Bit
+     * |        |          |0 = GPIOD port clock Disabled.
+     * |        |          |1 = GPIOD port clock Enabled.
+     * |[28]    |GPECKEN   |GPIOE Clock Enable Bit
+     * |        |          |0 = GPIOE port clock Disabled.
+     * |        |          |1 = GPIOE port clock Enabled.
+     * |[29]    |GPFCKEN   |GPIOF Clock Enable Bit
+     * |        |          |0 = GPIOF port clock Disabled.
+     * |        |          |1 = GPIOF port clock Enabled.
+     * @var CLK_T::APBCLK0
+     * Offset: 0x08  APB Devices Clock Enable Control Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WDTCKEN   |Watchdog Timer Clock Enable Bit (Write Protect)
+     * |        |          |0 = Watchdog timer clock Disabled.
+     * |        |          |1 = Watchdog timer clock Enabled.
+     * |        |          |Note 1: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note 2: This bit is forced to 1 when CONFIG0[3] or CONFIG0[4] or CONFIG0[31] is 0.
+     * |        |          |Note 3: Reset by power on reset or watch dog reset or software chip reset.
+     * |[1]     |RTCCKEN   |Real-time-clock APB Interface Clock Enable Bit
+     * |        |          |0 = RTC APB clock Disabled.
+     * |        |          |1 = RTC APB clock Enabled.
+     * |[2]     |TMR0CKEN  |Timer0 Clock Enable Bit
+     * |        |          |0 = Timer0 clock Disabled.
+     * |        |          |1 = Timer0 clock Enabled.
+     * |[3]     |TMR1CKEN  |Timer1 Clock Enable Bit
+     * |        |          |0 = Timer1 clock Disabled.
+     * |        |          |1 = Timer1 clock Enabled.
+     * |[4]     |TMR2CKEN  |Timer2 Clock Enable Bit
+     * |        |          |0 = Timer2 clock Disabled.
+     * |        |          |1 = Timer2 clock Enabled.
+     * |[5]     |TMR3CKEN  |Timer3 Clock Enable Bit
+     * |        |          |0 = Timer3 clock Disabled.
+     * |        |          |1 = Timer3 clock Enabled.
+     * |[6]     |CLKOCKEN  |CLKO Clock Enable Bit
+     * |        |          |0 = CLKO clock Disabled.
+     * |        |          |1 = CLKO clock Enabled.
+     * |[7]     |ACMP01CKEN|Analog Comparator 0/1 Clock Enable Bit
+     * |        |          |0 = Analog comparator 0/1 clock Disabled.
+     * |        |          |1 = Analog comparator 0/1 clock Enabled.
+     * |[8]     |I2C0CKEN  |I2C0 Clock Enable Bit
+     * |        |          |0 = I2C0 clock Disabled.
+     * |        |          |1 = I2C0 clock Enabled.
+     * |[9]     |I2C1CKEN  |I2C1 Clock Enable Bit
+     * |        |          |0 = I2C1 clock Disabled.
+     * |        |          |1 = I2C1 clock Enabled.
+     * |[12]    |QSPI0CKEN |QSPI0 Clock Enable Bit
+     * |        |          |0 = QSPI0 clock Disabled.
+     * |        |          |1 = QSPI0 clock Enabled.
+     * |[13]    |SPI0CKEN  |SPI0 Clock Enable Bit
+     * |        |          |0 = SPI0 clock Disabled.
+     * |        |          |1 = SPI0 clock Enabled.
+     * |[16]    |UART0CKEN |UART0 Clock Enable Bit
+     * |        |          |0 = UART0 clock Disabled.
+     * |        |          |1 = UART0 clock Enabled.
+     * |[17]    |UART1CKEN |UART1 Clock Enable Bit
+     * |        |          |0 = UART1 clock Disabled.
+     * |        |          |1 = UART1 clock Enabled.
+     * |[18]    |UART2CKEN |UART2 Clock Enable Bit
+     * |        |          |0 = UART2 clock Disabled.
+     * |        |          |1 = UART2 clock Enabled.
+     * |[27]    |USBDCKEN  |USB Device Clock Enable Bit
+     * |        |          |0 = USB Device clock Disabled.
+     * |        |          |1 = USB Device clock Enabled.
+     * |[28]    |EADCCKEN  |Enhanced Analog-digital-converter (EADC) Clock Enable Bit
+     * |        |          |0 = EADC clock Disabled.
+     * |        |          |1 = EADC clock Enabled.
+     * @var CLK_T::APBCLK1
+     * Offset: 0x0C  APB Devices Clock Enable Control Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SC0CKEN   |SC0 Clock Enable Bit
+     * |        |          |0 = SC0 clock Disabled.
+     * |        |          |1 = SC0 clock Enabled.
+     * |[8]     |USCI0CKEN |USCI0 Clock Enable Bit
+     * |        |          |0 = USCI0 clock Disabled.
+     * |        |          |1 = USCI0 clock Enabled.
+     * |[9]     |USCI1CKEN |USCI1 Clock Enable Bit
+     * |        |          |0 = USCI1 clock Disabled.
+     * |        |          |1 = USCI1 clock Enabled.
+     * |[10]    |USCI2CKEN |USCI2 Clock Enable Bit
+     * |        |          |0 = USCI1 clock Disabled.
+     * |        |          |1 = USCI1 clock Enabled.
+     * |[12]    |DACCKEN   |DAC Clock Enable Bit
+     * |        |          |0 = DAC clock Disabled.
+     * |        |          |1 = DAC clock Enabled.
+     * |[16]    |PWM0CKEN  |PWM0 Clock Enable Bit
+     * |        |          |0 = PWM0 clock Disabled.
+     * |        |          |1 = PWM0 clock Enabled.
+     * |[17]    |PWM1CKEN  |PWM1 Clock Enable Bit
+     * |        |          |0 = PWM1 clock Disabled.
+     * |        |          |1 = PWM1 clock Enabled.
+     * |[18]    |BPWM0CKEN |BPWM0 Clock Enable Bit
+     * |        |          |0 = BPWM0 clock Disabled.
+     * |        |          |1 = BPWM0 clock Enabled.
+     * |[19]    |BPWM1CKEN |BPWM1 Clock Enable Bit
+     * |        |          |0 = BPWM1 clock Disabled.
+     * |        |          |1 = BPWM1 clock Enabled.
+     * |[30]    |OPACKEN   |OP Amplifier (OPA) Clock Enable Bit
+     * |        |          |0 = OPA clock Disabled.
+     * |        |          |1 = OPA clock Enabled.
+     * |[31]    |PSIOCKEN  |PSIO Clock Enable Bit
+     * |        |          |0 = PSIO clock Disabled.
+     * |        |          |1 = PSIO clock Enabled.
+     * @var CLK_T::CLKSEL0
+     * Offset: 0x10  Clock Source Select Control Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |HCLKSEL   |HCLK Clock Source Selection (Write Protect)
+     * |        |          |Before clock switching, the related clock sources (both pre-select and new-select) must be turned on.
+     * |        |          |The default value is reloaded from the value of CFOSC (CONFIG0[26]) in user configuration register of Flash controller by any reset
+     * |        |          |Therefore the default value is either 000b or 101b.
+     * |        |          |000 = Clock source from HXT.
+     * |        |          |001 = Clock source from LXT.
+     * |        |          |010 = Clock source from PLL.
+     * |        |          |011 = Clock source from LIRC.
+     * |        |          |101= Clock source from MIRC.
+     * |        |          |111= Clock source from HIRC.
+     * |        |          |Other = Reserved.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[5:3]   |STCLKSEL  |Cortex-M23 SysTick Clock Source Selection (Write Protect)
+     * |        |          |If SYST_CTRL[2]=0, SysTick uses listed clock source below.
+     * |        |          |000 = Clock source from HXT.
+     * |        |          |001 = Clock source from LXT.
+     * |        |          |010 = Clock source from HXT/2.
+     * |        |          |011 = Clock source from HCLK/2.
+     * |        |          |111 = Clock source from HIRC/2.
+     * |        |          |Note: if SysTick clock source is not from HCLK (i.e
+     * |        |          |SYST_CTRL[2] = 0), SysTick clock source must less than or equal to HCLK/2.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[8]     |USBDSEL   |USB Device Clock Source Selection (Write Protect)
+     * |        |          |These bits are protected bit
+     * |        |          |It means programming this bit needs to write "59h", "16h", "88h" to address 0x4000_0100 to disable register protection
+     * |        |          |Refer to the register REGWRPROT at address GCR_BA+0x100.
+     * |        |          |0 = Clock source from HIRC.
+     * |        |          |1 = Clock source from PLL. divided
+     * @var CLK_T::CLKSEL1
+     * Offset: 0x14  Clock Source Select Control Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |WDTSEL    |Watchdog Timer Clock Source Selection (Write Protect)
+     * |        |          |00 = Reserved.
+     * |        |          |01 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |10 = Clock source from HCLK/2048.
+     * |        |          |11 = Clock source from 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |Note: This bit is write protected.Refer to the SYS_REGLCTL register
+     * |        |          |Note: This bit is forced to 11 when CONFIG0[31], CONFIG0[4], CONFIG0[3] are all ones.
+     * |[3:2]   |WWDTSEL   |Window Watchdog Timer Clock Source Selection (Write Protect)
+     * |        |          |10 = Clock source from HCLK/2048.
+     * |        |          |11 = Clock source from 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |Others = Reserved.
+     * |[6:4]   |CLKOSEL   |Clock Divider Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |010 = Clock source from HCLK.
+     * |        |          |011 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |100 = Clock source from 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |101 = Clock source from 4 MHz internal medium speed RC oscillator (MIRC).
+     * |        |          |110 = Clock source from PLL.
+     * |        |          |111 = Clock source from internal USB synchronous mode.
+     * |[10:8]  |TMR0SEL   |TIMER0 Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |010 = Clock source from PCLK0.
+     * |        |          |011 = Clock source from external clock T0 pin.
+     * |        |          |101 = Clock source from 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |111 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |Others = Reserved.
+     * |[14:12] |TMR1SEL   |TIMER1 Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |010 = Clock source from PCLK0.
+     * |        |          |011 = Clock source from external clock T1 pin.
+     * |        |          |101 = Clock source from 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |111 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |Others = Reserved.
+     * |[18:16] |TMR2SEL   |TIMER2 Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |010 = Clock source from PCLK1.
+     * |        |          |011 = Clock source from external clock T2 pin.
+     * |        |          |101 = Clock source from 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |111 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |Others = Reserved.
+     * |[22:20] |TMR3SEL   |TIMER3 Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |010 = Clock source from PCLK1.
+     * |        |          |011 = Clock source from external clock T3 pin.
+     * |        |          |101 = Clock source from 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |111 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |Others = Reserved.
+     * |[26:24] |UART0SEL  |UART0 Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from PLL.
+     * |        |          |010 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |011 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |100= PCLK0-> default.
+     * |        |          |101= LIRC
+     * |[30:28] |UART1SEL  |UART1 Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from PLL.
+     * |        |          |010 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |011 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |100= PCLK1 -> default.
+     * |        |          |101= LIRC
+     * @var CLK_T::CLKSEL2
+     * Offset: 0x18  Clock Source Select Control Register 2
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PWM0SEL   |PWM0 Clock Source Selection
+     * |        |          |The peripheral clock source of PWM0 is defined by PWM0SEL.
+     * |        |          |0 = Clock source from PLL.
+     * |        |          |1 = Clock source from PCLK0.
+     * |[1]     |PWM1SEL   |PWM1 Clock Source Selection
+     * |        |          |The peripheral clock source of PWM1 is defined by PWM1SEL.
+     * |        |          |0 = Clock source from PLL.
+     * |        |          |1 = Clock source from PCLK1.
+     * |[3:2]   |QSPI0SEL  |QSPI0 Clock Source Selection
+     * |        |          |00 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |01 = Clock source from PLL.
+     * |        |          |10 = Clock source from PCLK0.
+     * |        |          |11 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |[5:4]   |SPI0SEL   |SPI0 Clock Source Selection
+     * |        |          |00 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |01 = Clock source from PLL.
+     * |        |          |10 = Clock source from PCLK1.
+     * |        |          |11 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |[8]     |BPWM0SEL  |BPWM0 Clock Source Selection
+     * |        |          |The peripheral clock source of BPWM0 is defined by BPWM0SEL.
+     * |        |          |0 = Clock source from PLL.
+     * |        |          |1 = Clock source from PCLK0.
+     * |[9]     |BPWM1SEL  |BPWM1 Clock Source Selection
+     * |        |          |The peripheral clock source of BPWM1 is defined by BPWM1SEL.
+     * |        |          |0 = Clock source from PLL.
+     * |        |          |1 = Clock source from PCLK1.
+     * |[30:28] |PSIOSEL   |PSIO Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |010 = Clock source from PCLK1.
+     * |        |          |011 = Clock source from PLL.
+     * |        |          |100 = Clock source from 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |111 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |Others = Reserved.
+     * @var CLK_T::CLKSEL3
+     * Offset: 0x1C  Clock Source Select Control Register 3
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |SC0SEL    |SC0 Clock Source Selection
+     * |        |          |00 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |01 = Clock source from PLL.
+     * |        |          |10 = Clock source from PCLK0.
+     * |        |          |11 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |[26:24] |UART2SEL  |UART2 Clock Source Selection
+     * |        |          |000 = Clock source from 4~32 MHz external high speed crystal oscillator (HXT).
+     * |        |          |001 = Clock source from PLL.
+     * |        |          |010 = Reserved.
+     * |        |          |010 = Clock source from 32.768 kHz external low speed crystal oscillator (LXT).
+     * |        |          |011 = Clock source from 48 MHz internal high speed RC oscillator (HIRC).
+     * |        |          |100= PCLK 0-> default.
+     * |        |          |101= LIRC
+     * @var CLK_T::CLKDIV0
+     * Offset: 0x20  Clock Divider Number Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |HCLKDIV   |HCLK Clock Divide Number From HCLK Clock Source
+     * |        |          |HCLK clock frequency = (HCLK clock source frequency) / (HCLKDIV + 1).
+     * |[7:4]   |USBDIV    |USB Clock Divide Number From PLL Clock
+     * |        |          |USB clock frequency = (PLL frequency) / (USBDIV + 1).
+     * |[11:8]  |UART0DIV  |UART0 Clock Divide Number From UART0 Clock Source
+     * |        |          |UART0 clock frequency = (UART0 clock source frequency) / (UART0DIV + 1).
+     * |[15:12] |UART1DIV  |UART1 Clock Divide Number From UART1 Clock Source
+     * |        |          |UART1 clock frequency = (UART1 clock source frequency) / (UART1DIV + 1).
+     * |[23:16] |EADCDIV   |EADC Clock Divide Number From EADC Clock Source
+     * |        |          |EADC clock frequency = (EADC clock source frequency) / (EADCDIV + 1).
+     * @var CLK_T::CLKDIV1
+     * Offset: 0x24  Clock Divider Number Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |SC0DIV    |SC0 Clock Divide Number From SC0 Clock Source
+     * |        |          |SC0 clock frequency = (SC0 clock source frequency ) / (SC0DIV + 1).
+     * |[31:24] |PSIODIV   |PSIO Clock Divide Number From PSIO Clock Source
+     * |        |          |PSIO clock frequency = (PSIO clock source frequency ) / (PSIODIV + 1).
+     * @var CLK_T::CLKDIV4
+     * Offset: 0x30  Clock Divider Number Register 4
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |UART2DIV  |UART2 Clock Divide Number From UART2 Clock Source
+     * |        |          |UART2 clock frequency = (UART2 clock source frequency) / (UART2DIV + 1).
+     * @var CLK_T::PCLKDIV
+     * Offset: 0x34  APB Clock Divider Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |APB0DIV   |APB0 Clock DIvider
+     * |        |          |APB0 clock can be divided from HCLK
+     * |        |          |000: PCLK0 = HCLK.
+     * |        |          |001: PCLK0 = 1/2 HCLK.
+     * |        |          |010: PCLK0 = 1/4 HCLK.
+     * |        |          |011: PCLK0 = 1/8 HCLK.
+     * |        |          |100: PCLK0 = 1/16 HCLK.
+     * |        |          |101: PCLK0 = 1/32 HCLK.
+     * |        |          |Others: Reserved.
+     * |[6:4]   |APB1DIV   |APB1 Clock DIvider
+     * |        |          |APB1 clock can be divided from HCLK
+     * |        |          |000: PCLK1 = HCLK.
+     * |        |          |001: PCLK1 = 1/2 HCLK.
+     * |        |          |010: PCLK1 = 1/4 HCLK.
+     * |        |          |011: PCLK1 = 1/8 HCLK.
+     * |        |          |100: PCLK1 = 1/16 HCLK.
+     * |        |          |101: PCLK1 = 1/32 HCLK.
+     * |        |          |Others: Reserved.
+     * @var CLK_T::PLLCTL
+     * Offset: 0x40  PLL Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[5:0]   |FBDIV     |PLL Feedback Divider Control (Write Protect)
+     * |        |          |Refer to the formulas below the table.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[12:9]  |INDIV     |PLL Input Divider Control (Write Protect)
+     * |        |          |Refer to the formulas below the table.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[15:14] |OUTDIV    |PLL Output Divider Control (Write Protect)
+     * |        |          |Refer to the formulas below the table.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[16]    |PD        |Power-down Mode (Write Protect)
+     * |        |          |If set the PDEN bit to 1 in CLK_PWRCTL register, the PLL will enter Power-down mode, too.
+     * |        |          |0 = PLL is in normal mode.
+     * |        |          |1 = PLL is in Power-down mode (default).
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[17]    |BP        |PLL Bypass Control (Write Protect)
+     * |        |          |0 = PLL is in normal mode (default).
+     * |        |          |1 = PLL clock output is same as PLL input clock FIN.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[18]    |OE        |PLL OE (FOUT Enable) Pin Control (Write Protect)
+     * |        |          |0 = PLL FOUT Enabled.
+     * |        |          |1 = PLL FOUT is fixed low.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[20:19] |PLLSRC    |PLL Source Clock Selection (Write Protect)
+     * |        |          |00 = PLL source clock from 4~32 MHz external high-speed crystal oscillator (HXT).
+     * |        |          |01 = PLL source clock from 12 MHz internal high-speed oscillator (HIRC/4).
+     * |        |          |10 = PLL source clock from 4~32 MHz external high-speed crystal oscillator (HXT).
+     * |        |          |11 = PLL source clock from 4 MHz internal high-speed oscillator (MIRC).
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note: MIRC and HIRC have to be both on when source switch between them
+     * |[23]    |STBSEL    |PLL Stable Counter Selection (Write Protect)
+     * |        |          |0 = PLL stable time is 1200 PLL source clock (suitable for source clock is equal to or less than 12 MHz).
+     * |        |          |1 = PLL stable time is 2400 PLL source clock (suitable for source clock is larger than 12 MHz).
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[24]    |PLL_CLF_EN|1: PLL Clock Filter On
+     * |        |          |0 : OFF
+     * @var CLK_T::STATUS
+     * Offset: 0x50  Clock Status Monitor Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |HXTSTB    |HXT Clock Source Stable Flag (Read Only)
+     * |        |          |0 = 4~32 MHz external high speed crystal oscillator (HXT) clock is not stable or disabled.
+     * |        |          |1 = 4~32 MHz external high speed crystal oscillator (HXT) clock is stable and enabled.
+     * |[1]     |LXTSTB    |LXT Clock Source Stable Flag (Read Only)
+     * |        |          |0 = 32.768 kHz external low speed crystal oscillator (LXT) clock is not stable or disabled.
+     * |        |          |1 = 32.768 kHz external low speed crystal oscillator (LXT) clock is stabled and enabled.
+     * |[2]     |PLLSTB    |Internal PLL Clock Source Stable Flag (Read Only)
+     * |        |          |0 = Internal PLL clock is not stable or disabled.
+     * |        |          |1 = Internal PLL clock is stable and enabled.
+     * |[3]     |LIRCSTB   |LIRC Clock Source Stable Flag (Read Only)
+     * |        |          |0 = 38.4 kHz internal low speed RC oscillator (LIRC) clock is not stable or disabled.
+     * |        |          |1 = 38.4 kHz internal low speed RC oscillator (LIRC) clock is stable and enabled.
+     * |[4]     |HIRCSTB   |HIRC Clock Source Stable Flag (Read Only)
+     * |        |          |0 = 48 MHz internal high speed RC oscillator (HIRC) clock is not stable or disabled.
+     * |        |          |1 = 48 MHz internal high speed RC oscillator (HIRC) clock is stable and enabled.
+     * |[6]     |MIRCSTB   |MIRC Clock Source Stable Flag (Read Only)
+     * |        |          |0 = 4 MHz internal mid speed RC oscillator (MIRC) clock is not stable or disabled.
+     * |        |          |1 = 4 MHz internal mid speed RC oscillator (MIRC) clock is stable and enabled.
+     * |[7]     |CLKSFAIL  |Clock Switching Fail Flag (Read Only)
+     * |        |          |This bit is updated when software switches system clock source
+     * |        |          |If switch target clock is stable, this bit will be set to 0
+     * |        |          |If switch target clock is not stable, this bit will be set to 1.
+     * |        |          |0 = Clock switching success.
+     * |        |          |1 = Clock switching failure.
+     * |        |          |Note: Write 1 to clear the bit to 0.
+     * @var CLK_T::CLKOCTL
+     * Offset: 0x60  Clock Output Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |FREQSEL   |Clock Output Frequency Selection
+     * |        |          |The formula of output frequency is
+     * |        |          |Fout = Fin/2(N+1).
+     * |        |          |Fin is the input clock frequency.
+     * |        |          |Fout is the frequency of divider output clock.
+     * |        |          |N is the 4-bit value of FREQSEL[3:0].
+     * |[4]     |CLKOEN    |Clock Output Enable Bit
+     * |        |          |0 = Clock Output function Disabled.
+     * |        |          |1 = Clock Output function Enabled.
+     * |[5]     |DIV1EN    |Clock Output Divide One Enable Bit
+     * |        |          |0 = Clock Output will output clock with source frequency divided by FREQSEL.
+     * |        |          |1 = Clock Output will output clock with source frequency.
+     * |[6]     |CLK1HZEN  |Clock Output 1Hz Enable Bit
+     * |        |          |0 = 1 Hz clock output for 32.768 kHz frequency compensation Disabled.
+     * |        |          |1 = 1 Hz clock output for 32.768 kHz frequency compensation Enabled.
+     * @var CLK_T::CLKDCTL
+     * Offset: 0x70  Clock Fail Detector Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[4]     |HXTFDEN   |HXT Clock Fail Detector Enable Bit
+     * |        |          |0 = 4~32 MHz external high speed crystal oscillator (HXT) clock fail detector Disabled.
+     * |        |          |1 = 4~32 MHz external high speed crystal oscillator (HXT) clock fail detector Enabled.
+     * |[5]     |HXTFIEN   |HXT Clock Fail Interrupt Enable Bit
+     * |        |          |0 = 4~32 MHz external high speed crystal oscillator (HXT) clock fail interrupt Disabled.
+     * |        |          |1 = 4~32 MHz external high speed crystal oscillator (HXT) clock fail interrupt Enabled.
+     * |[12]    |LXTFDEN   |LXT Clock Fail Detector Enable Bit
+     * |        |          |0 = 32.768 kHz external low speed crystal oscillator (LXT) clock fail detector Disabled.
+     * |        |          |1 = 32.768 kHz external low speed crystal oscillator (LXT) clock fail detector Enabled.
+     * |[13]    |LXTFIEN   |LXT Clock Fail Interrupt Enable Bit
+     * |        |          |0 = 32.768 kHz external low speed crystal oscillator (LXT) clock fail interrupt Disabled.
+     * |        |          |1 = 32.768 kHz external low speed crystal oscillator (LXT) clock fail interrupt Enabled.
+     * |[16]    |HXTFQDEN  |HXT Clock Frequency Range Detector Enable Bit
+     * |        |          |0 = 4~32 MHz external high speed crystal oscillator (HXT) clock frequency range detector Disabled.
+     * |        |          |1 = 4~32 MHz external high speed crystal oscillator (HXT) clock frequency range detector Enabled.
+     * |[17]    |HXTFQIEN  |HXT Clock Frequency Range Detector Interrupt Enable Bit
+     * |        |          |0 = 4~32 MHz external high speed crystal oscillator (HXT) clock frequency range detector fail interrupt Disabled.
+     * |        |          |1 = 4~32 MHz external high speed crystal oscillator (HXT) clock frequency range detector fail interrupt Enabled.
+     * @var CLK_T::CLKDSTS
+     * Offset: 0x74  Clock Fail Detector Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |HXTFIF    |HXT Clock Fail Interrupt Flag (Write Protect)
+     * |        |          |0 = 4~32 MHz external high speed crystal oscillator (HXT) clock is normal.
+     * |        |          |1 = 4~32 MHz external high speed crystal oscillator (HXT) clock stops.
+     * |        |          |Note: Write 1 to clear the bit to 0.
+     * |[1]     |LXTFIF    |LXT Clock Fail Interrupt Flag (Write Protect)
+     * |        |          |0 = 32.768 kHz external low speed crystal oscillator (LXT) clock is normal.
+     * |        |          |1 = 32.768 kHz external low speed crystal oscillator (LXT) stops.
+     * |        |          |Note: Write 1 to clear the bit to 0.
+     * |[8]     |HXTFQIF   |HXT Clock Frequency Range Detector Interrupt Flag (Write Protect)
+     * |        |          |0 = 4~32 MHz external high speed crystal oscillator (HXT) clock frequency is normal.
+     * |        |          |1 = 4~32 MHz external high speed crystal oscillator (HXT) clock frequency is abnormal.
+     * |        |          |Note: Write 1 to clear the bit to 0.
+     * @var CLK_T::CDUPB
+     * Offset: 0x78  Clock Frequency Range Detector Upper Boundary Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9:0]   |UPERBD    |HXT Clock Frequency Range Detector Upper Boundary Value
+     * |        |          |The bits define the maximum value of frequency range detector window.
+     * |        |          |When HXT frequency higher than this maximum frequency value, the HXT Clock Frequency Range Detector Interrupt Flag will set to 1.
+     * @var CLK_T::CDLOWB
+     * Offset: 0x7C  Clock Frequency Range Detector Lower Boundary Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9:0]   |LOWERBD   |HXT Clock Frequency Range Detector Lower Boundary Value
+     * |        |          |The bits define the minimum value of frequency range detector window.
+     * |        |          |When HXT frequency lower than this minimum frequency value, the HXT Clock Frequency Range Detector Interrupt Flag will set to 1.
+     * @var CLK_T::PMUCTL
+     * Offset: 0x90  Power Manager Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |PDMSEL    |Power-down Mode Selection (Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |These bits control chip power-down mode grade selection when CPU execute WFI/WFE instruction.
+     * |        |          |000 = Power-down mode is selected. (PD)
+     * |        |          |010 = fast wake up.(FWPD)
+     * |        |          |110 = Deep Power-down mode is selected (DPD).
+     * |        |          |others = Reserved.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[8]     |WKTMREN   |Wake-up Timer Enable (Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |0 = Wake-up timer disable at DPD mode.
+     * |        |          |1 = Wake-up timer enabled at DPD mode.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[11:9]  |WKTMRIS   |Wake-up Timer Time-out Interval Select (Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |These bits control wake-up timer time-out interval when chip at DPD mode.
+     * |        |          |000 = Time-out interval is 128 OSC32K clocks (~3.368 ms).
+     * |        |          |001 = Time-out interval is 256 OSC32K clocks (~6.736 ms).
+     * |        |          |010 = Time-out interval is 512 OSC32K clocks (~13.47 ms).
+     * |        |          |011 = Time-out interval is 1024 OSC32K clocks (~26.95 ms).
+     * |        |          |100 = Time-out interval is 4096 OSC32K clocks (~107.79 ms).
+     * |        |          |101 = Time-out interval is 8192 OSC32K clocks (~215.58 ms).
+     * |        |          |110 = Time-out interval is 16384 OSC32K clocks (~431.16 ms).
+     * |        |          |111 = Time-out interval is 32768 OSC32K clocks (~862.32 ms).
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[17:16] |WKPINEN0  |Wake-up Pin Enable 0(Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |This is control register for GPC.0 to wake-up pin.
+     * |        |          |00 = Wake-up pin disable at Deep Power-down mode.
+     * |        |          |01 = Wake-up pin rising edge enabled at Deep Power-down mode.
+     * |        |          |10 = Wake-up pin falling edge enabled at Deep Power-down mode.
+     * |        |          |11 = Wake-up pin both edge enabled at Deep Power-down mode.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[22]    |WKPINDBEN |Wake-up pin De-bounce Enable Bit (Write Protect)
+     * |        |          |The WKPINDBEN bit is used to enable the de-bounce function for wake-up pin.
+     * |        |          |If the input signal pulse width cannot be sampled by continuous eight de-bounce sample cycle,
+     * |        |          |the input signal transition is seen as the signal bounce and will not trigger the wakeup.
+     * |        |          |The de-bounce clock source is the 38 kHz internal low speed RC oscillator (LIRC).
+     * |        |          |0 = Deep power-down wake-up pin De-bounce function disable.
+     * |        |          |1 = Deep power-down wake-up pin De-bounce function enable.
+     * |        |          |The de-bounce function is valid only for edge triggered
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[23]    |RTCWKEN   |RTC Wake-up Enable (Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |0 = RTC wake-up disable at Deep Power-down mode or Standby Power-down mode.
+     * |        |          |1 = RTC wake-up enabled at Deep Power-down mode or Standby Power-down mode.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[25:24] |WKPINEN1  |Wake-up Pin Enable 1(Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |This is control register for GPB.0 to wake-up pin.
+     * |        |          |00 = Wake-up pin disable at Deep Power-down mode.
+     * |        |          |01 = Wake-up pin rising edge enabled at Deep Power-down mode.
+     * |        |          |10 = Wake-up pin falling edge enabled at Deep Power-down mode.
+     * |        |          |11 = Wake-up pin both edge enabled at Deep Power-down mode.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register
+     * |[27:26] |WKPINEN2  |Wake-up Pin Enable 2(Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |This is control register for GPB.2 to wake-up pin.
+     * |        |          |00 = Wake-up pin disable at Deep Power-down mode.
+     * |        |          |01 = Wake-up pin rising edge enabled at Deep Power-down mode.
+     * |        |          |10 = Wake-up pin falling edge enabled at Deep Power-down mode.
+     * |        |          |11 = Wake-up pin both edge enabled at Deep Power-down mode.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[29:28] |WKPINEN3  |Wake-up Pin Enable 3(Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |This is control register for GPB.12 to wake-up pin.
+     * |        |          |00 = Wake-up pin disable at Deep Power-down mode.
+     * |        |          |01 = Wake-up pin rising edge enabled at Deep Power-down mode.
+     * |        |          |10 = Wake-up pin falling edge enabled at Deep Power-down mode.
+     * |        |          |11 = Wake-up pin both edge enabled at Deep Power-down mode.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[31:30] |WKPINEN4  |Wake-up Pin Enable 4(Write Protect)
+     * |        |          |This is a protected register. Please refer to open lock sequence to program it.
+     * |        |          |This is control register for GPF.6 to wake-up pin.
+     * |        |          |00 = Wake-up pin disable at Deep Power-down mode.
+     * |        |          |01 = Wake-up pin rising edge enabled at Deep Power-down mode.
+     * |        |          |10 = Wake-up pin falling edge enabled at Deep Power-down mode.
+     * |        |          |11 = Wake-up pin both edge enabled at Deep Power-down mode.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var CLK_T::PMUSTS
+     * Offset: 0x94  Power Manager Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PINWK0    |Pin Wake-up Flag (Read Only)
+     * |        |          |This flag indicates that wake-up of chip from Deep Power-down mode was requested by a transition of the WAKEUP pin (GPC.0)
+     * |        |          |This flag is cleared when DPD mode is entered.
+     * |[1]     |TMRWK     |Timer Wake-up Flag (Read Only)
+     * |        |          |This flag indicates that wake-up of chip from Deep Power-down mode (DPD) was requested by wakeup timer time-out
+     * |        |          |This flag is cleared when DPD mode is entered.
+     * |[2]     |RTCWK     |RTC Wake-up Flag (Read Only)
+     * |        |          |This flag indicates that wakeup of device from Deep Power-down mode (DPD) was requested with a RTC alarm, tick time or tamper happened
+     * |        |          |This flag is cleared when DPD mode is entered.
+     * |[3]     |PINWK1    |Pin Wake-up Flag (Read Only)
+     * |        |          |This flag indicates that wake-up of chip from Deep Power-down mode was requested by a transition of the WAKEUP pin (GPB.0)
+     * |        |          |This flag is cleared when DPD mode is entered.
+     * |[4]     |PINWK2    |Pin Wake-up Flag (Read Only)
+     * |        |          |This flag indicates that wake-up of chip from Deep Power-down mode was requested by a transition of the WAKEUP pin (GPB.2)
+     * |        |          |This flag is cleared when DPD mode is entered.
+     * |[5]     |PINWK3    |Pin Wake-up Flag (Read Only)
+     * |        |          |This flag indicates that wake-up of chip from Deep Power-down mode was requested by a transition of the WAKEUP pin (GPB.12)
+     * |        |          |This flag is cleared when DPD mode is entered.
+     * |[6]     |PINWK4    |Pin Wake-up Flag (Read Only)
+     * |        |          |This flag indicates that wake-up of chip from Deep Power-down mode was requested by a transition of the WAKEUP pin (GPF.6)
+     * |        |          |This flag is cleared when DPD mode is entered.
+     * |[12]    |LVRWK     |LVR Wake-up Flag (Read Only)
+     * |        |          |This flag indicates that wakeup of device from Deep Power-down mode was requested with a LVR happened
+     * |        |          |This flag is cleared when DPD mode is entered.
+     * |[31]    |CLRWK     |Clear Wake-up Flag
+     * |        |          |0 = No clear.
+     * |        |          |1= Clear all wake-up flag.
+     * @var CLK_T::HXTFSEL
+     * Offset: 0xB4  HXT Filter Select Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |HXTFSEL   |HXT Filter Select (Write Protect)
+     * |        |          |0 = HXT frequency is > 12MHz.
+     * |        |          |1 = HXT frequency is <= 12MHz.
+     */
+    __IO uint32_t PWRCTL;                /*!< [0x0000] System Power-down Control Register                               */
+    __IO uint32_t AHBCLK;                /*!< [0x0004] AHB Devices Clock Enable Control Register                        */
+    __IO uint32_t APBCLK0;               /*!< [0x0008] APB Devices Clock Enable Control Register 0                      */
+    __IO uint32_t APBCLK1;               /*!< [0x000c] APB Devices Clock Enable Control Register 1                      */
+    __IO uint32_t CLKSEL0;               /*!< [0x0010] Clock Source Select Control Register 0                           */
+    __IO uint32_t CLKSEL1;               /*!< [0x0014] Clock Source Select Control Register 1                           */
+    __IO uint32_t CLKSEL2;               /*!< [0x0018] Clock Source Select Control Register 2                           */
+    __IO uint32_t CLKSEL3;               /*!< [0x001c] Clock Source Select Control Register 3                           */
+    __IO uint32_t CLKDIV0;               /*!< [0x0020] Clock Divider Number Register 0                                  */
+    __IO uint32_t CLKDIV1;               /*!< [0x0024] Clock Divider Number Register 1                                  */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CLKDIV4;               /*!< [0x0030] Clock Divider Number Register 4                                  */
+    __IO uint32_t PCLKDIV;               /*!< [0x0034] APB Clock Divider Register                                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PLLCTL;                /*!< [0x0040] PLL Control Register                                             */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t STATUS;                /*!< [0x0050] Clock Status Monitor Register                                    */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CLKOCTL;               /*!< [0x0060] Clock Output Control Register                                    */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE4[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CLKDCTL;               /*!< [0x0070] Clock Fail Detector Control Register                             */
+    __IO uint32_t CLKDSTS;               /*!< [0x0074] Clock Fail Detector Status Register                              */
+    __IO uint32_t CDUPB;                 /*!< [0x0078] Clock Frequency Range Detector Upper Boundary Register           */
+    __IO uint32_t CDLOWB;                /*!< [0x007c] Clock Frequency Range Detector Lower Boundary Register           */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE5[4];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PMUCTL;                /*!< [0x0090] Power Manager Control Register                                   */
+    __IO uint32_t PMUSTS;                /*!< [0x0094] Power Manager Status Register                                    */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE6[7];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t HXTFSEL;               /*!< [0x00b4] HXT Filter Select Control Register                               */
+} CLK_T;
+
+/**
+    @addtogroup CLK_CONST CLK Bit Field Definition
+    Constant Definitions for CLK Controller
+@{ */
+
+#define CLK_PWRCTL_HXTEN_Pos             (0)                                               /*!< CLK_T::PWRCTL: HXTEN Position          */
+#define CLK_PWRCTL_HXTEN_Msk             (0x1ul << CLK_PWRCTL_HXTEN_Pos)                   /*!< CLK_T::PWRCTL: HXTEN Mask              */
+
+#define CLK_PWRCTL_LXTEN_Pos             (1)                                               /*!< CLK_T::PWRCTL: LXTEN Position          */
+#define CLK_PWRCTL_LXTEN_Msk             (0x1ul << CLK_PWRCTL_LXTEN_Pos)                   /*!< CLK_T::PWRCTL: LXTEN Mask              */
+
+#define CLK_PWRCTL_HIRCEN_Pos            (2)                                               /*!< CLK_T::PWRCTL: HIRCEN Position         */
+#define CLK_PWRCTL_HIRCEN_Msk            (0x1ul << CLK_PWRCTL_HIRCEN_Pos)                  /*!< CLK_T::PWRCTL: HIRCEN Mask             */
+
+#define CLK_PWRCTL_LIRCEN_Pos            (3)                                               /*!< CLK_T::PWRCTL: LIRCEN Position         */
+#define CLK_PWRCTL_LIRCEN_Msk            (0x1ul << CLK_PWRCTL_LIRCEN_Pos)                  /*!< CLK_T::PWRCTL: LIRCEN Mask             */
+
+#define CLK_PWRCTL_PDWKDLY_Pos           (4)                                               /*!< CLK_T::PWRCTL: PDWKDLY Position        */
+#define CLK_PWRCTL_PDWKDLY_Msk           (0x1ul << CLK_PWRCTL_PDWKDLY_Pos)                 /*!< CLK_T::PWRCTL: PDWKDLY Mask            */
+
+#define CLK_PWRCTL_PDWKIEN_Pos           (5)                                               /*!< CLK_T::PWRCTL: PDWKIEN Position        */
+#define CLK_PWRCTL_PDWKIEN_Msk           (0x1ul << CLK_PWRCTL_PDWKIEN_Pos)                 /*!< CLK_T::PWRCTL: PDWKIEN Mask            */
+
+#define CLK_PWRCTL_PDWKIF_Pos            (6)                                               /*!< CLK_T::PWRCTL: PDWKIF Position         */
+#define CLK_PWRCTL_PDWKIF_Msk            (0x1ul << CLK_PWRCTL_PDWKIF_Pos)                  /*!< CLK_T::PWRCTL: PDWKIF Mask             */
+
+#define CLK_PWRCTL_PDEN_Pos              (7)                                               /*!< CLK_T::PWRCTL: PDEN Position           */
+#define CLK_PWRCTL_PDEN_Msk              (0x1ul << CLK_PWRCTL_PDEN_Pos)                    /*!< CLK_T::PWRCTL: PDEN Mask               */
+
+#define CLK_PWRCTL_MIRCEN_Pos            (19)                                              /*!< CLK_T::PWRCTL: MIRCEN Position         */
+#define CLK_PWRCTL_MIRCEN_Msk            (0x1ul << CLK_PWRCTL_MIRCEN_Pos)                  /*!< CLK_T::PWRCTL: MIRCEN Mask             */
+
+#define CLK_PWRCTL_HXTGAIN_Pos           (20)                                              /*!< CLK_T::PWRCTL: HXTGAIN Position        */
+#define CLK_PWRCTL_HXTGAIN_Msk           (0x7ul << CLK_PWRCTL_HXTGAIN_Pos)                /*!< CLK_T::PWRCTL: HXTGAIN Mask            */
+
+#define CLK_AHBCLK_PDMACKEN_Pos          (1)                                               /*!< CLK_T::AHBCLK: PDMACKEN Position       */
+#define CLK_AHBCLK_PDMACKEN_Msk          (0x1ul << CLK_AHBCLK_PDMACKEN_Pos)                /*!< CLK_T::AHBCLK: PDMACKEN Mask           */
+
+#define CLK_AHBCLK_ISPCKEN_Pos           (2)                                               /*!< CLK_T::AHBCLK: ISPCKEN Position        */
+#define CLK_AHBCLK_ISPCKEN_Msk           (0x1ul << CLK_AHBCLK_ISPCKEN_Pos)                 /*!< CLK_T::AHBCLK: ISPCKEN Mask            */
+
+#define CLK_AHBCLK_EBICKEN_Pos           (3)                                               /*!< CLK_T::AHBCLK: EBICKEN Position        */
+#define CLK_AHBCLK_EBICKEN_Msk           (0x1ul << CLK_AHBCLK_EBICKEN_Pos)                 /*!< CLK_T::AHBCLK: EBICKEN Mask            */
+
+#define CLK_AHBCLK_EXSTCKEN_Pos          (4)                                               /*!< CLK_T::AHBCLK: EXSTCKEN Position       */
+#define CLK_AHBCLK_EXSTCKEN_Msk          (0x1ul << CLK_AHBCLK_EXSTCKEN_Pos)                /*!< CLK_T::AHBCLK: EXSTCKEN Mask           */
+
+#define CLK_AHBCLK_CRCCKEN_Pos           (7)                                               /*!< CLK_T::AHBCLK: CRCCKEN Position        */
+#define CLK_AHBCLK_CRCCKEN_Msk           (0x1ul << CLK_AHBCLK_CRCCKEN_Pos)                 /*!< CLK_T::AHBCLK: CRCCKEN Mask            */
+
+#define CLK_AHBCLK_CRPTCKEN_Pos          (12)                                              /*!< CLK_T::AHBCLK: CRPTCKEN Position       */
+#define CLK_AHBCLK_CRPTCKEN_Msk          (0x1ul << CLK_AHBCLK_CRPTCKEN_Pos)                /*!< CLK_T::AHBCLK: CRPTCKEN Mask           */
+
+#define CLK_AHBCLK_FMCIDLE_Pos           (15)                                              /*!< CLK_T::AHBCLK: FMCIDLE Position        */
+#define CLK_AHBCLK_FMCIDLE_Msk           (0x1ul << CLK_AHBCLK_FMCIDLE_Pos)                 /*!< CLK_T::AHBCLK: FMCIDLE Mask            */
+
+#define CLK_AHBCLK_GPACKEN_Pos           (24)                                              /*!< CLK_T::AHBCLK: GPACKEN Position        */
+#define CLK_AHBCLK_GPACKEN_Msk           (0x1ul << CLK_AHBCLK_GPACKEN_Pos)                 /*!< CLK_T::AHBCLK: GPACKEN Mask            */
+
+#define CLK_AHBCLK_GPBCKEN_Pos           (25)                                              /*!< CLK_T::AHBCLK: GPBCKEN Position        */
+#define CLK_AHBCLK_GPBCKEN_Msk           (0x1ul << CLK_AHBCLK_GPBCKEN_Pos)                 /*!< CLK_T::AHBCLK: GPBCKEN Mask            */
+
+#define CLK_AHBCLK_GPCCKEN_Pos           (26)                                              /*!< CLK_T::AHBCLK: GPCCKEN Position        */
+#define CLK_AHBCLK_GPCCKEN_Msk           (0x1ul << CLK_AHBCLK_GPCCKEN_Pos)                 /*!< CLK_T::AHBCLK: GPCCKEN Mask            */
+
+#define CLK_AHBCLK_GPDCKEN_Pos           (27)                                              /*!< CLK_T::AHBCLK: GPDCKEN Position        */
+#define CLK_AHBCLK_GPDCKEN_Msk           (0x1ul << CLK_AHBCLK_GPDCKEN_Pos)                 /*!< CLK_T::AHBCLK: GPDCKEN Mask            */
+
+#define CLK_AHBCLK_GPECKEN_Pos           (28)                                              /*!< CLK_T::AHBCLK: GPECKEN Position        */
+#define CLK_AHBCLK_GPECKEN_Msk           (0x1ul << CLK_AHBCLK_GPECKEN_Pos)                 /*!< CLK_T::AHBCLK: GPECKEN Mask            */
+
+#define CLK_AHBCLK_GPFCKEN_Pos           (29)                                              /*!< CLK_T::AHBCLK: GPFCKEN Position        */
+#define CLK_AHBCLK_GPFCKEN_Msk           (0x1ul << CLK_AHBCLK_GPFCKEN_Pos)                 /*!< CLK_T::AHBCLK: GPFCKEN Mask            */
+
+#define CLK_APBCLK0_WDTCKEN_Pos          (0)                                               /*!< CLK_T::APBCLK0: WDTCKEN Position       */
+#define CLK_APBCLK0_WDTCKEN_Msk          (0x1ul << CLK_APBCLK0_WDTCKEN_Pos)                /*!< CLK_T::APBCLK0: WDTCKEN Mask           */
+
+#define CLK_APBCLK0_RTCCKEN_Pos          (1)                                               /*!< CLK_T::APBCLK0: RTCCKEN Position       */
+#define CLK_APBCLK0_RTCCKEN_Msk          (0x1ul << CLK_APBCLK0_RTCCKEN_Pos)                /*!< CLK_T::APBCLK0: RTCCKEN Mask           */
+
+#define CLK_APBCLK0_TMR0CKEN_Pos         (2)                                               /*!< CLK_T::APBCLK0: TMR0CKEN Position      */
+#define CLK_APBCLK0_TMR0CKEN_Msk         (0x1ul << CLK_APBCLK0_TMR0CKEN_Pos)               /*!< CLK_T::APBCLK0: TMR0CKEN Mask          */
+
+#define CLK_APBCLK0_TMR1CKEN_Pos         (3)                                               /*!< CLK_T::APBCLK0: TMR1CKEN Position      */
+#define CLK_APBCLK0_TMR1CKEN_Msk         (0x1ul << CLK_APBCLK0_TMR1CKEN_Pos)               /*!< CLK_T::APBCLK0: TMR1CKEN Mask          */
+
+#define CLK_APBCLK0_TMR2CKEN_Pos         (4)                                               /*!< CLK_T::APBCLK0: TMR2CKEN Position      */
+#define CLK_APBCLK0_TMR2CKEN_Msk         (0x1ul << CLK_APBCLK0_TMR2CKEN_Pos)               /*!< CLK_T::APBCLK0: TMR2CKEN Mask          */
+
+#define CLK_APBCLK0_TMR3CKEN_Pos         (5)                                               /*!< CLK_T::APBCLK0: TMR3CKEN Position      */
+#define CLK_APBCLK0_TMR3CKEN_Msk         (0x1ul << CLK_APBCLK0_TMR3CKEN_Pos)               /*!< CLK_T::APBCLK0: TMR3CKEN Mask          */
+
+#define CLK_APBCLK0_CLKOCKEN_Pos         (6)                                               /*!< CLK_T::APBCLK0: CLKOCKEN Position      */
+#define CLK_APBCLK0_CLKOCKEN_Msk         (0x1ul << CLK_APBCLK0_CLKOCKEN_Pos)               /*!< CLK_T::APBCLK0: CLKOCKEN Mask          */
+
+#define CLK_APBCLK0_ACMP01CKEN_Pos       (7)                                               /*!< CLK_T::APBCLK0: ACMP01CKEN Position    */
+#define CLK_APBCLK0_ACMP01CKEN_Msk       (0x1ul << CLK_APBCLK0_ACMP01CKEN_Pos)             /*!< CLK_T::APBCLK0: ACMP01CKEN Mask        */
+
+#define CLK_APBCLK0_I2C0CKEN_Pos         (8)                                               /*!< CLK_T::APBCLK0: I2C0CKEN Position      */
+#define CLK_APBCLK0_I2C0CKEN_Msk         (0x1ul << CLK_APBCLK0_I2C0CKEN_Pos)               /*!< CLK_T::APBCLK0: I2C0CKEN Mask          */
+
+#define CLK_APBCLK0_I2C1CKEN_Pos         (9)                                               /*!< CLK_T::APBCLK0: I2C1CKEN Position      */
+#define CLK_APBCLK0_I2C1CKEN_Msk         (0x1ul << CLK_APBCLK0_I2C1CKEN_Pos)               /*!< CLK_T::APBCLK0: I2C1CKEN Mask          */
+
+#define CLK_APBCLK0_QSPI0CKEN_Pos        (12)                                              /*!< CLK_T::APBCLK0: QSPI0CKEN Position     */
+#define CLK_APBCLK0_QSPI0CKEN_Msk        (0x1ul << CLK_APBCLK0_QSPI0CKEN_Pos)              /*!< CLK_T::APBCLK0: QSPI0CKEN Mask         */
+
+#define CLK_APBCLK0_SPI0CKEN_Pos         (13)                                              /*!< CLK_T::APBCLK0: SPI0CKEN Position      */
+#define CLK_APBCLK0_SPI0CKEN_Msk         (0x1ul << CLK_APBCLK0_SPI0CKEN_Pos)               /*!< CLK_T::APBCLK0: SPI0CKEN Mask          */
+
+#define CLK_APBCLK0_SPI1CKEN_Pos         (14)                                              /*!< CLK_T::APBCLK0: SPI1CKEN Position      */
+#define CLK_APBCLK0_SPI1CKEN_Msk         (0x1ul << CLK_APBCLK0_SPI1CKEN_Pos)               /*!< CLK_T::APBCLK0: SPI1CKEN Mask          */
+
+#define CLK_APBCLK0_UART0CKEN_Pos        (16)                                              /*!< CLK_T::APBCLK0: UART0CKEN Position     */
+#define CLK_APBCLK0_UART0CKEN_Msk        (0x1ul << CLK_APBCLK0_UART0CKEN_Pos)              /*!< CLK_T::APBCLK0: UART0CKEN Mask         */
+
+#define CLK_APBCLK0_UART1CKEN_Pos        (17)                                              /*!< CLK_T::APBCLK0: UART1CKEN Position     */
+#define CLK_APBCLK0_UART1CKEN_Msk        (0x1ul << CLK_APBCLK0_UART1CKEN_Pos)              /*!< CLK_T::APBCLK0: UART1CKEN Mask         */
+
+#define CLK_APBCLK0_UART2CKEN_Pos        (18)                                              /*!< CLK_T::APBCLK0: UART2CKEN Position     */
+#define CLK_APBCLK0_UART2CKEN_Msk        (0x1ul << CLK_APBCLK0_UART2CKEN_Pos)              /*!< CLK_T::APBCLK0: UART2CKEN Mask         */
+
+#define CLK_APBCLK0_UART3CKEN_Pos        (19)                                              /*!< CLK_T::APBCLK0: UART3CKEN Position     */
+#define CLK_APBCLK0_UART3CKEN_Msk        (0x1ul << CLK_APBCLK0_UART3CKEN_Pos)              /*!< CLK_T::APBCLK0: UART3CKEN Mask         */
+
+#define CLK_APBCLK0_USBDCKEN_Pos         (27)                                              /*!< CLK_T::APBCLK0: USBDCKEN Position      */
+#define CLK_APBCLK0_USBDCKEN_Msk         (0x1ul << CLK_APBCLK0_USBDCKEN_Pos)               /*!< CLK_T::APBCLK0: USBDCKEN Mask          */
+
+#define CLK_APBCLK0_EADCCKEN_Pos         (28)                                              /*!< CLK_T::APBCLK0: EADCCKEN Position      */
+#define CLK_APBCLK0_EADCCKEN_Msk         (0x1ul << CLK_APBCLK0_EADCCKEN_Pos)               /*!< CLK_T::APBCLK0: EADCCKEN Mask          */
+
+#define CLK_APBCLK0_TKCKEN_Pos           (29)                                              /*!< CLK_T::APBCLK0: TKCKEN Position        */
+#define CLK_APBCLK0_TKCKEN_Msk           (0x1ul << CLK_APBCLK0_TKCKEN_Pos)                 /*!< CLK_T::APBCLK0: TKCKEN Mask            */
+
+#define CLK_APBCLK1_SC0CKEN_Pos          (0)                                               /*!< CLK_T::APBCLK1: SC0CKEN Position       */
+#define CLK_APBCLK1_SC0CKEN_Msk          (0x1ul << CLK_APBCLK1_SC0CKEN_Pos)                /*!< CLK_T::APBCLK1: SC0CKEN Mask           */
+
+#define CLK_APBCLK1_USCI0CKEN_Pos        (8)                                               /*!< CLK_T::APBCLK1: USCI0CKEN Position     */
+#define CLK_APBCLK1_USCI0CKEN_Msk        (0x1ul << CLK_APBCLK1_USCI0CKEN_Pos)              /*!< CLK_T::APBCLK1: USCI0CKEN Mask         */
+
+#define CLK_APBCLK1_USCI1CKEN_Pos        (9)                                               /*!< CLK_T::APBCLK1: USCI1CKEN Position     */
+#define CLK_APBCLK1_USCI1CKEN_Msk        (0x1ul << CLK_APBCLK1_USCI1CKEN_Pos)              /*!< CLK_T::APBCLK1: USCI1CKEN Mask         */
+
+#define CLK_APBCLK1_USCI2CKEN_Pos        (10)                                              /*!< CLK_T::APBCLK1: USCI2CKEN Position     */
+#define CLK_APBCLK1_USCI2CKEN_Msk        (0x1ul << CLK_APBCLK1_USCI2CKEN_Pos)              /*!< CLK_T::APBCLK1: USCI2CKEN Mask         */
+
+#define CLK_APBCLK1_DACCKEN_Pos          (12)                                              /*!< CLK_T::APBCLK1: DACCKEN Position       */
+#define CLK_APBCLK1_DACCKEN_Msk          (0x1ul << CLK_APBCLK1_DACCKEN_Pos)                /*!< CLK_T::APBCLK1: DACCKEN Mask           */
+
+#define CLK_APBCLK1_LCDCKEN_Pos          (14)                                              /*!< CLK_T::APBCLK1: LCDCKEN Position       */
+#define CLK_APBCLK1_LCDCKEN_Msk          (0x1ul << CLK_APBCLK1_LCDCKEN_Pos)                /*!< CLK_T::APBCLK1: LCDCKEN Mask           */
+
+#define CLK_APBCLK1_LCDCPCKEN_Pos        (15)                                              /*!< CLK_T::APBCLK1: LCDCPCKEN Position     */
+#define CLK_APBCLK1_LCDCPCKEN_Msk        (0x1ul << CLK_APBCLK1_LCDCPCKEN_Pos)              /*!< CLK_T::APBCLK1: LCDCPCKEN Mask         */
+
+#define CLK_APBCLK1_PWM0CKEN_Pos         (16)                                              /*!< CLK_T::APBCLK1: PWM0CKEN Position      */
+#define CLK_APBCLK1_PWM0CKEN_Msk         (0x1ul << CLK_APBCLK1_PWM0CKEN_Pos)               /*!< CLK_T::APBCLK1: PWM0CKEN Mask          */
+
+#define CLK_APBCLK1_PWM1CKEN_Pos         (17)                                              /*!< CLK_T::APBCLK1: PWM1CKEN Position      */
+#define CLK_APBCLK1_PWM1CKEN_Msk         (0x1ul << CLK_APBCLK1_PWM1CKEN_Pos)               /*!< CLK_T::APBCLK1: PWM1CKEN Mask          */
+
+#define CLK_APBCLK1_BPWM0CKEN_Pos        (18)                                              /*!< CLK_T::APBCLK1: BPWM0CKEN Position     */
+#define CLK_APBCLK1_BPWM0CKEN_Msk        (0x1ul << CLK_APBCLK1_BPWM0CKEN_Pos)              /*!< CLK_T::APBCLK1: BPWM0CKEN Mask         */
+
+#define CLK_APBCLK1_BPWM1CKEN_Pos        (19)                                              /*!< CLK_T::APBCLK1: BPWM1CKEN Position     */
+#define CLK_APBCLK1_BPWM1CKEN_Msk        (0x1ul << CLK_APBCLK1_BPWM1CKEN_Pos)              /*!< CLK_T::APBCLK1: BPWM1CKEN Mask         */
+
+#define CLK_APBCLK1_OPACKEN_Pos          (30)                                              /*!< CLK_T::APBCLK1: OPACKEN Position       */
+#define CLK_APBCLK1_OPACKEN_Msk          (0x1ul << CLK_APBCLK1_OPACKEN_Pos)                /*!< CLK_T::APBCLK1: OPACKEN Mask           */
+
+#define CLK_APBCLK1_PSIOCKEN_Pos         (31)                                              /*!< CLK_T::APBCLK1: PSIOCKEN Position      */
+#define CLK_APBCLK1_PSIOCKEN_Msk         (0x1ul << CLK_APBCLK1_PSIOCKEN_Pos)               /*!< CLK_T::APBCLK1: PSIOCKEN Mask          */
+
+#define CLK_CLKSEL0_HCLKSEL_Pos          (0)                                               /*!< CLK_T::CLKSEL0: HCLKSEL Position       */
+#define CLK_CLKSEL0_HCLKSEL_Msk          (0x7ul << CLK_CLKSEL0_HCLKSEL_Pos)                /*!< CLK_T::CLKSEL0: HCLKSEL Mask           */
+
+#define CLK_CLKSEL0_STCLKSEL_Pos         (3)                                               /*!< CLK_T::CLKSEL0: STCLKSEL Position      */
+#define CLK_CLKSEL0_STCLKSEL_Msk         (0x7ul << CLK_CLKSEL0_STCLKSEL_Pos)               /*!< CLK_T::CLKSEL0: STCLKSEL Mask          */
+
+#define CLK_CLKSEL0_USBDSEL_Pos          (8)                                               /*!< CLK_T::CLKSEL0: USBDSEL Position       */
+#define CLK_CLKSEL0_USBDSEL_Msk          (0x1ul << CLK_CLKSEL0_USBDSEL_Pos)                /*!< CLK_T::CLKSEL0: USBDSEL Mask           */
+
+#define CLK_CLKSEL1_WDTSEL_Pos           (0)                                               /*!< CLK_T::CLKSEL1: WDTSEL Position        */
+#define CLK_CLKSEL1_WDTSEL_Msk           (0x3ul << CLK_CLKSEL1_WDTSEL_Pos)                 /*!< CLK_T::CLKSEL1: WDTSEL Mask            */
+
+#define CLK_CLKSEL1_WWDTSEL_Pos          (2)                                               /*!< CLK_T::CLKSEL1: WWDTSEL Position       */
+#define CLK_CLKSEL1_WWDTSEL_Msk          (0x3ul << CLK_CLKSEL1_WWDTSEL_Pos)                /*!< CLK_T::CLKSEL1: WWDTSEL Mask           */
+
+#define CLK_CLKSEL1_CLKOSEL_Pos          (4)                                               /*!< CLK_T::CLKSEL1: CLKOSEL Position       */
+#define CLK_CLKSEL1_CLKOSEL_Msk          (0x7ul << CLK_CLKSEL1_CLKOSEL_Pos)                /*!< CLK_T::CLKSEL1: CLKOSEL Mask           */
+
+#define CLK_CLKSEL1_TMR0SEL_Pos          (8)                                               /*!< CLK_T::CLKSEL1: TMR0SEL Position       */
+#define CLK_CLKSEL1_TMR0SEL_Msk          (0x7ul << CLK_CLKSEL1_TMR0SEL_Pos)                /*!< CLK_T::CLKSEL1: TMR0SEL Mask           */
+
+#define CLK_CLKSEL1_TMR1SEL_Pos          (12)                                              /*!< CLK_T::CLKSEL1: TMR1SEL Position       */
+#define CLK_CLKSEL1_TMR1SEL_Msk          (0x7ul << CLK_CLKSEL1_TMR1SEL_Pos)                /*!< CLK_T::CLKSEL1: TMR1SEL Mask           */
+
+#define CLK_CLKSEL1_TMR2SEL_Pos          (16)                                              /*!< CLK_T::CLKSEL1: TMR2SEL Position       */
+#define CLK_CLKSEL1_TMR2SEL_Msk          (0x7ul << CLK_CLKSEL1_TMR2SEL_Pos)                /*!< CLK_T::CLKSEL1: TMR2SEL Mask           */
+
+#define CLK_CLKSEL1_TMR3SEL_Pos          (20)                                              /*!< CLK_T::CLKSEL1: TMR3SEL Position       */
+#define CLK_CLKSEL1_TMR3SEL_Msk          (0x7ul << CLK_CLKSEL1_TMR3SEL_Pos)                /*!< CLK_T::CLKSEL1: TMR3SEL Mask           */
+
+#define CLK_CLKSEL1_UART0SEL_Pos         (24)                                              /*!< CLK_T::CLKSEL1: UART0SEL Position      */
+#define CLK_CLKSEL1_UART0SEL_Msk         (0x7ul << CLK_CLKSEL1_UART0SEL_Pos)               /*!< CLK_T::CLKSEL1: UART0SEL Mask          */
+
+#define CLK_CLKSEL1_UART1SEL_Pos         (28)                                              /*!< CLK_T::CLKSEL1: UART1SEL Position      */
+#define CLK_CLKSEL1_UART1SEL_Msk         (0x7ul << CLK_CLKSEL1_UART1SEL_Pos)               /*!< CLK_T::CLKSEL1: UART1SEL Mask          */
+
+#define CLK_CLKSEL2_PWM0SEL_Pos          (0)                                               /*!< CLK_T::CLKSEL2: PWM0SEL Position       */
+#define CLK_CLKSEL2_PWM0SEL_Msk          (0x1ul << CLK_CLKSEL2_PWM0SEL_Pos)                /*!< CLK_T::CLKSEL2: PWM0SEL Mask           */
+
+#define CLK_CLKSEL2_PWM1SEL_Pos          (1)                                               /*!< CLK_T::CLKSEL2: PWM1SEL Position       */
+#define CLK_CLKSEL2_PWM1SEL_Msk          (0x1ul << CLK_CLKSEL2_PWM1SEL_Pos)                /*!< CLK_T::CLKSEL2: PWM1SEL Mask           */
+
+#define CLK_CLKSEL2_QSPI0SEL_Pos         (2)                                               /*!< CLK_T::CLKSEL2: QSPI0SEL Position      */
+#define CLK_CLKSEL2_QSPI0SEL_Msk         (0x3ul << CLK_CLKSEL2_QSPI0SEL_Pos)               /*!< CLK_T::CLKSEL2: QSPI0SEL Mask          */
+
+#define CLK_CLKSEL2_SPI0SEL_Pos          (4)                                               /*!< CLK_T::CLKSEL2: SPI0SEL Position       */
+#define CLK_CLKSEL2_SPI0SEL_Msk          (0x3ul << CLK_CLKSEL2_SPI0SEL_Pos)                /*!< CLK_T::CLKSEL2: SPI0SEL Mask           */
+
+#define CLK_CLKSEL2_SPI1SEL_Pos          (6)                                               /*!< CLK_T::CLKSEL2: SPI1SEL Position       */
+#define CLK_CLKSEL2_SPI1SEL_Msk          (0x3ul << CLK_CLKSEL2_SPI1SEL_Pos)                /*!< CLK_T::CLKSEL2: SPI1SEL Mask           */
+
+#define CLK_CLKSEL2_BPWM0SEL_Pos         (8)                                               /*!< CLK_T::CLKSEL2: BPWM0SEL Position      */
+#define CLK_CLKSEL2_BPWM0SEL_Msk         (0x1ul << CLK_CLKSEL2_BPWM0SEL_Pos)               /*!< CLK_T::CLKSEL2: BPWM0SEL Mask          */
+
+#define CLK_CLKSEL2_BPWM1SEL_Pos         (9)                                               /*!< CLK_T::CLKSEL2: BPWM1SEL Position      */
+#define CLK_CLKSEL2_BPWM1SEL_Msk         (0x1ul << CLK_CLKSEL2_BPWM1SEL_Pos)               /*!< CLK_T::CLKSEL2: BPWM1SEL Mask          */
+
+#define CLK_CLKSEL2_LCDSEL_Pos           (24)                                              /*!< CLK_T::CLKSEL2: LCDSEL Position        */
+#define CLK_CLKSEL2_LCDSEL_Msk           (0x1ul << CLK_CLKSEL2_LCDSEL_Pos)                 /*!< CLK_T::CLKSEL2: LCDSEL Mask            */
+
+#define CLK_CLKSEL2_LCDCPSEL_Pos         (25)                                              /*!< CLK_T::CLKSEL2: LCDCPSEL Position      */
+#define CLK_CLKSEL2_LCDCPSEL_Msk         (0x1ul << CLK_CLKSEL2_LCDCPSEL_Pos)               /*!< CLK_T::CLKSEL2: LCDCPSEL Mask          */
+
+#define CLK_CLKSEL2_PSIOSEL_Pos          (28)                                              /*!< CLK_T::CLKSEL2: PSIOSEL Position       */
+#define CLK_CLKSEL2_PSIOSEL_Msk          (0x7ul << CLK_CLKSEL2_PSIOSEL_Pos)                /*!< CLK_T::CLKSEL2: PSIOSEL Mask           */
+
+#define CLK_CLKSEL3_SC0SEL_Pos           (0)                                               /*!< CLK_T::CLKSEL3: SC0SEL Position        */
+#define CLK_CLKSEL3_SC0SEL_Msk           (0x3ul << CLK_CLKSEL3_SC0SEL_Pos)                 /*!< CLK_T::CLKSEL3: SC0SEL Mask            */
+
+#define CLK_CLKSEL3_UART2SEL_Pos         (24)                                              /*!< CLK_T::CLKSEL3: UART2SEL Position      */
+#define CLK_CLKSEL3_UART2SEL_Msk         (0x7ul << CLK_CLKSEL3_UART2SEL_Pos)               /*!< CLK_T::CLKSEL3: UART2SEL Mask          */
+
+#define CLK_CLKSEL3_UART3SEL_Pos         (28)                                              /*!< CLK_T::CLKSEL3: UART3SEL Position      */
+#define CLK_CLKSEL3_UART3SEL_Msk         (0x7ul << CLK_CLKSEL3_UART3SEL_Pos)               /*!< CLK_T::CLKSEL3: UART3SEL Mask          */
+
+#define CLK_CLKDIV0_HCLKDIV_Pos          (0)                                               /*!< CLK_T::CLKDIV0: HCLKDIV Position       */
+#define CLK_CLKDIV0_HCLKDIV_Msk          (0xful << CLK_CLKDIV0_HCLKDIV_Pos)                /*!< CLK_T::CLKDIV0: HCLKDIV Mask           */
+
+#define CLK_CLKDIV0_USBDIV_Pos           (4)                                               /*!< CLK_T::CLKDIV0: USBDIV Position        */
+#define CLK_CLKDIV0_USBDIV_Msk           (0xful << CLK_CLKDIV0_USBDIV_Pos)                 /*!< CLK_T::CLKDIV0: USBDIV Mask            */
+
+#define CLK_CLKDIV0_UART0DIV_Pos         (8)                                               /*!< CLK_T::CLKDIV0: UART0DIV Position      */
+#define CLK_CLKDIV0_UART0DIV_Msk         (0xful << CLK_CLKDIV0_UART0DIV_Pos)               /*!< CLK_T::CLKDIV0: UART0DIV Mask          */
+
+#define CLK_CLKDIV0_UART1DIV_Pos         (12)                                              /*!< CLK_T::CLKDIV0: UART1DIV Position      */
+#define CLK_CLKDIV0_UART1DIV_Msk         (0xful << CLK_CLKDIV0_UART1DIV_Pos)               /*!< CLK_T::CLKDIV0: UART1DIV Mask          */
+
+#define CLK_CLKDIV0_EADCDIV_Pos          (16)                                              /*!< CLK_T::CLKDIV0: EADCDIV Position       */
+#define CLK_CLKDIV0_EADCDIV_Msk          (0xfful << CLK_CLKDIV0_EADCDIV_Pos)               /*!< CLK_T::CLKDIV0: EADCDIV Mask           */
+
+#define CLK_CLKDIV1_SC0DIV_Pos           (0)                                               /*!< CLK_T::CLKDIV1: SC0DIV Position        */
+#define CLK_CLKDIV1_SC0DIV_Msk           (0xfful << CLK_CLKDIV1_SC0DIV_Pos)                /*!< CLK_T::CLKDIV1: SC0DIV Mask            */
+
+#define CLK_CLKDIV1_PSIODIV_Pos          (24)                                              /*!< CLK_T::CLKDIV1: PSIODIV Position       */
+#define CLK_CLKDIV1_PSIODIV_Msk          (0xfful << CLK_CLKDIV1_PSIODIV_Pos)               /*!< CLK_T::CLKDIV1: PSIODIV Mask           */
+
+#define CLK_CLKDIV4_UART2DIV_Pos         (0)                                               /*!< CLK_T::CLKDIV4: UART2DIV Position      */
+#define CLK_CLKDIV4_UART2DIV_Msk         (0xful << CLK_CLKDIV4_UART2DIV_Pos)               /*!< CLK_T::CLKDIV4: UART2DIV Mask          */
+
+#define CLK_CLKDIV4_UART3DIV_Pos         (4)                                               /*!< CLK_T::CLKDIV4: UART3DIV Position      */
+#define CLK_CLKDIV4_UART3DIV_Msk         (0xful << CLK_CLKDIV4_UART3DIV_Pos)               /*!< CLK_T::CLKDIV4: UART3DIV Mask          */
+
+#define CLK_PCLKDIV_APB0DIV_Pos          (0)                                               /*!< CLK_T::PCLKDIV: APB0DIV Position       */
+#define CLK_PCLKDIV_APB0DIV_Msk          (0x7ul << CLK_PCLKDIV_APB0DIV_Pos)                /*!< CLK_T::PCLKDIV: APB0DIV Mask           */
+
+#define CLK_PCLKDIV_APB1DIV_Pos          (4)                                               /*!< CLK_T::PCLKDIV: APB1DIV Position       */
+#define CLK_PCLKDIV_APB1DIV_Msk          (0x7ul << CLK_PCLKDIV_APB1DIV_Pos)                /*!< CLK_T::PCLKDIV: APB1DIV Mask           */
+
+#define CLK_PLLCTL_FBDIV_Pos             (0)                                               /*!< CLK_T::PLLCTL: FBDIV Position          */
+#define CLK_PLLCTL_FBDIV_Msk             (0x3ful << CLK_PLLCTL_FBDIV_Pos)                  /*!< CLK_T::PLLCTL: FBDIV Mask              */
+
+#define CLK_PLLCTL_INDIV_Pos             (9)                                               /*!< CLK_T::PLLCTL: INDIV Position          */
+#define CLK_PLLCTL_INDIV_Msk             (0xful << CLK_PLLCTL_INDIV_Pos)                   /*!< CLK_T::PLLCTL: INDIV Mask              */
+
+#define CLK_PLLCTL_OUTDIV_Pos            (14)                                              /*!< CLK_T::PLLCTL: OUTDIV Position         */
+#define CLK_PLLCTL_OUTDIV_Msk            (0x3ul << CLK_PLLCTL_OUTDIV_Pos)                  /*!< CLK_T::PLLCTL: OUTDIV Mask             */
+
+#define CLK_PLLCTL_PD_Pos                (16)                                              /*!< CLK_T::PLLCTL: PD Position             */
+#define CLK_PLLCTL_PD_Msk                (0x1ul << CLK_PLLCTL_PD_Pos)                      /*!< CLK_T::PLLCTL: PD Mask                 */
+
+#define CLK_PLLCTL_BP_Pos                (17)                                              /*!< CLK_T::PLLCTL: BP Position             */
+#define CLK_PLLCTL_BP_Msk                (0x1ul << CLK_PLLCTL_BP_Pos)                      /*!< CLK_T::PLLCTL: BP Mask                 */
+
+#define CLK_PLLCTL_OE_Pos                (18)                                              /*!< CLK_T::PLLCTL: OE Position             */
+#define CLK_PLLCTL_OE_Msk                (0x1ul << CLK_PLLCTL_OE_Pos)                      /*!< CLK_T::PLLCTL: OE Mask                 */
+
+#define CLK_PLLCTL_PLLSRC_Pos            (19)                                              /*!< CLK_T::PLLCTL: PLLSRC Position         */
+#define CLK_PLLCTL_PLLSRC_Msk            (0x3ul << CLK_PLLCTL_PLLSRC_Pos)                  /*!< CLK_T::PLLCTL: PLLSRC Mask             */
+
+#define CLK_PLLCTL_STBSEL_Pos            (23)                                              /*!< CLK_T::PLLCTL: STBSEL Position         */
+#define CLK_PLLCTL_STBSEL_Msk            (0x1ul << CLK_PLLCTL_STBSEL_Pos)                  /*!< CLK_T::PLLCTL: STBSEL Mask             */
+
+#define CLK_PLLCTL_PLL_CLF_EN_Pos        (24)                                              /*!< CLK_T::PLLCTL: PLL_CLF_EN Position     */
+#define CLK_PLLCTL_PLL_CLF_EN_Msk        (0x1ul << CLK_PLLCTL_PLL_CLF_EN_Pos)              /*!< CLK_T::PLLCTL: PLL_CLF_EN Mask         */
+
+#define CLK_STATUS_HXTSTB_Pos            (0)                                               /*!< CLK_T::STATUS: HXTSTB Position         */
+#define CLK_STATUS_HXTSTB_Msk            (0x1ul << CLK_STATUS_HXTSTB_Pos)                  /*!< CLK_T::STATUS: HXTSTB Mask             */
+
+#define CLK_STATUS_LXTSTB_Pos            (1)                                               /*!< CLK_T::STATUS: LXTSTB Position         */
+#define CLK_STATUS_LXTSTB_Msk            (0x1ul << CLK_STATUS_LXTSTB_Pos)                  /*!< CLK_T::STATUS: LXTSTB Mask             */
+
+#define CLK_STATUS_PLLSTB_Pos            (2)                                               /*!< CLK_T::STATUS: PLLSTB Position         */
+#define CLK_STATUS_PLLSTB_Msk            (0x1ul << CLK_STATUS_PLLSTB_Pos)                  /*!< CLK_T::STATUS: PLLSTB Mask             */
+
+#define CLK_STATUS_LIRCSTB_Pos           (3)                                               /*!< CLK_T::STATUS: LIRCSTB Position        */
+#define CLK_STATUS_LIRCSTB_Msk           (0x1ul << CLK_STATUS_LIRCSTB_Pos)                 /*!< CLK_T::STATUS: LIRCSTB Mask            */
+
+#define CLK_STATUS_HIRCSTB_Pos           (4)                                               /*!< CLK_T::STATUS: HIRCSTB Position        */
+#define CLK_STATUS_HIRCSTB_Msk           (0x1ul << CLK_STATUS_HIRCSTB_Pos)                 /*!< CLK_T::STATUS: HIRCSTB Mask            */
+
+#define CLK_STATUS_MIRCSTB_Pos           (6)                                               /*!< CLK_T::STATUS: MIRCSTB Position        */
+#define CLK_STATUS_MIRCSTB_Msk           (0x1ul << CLK_STATUS_MIRCSTB_Pos)                 /*!< CLK_T::STATUS: MIRCSTB Mask            */
+
+#define CLK_STATUS_CLKSFAIL_Pos          (7)                                               /*!< CLK_T::STATUS: CLKSFAIL Position       */
+#define CLK_STATUS_CLKSFAIL_Msk          (0x1ul << CLK_STATUS_CLKSFAIL_Pos)                /*!< CLK_T::STATUS: CLKSFAIL Mask           */
+
+#define CLK_CLKOCTL_FREQSEL_Pos          (0)                                               /*!< CLK_T::CLKOCTL: FREQSEL Position       */
+#define CLK_CLKOCTL_FREQSEL_Msk          (0xful << CLK_CLKOCTL_FREQSEL_Pos)                /*!< CLK_T::CLKOCTL: FREQSEL Mask           */
+
+#define CLK_CLKOCTL_CLKOEN_Pos           (4)                                               /*!< CLK_T::CLKOCTL: CLKOEN Position        */
+#define CLK_CLKOCTL_CLKOEN_Msk           (0x1ul << CLK_CLKOCTL_CLKOEN_Pos)                 /*!< CLK_T::CLKOCTL: CLKOEN Mask            */
+
+#define CLK_CLKOCTL_DIV1EN_Pos           (5)                                               /*!< CLK_T::CLKOCTL: DIV1EN Position        */
+#define CLK_CLKOCTL_DIV1EN_Msk           (0x1ul << CLK_CLKOCTL_DIV1EN_Pos)                 /*!< CLK_T::CLKOCTL: DIV1EN Mask            */
+
+#define CLK_CLKOCTL_CLK1HZEN_Pos         (6)                                               /*!< CLK_T::CLKOCTL: CLK1HZEN Position      */
+#define CLK_CLKOCTL_CLK1HZEN_Msk         (0x1ul << CLK_CLKOCTL_CLK1HZEN_Pos)               /*!< CLK_T::CLKOCTL: CLK1HZEN Mask          */
+
+#define CLK_CLKDCTL_HXTFDEN_Pos          (4)                                               /*!< CLK_T::CLKDCTL: HXTFDEN Position       */
+#define CLK_CLKDCTL_HXTFDEN_Msk          (0x1ul << CLK_CLKDCTL_HXTFDEN_Pos)                /*!< CLK_T::CLKDCTL: HXTFDEN Mask           */
+
+#define CLK_CLKDCTL_HXTFIEN_Pos          (5)                                               /*!< CLK_T::CLKDCTL: HXTFIEN Position       */
+#define CLK_CLKDCTL_HXTFIEN_Msk          (0x1ul << CLK_CLKDCTL_HXTFIEN_Pos)                /*!< CLK_T::CLKDCTL: HXTFIEN Mask           */
+
+#define CLK_CLKDCTL_LXTFDEN_Pos          (12)                                              /*!< CLK_T::CLKDCTL: LXTFDEN Position       */
+#define CLK_CLKDCTL_LXTFDEN_Msk          (0x1ul << CLK_CLKDCTL_LXTFDEN_Pos)                /*!< CLK_T::CLKDCTL: LXTFDEN Mask           */
+
+#define CLK_CLKDCTL_LXTFIEN_Pos          (13)                                              /*!< CLK_T::CLKDCTL: LXTFIEN Position       */
+#define CLK_CLKDCTL_LXTFIEN_Msk          (0x1ul << CLK_CLKDCTL_LXTFIEN_Pos)                /*!< CLK_T::CLKDCTL: LXTFIEN Mask           */
+
+#define CLK_CLKDCTL_HXTFQDEN_Pos         (16)                                              /*!< CLK_T::CLKDCTL: HXTFQDEN Position      */
+#define CLK_CLKDCTL_HXTFQDEN_Msk         (0x1ul << CLK_CLKDCTL_HXTFQDEN_Pos)               /*!< CLK_T::CLKDCTL: HXTFQDEN Mask          */
+
+#define CLK_CLKDCTL_HXTFQIEN_Pos         (17)                                              /*!< CLK_T::CLKDCTL: HXTFQIEN Position      */
+#define CLK_CLKDCTL_HXTFQIEN_Msk         (0x1ul << CLK_CLKDCTL_HXTFQIEN_Pos)               /*!< CLK_T::CLKDCTL: HXTFQIEN Mask          */
+
+#define CLK_CLKDSTS_HXTFIF_Pos           (0)                                               /*!< CLK_T::CLKDSTS: HXTFIF Position        */
+#define CLK_CLKDSTS_HXTFIF_Msk           (0x1ul << CLK_CLKDSTS_HXTFIF_Pos)                 /*!< CLK_T::CLKDSTS: HXTFIF Mask            */
+
+#define CLK_CLKDSTS_LXTFIF_Pos           (1)                                               /*!< CLK_T::CLKDSTS: LXTFIF Position        */
+#define CLK_CLKDSTS_LXTFIF_Msk           (0x1ul << CLK_CLKDSTS_LXTFIF_Pos)                 /*!< CLK_T::CLKDSTS: LXTFIF Mask            */
+
+#define CLK_CLKDSTS_HXTFQIF_Pos          (8)                                               /*!< CLK_T::CLKDSTS: HXTFQIF Position       */
+#define CLK_CLKDSTS_HXTFQIF_Msk          (0x1ul << CLK_CLKDSTS_HXTFQIF_Pos)                /*!< CLK_T::CLKDSTS: HXTFQIF Mask           */
+
+#define CLK_CDUPB_UPERBD_Pos             (0)                                               /*!< CLK_T::CDUPB: UPERBD Position          */
+#define CLK_CDUPB_UPERBD_Msk             (0x3fful << CLK_CDUPB_UPERBD_Pos)                 /*!< CLK_T::CDUPB: UPERBD Mask              */
+
+#define CLK_CDLOWB_LOWERBD_Pos           (0)                                               /*!< CLK_T::CDLOWB: LOWERBD Position        */
+#define CLK_CDLOWB_LOWERBD_Msk           (0x3fful << CLK_CDLOWB_LOWERBD_Pos)               /*!< CLK_T::CDLOWB: LOWERBD Mask            */
+
+#define CLK_PMUCTL_PDMSEL_Pos            (0)                                               /*!< CLK_T::PMUCTL: PDMSEL Position         */
+#define CLK_PMUCTL_PDMSEL_Msk            (0x7ul << CLK_PMUCTL_PDMSEL_Pos)                  /*!< CLK_T::PMUCTL: PDMSEL Mask             */
+
+#define CLK_PMUCTL_WKTMREN_Pos           (8)                                               /*!< CLK_T::PMUCTL: WKTMREN Position        */
+#define CLK_PMUCTL_WKTMREN_Msk           (0x1ul << CLK_PMUCTL_WKTMREN_Pos)                 /*!< CLK_T::PMUCTL: WKTMREN Mask            */
+
+#define CLK_PMUCTL_WKTMRIS_Pos           (9)                                               /*!< CLK_T::PMUCTL: WKTMRIS Position        */
+#define CLK_PMUCTL_WKTMRIS_Msk           (0x7ul << CLK_PMUCTL_WKTMRIS_Pos)                 /*!< CLK_T::PMUCTL: WKTMRIS Mask            */
+
+#define CLK_PMUCTL_WKPINEN0_Pos          (16)                                              /*!< CLK_T::PMUCTL: WKPINEN0 Position        */
+#define CLK_PMUCTL_WKPINEN0_Msk          (0x3ul << CLK_PMUCTL_WKPINEN0_Pos)                /*!< CLK_T::PMUCTL: WKPINEN0 Mask            */
+
+#define CLK_PMUCTL_WKPINDBEN_Pos         (22)                                              /*!< CLK_T::PMUCTL: WKPINDBEN Position        */
+#define CLK_PMUCTL_WKPINDBEN_Msk         (0x1ul << CLK_PMUCTL_WKPINDBEN_Pos)               /*!< CLK_T::PMUCTL: WKPINDBEN Mask            */
+
+#define CLK_PMUCTL_RTCWKEN_Pos           (23)                                              /*!< CLK_T::PMUCTL: RTCWKEN Position        */
+#define CLK_PMUCTL_RTCWKEN_Msk           (0x1ul << CLK_PMUCTL_RTCWKEN_Pos)                 /*!< CLK_T::PMUCTL: RTCWKEN Mask            */
+
+#define CLK_PMUCTL_WKPINEN1_Pos          (24)                                              /*!< CLK_T::PMUCTL: WKPINEN1 Position        */
+#define CLK_PMUCTL_WKPINEN1_Msk          (0x3ul << CLK_PMUCTL_WKPINEN1_Pos)                /*!< CLK_T::PMUCTL: WKPINEN1 Mask            */
+
+#define CLK_PMUCTL_WKPINEN2_Pos          (26)                                              /*!< CLK_T::PMUCTL: WKPINEN2 Position        */
+#define CLK_PMUCTL_WKPINEN2_Msk          (0x3ul << CLK_PMUCTL_WKPINEN2_Pos)                /*!< CLK_T::PMUCTL: WKPINEN2 Mask            */
+
+#define CLK_PMUCTL_WKPINEN3_Pos          (28)                                              /*!< CLK_T::PMUCTL: WKPINEN3 Position        */
+#define CLK_PMUCTL_WKPINEN3_Msk          (0x3ul << CLK_PMUCTL_WKPINEN3_Pos)                /*!< CLK_T::PMUCTL: WKPINEN3 Mask            */
+
+#define CLK_PMUCTL_WKPINEN4_Pos          (30)                                              /*!< CLK_T::PMUCTL: WKPINEN4 Position        */
+#define CLK_PMUCTL_WKPINEN4_Msk          (0x3ul << CLK_PMUCTL_WKPINEN4_Pos)                /*!< CLK_T::PMUCTL: WKPINEN4 Mask            */
+
+#define CLK_PMUSTS_PINWK0_Pos            (0)                                               /*!< CLK_T::PMUSTS: PINWK0 Position          */
+#define CLK_PMUSTS_PINWK0_Msk            (0x1ul << CLK_PMUSTS_PINWK0_Pos)                  /*!< CLK_T::PMUSTS: PINWK0 Mask              */
+
+#define CLK_PMUSTS_TMRWK_Pos             (1)                                               /*!< CLK_T::PMUSTS: TMRWK Position          */
+#define CLK_PMUSTS_TMRWK_Msk             (0x1ul << CLK_PMUSTS_TMRWK_Pos)                   /*!< CLK_T::PMUSTS: TMRWK Mask              */
+
+#define CLK_PMUSTS_RTCWK_Pos             (2)                                               /*!< CLK_T::PMUSTS: RTCWK Position          */
+#define CLK_PMUSTS_RTCWK_Msk             (0x1ul << CLK_PMUSTS_RTCWK_Pos)                   /*!< CLK_T::PMUSTS: RTCWK Mask              */
+
+#define CLK_PMUSTS_PINWK1_Pos            (3)                                               /*!< CLK_T::PMUSTS: PINWK1 Position          */
+#define CLK_PMUSTS_PINWK1_Msk            (0x1ul << CLK_PMUSTS_PINWK1_Pos)                  /*!< CLK_T::PMUSTS: PINWK1 Mask              */
+
+#define CLK_PMUSTS_PINWK2_Pos            (4)                                               /*!< CLK_T::PMUSTS: PINWK2 Position          */
+#define CLK_PMUSTS_PINWK2_Msk            (0x1ul << CLK_PMUSTS_PINWK2_Pos)                  /*!< CLK_T::PMUSTS: PINWK2 Mask              */
+
+#define CLK_PMUSTS_PINWK3_Pos            (5)                                               /*!< CLK_T::PMUSTS: PINWK3 Position          */
+#define CLK_PMUSTS_PINWK3_Msk            (0x1ul << CLK_PMUSTS_PINWK3_Pos)                  /*!< CLK_T::PMUSTS: PINWK3 Mask              */
+
+#define CLK_PMUSTS_PINWK4_Pos            (6)                                               /*!< CLK_T::PMUSTS: PINWK4 Position          */
+#define CLK_PMUSTS_PINWK4_Msk            (0x1ul << CLK_PMUSTS_PINWK4_Pos)                  /*!< CLK_T::PMUSTS: PINWK4 Mask              */
+
+#define CLK_PMUSTS_LVRWK_Pos             (12)                                              /*!< CLK_T::PMUSTS: LVRWK Position          */
+#define CLK_PMUSTS_LVRWK_Msk             (0x1ul << CLK_PMUSTS_LVRWK_Pos)                   /*!< CLK_T::PMUSTS: LVRWK Mask              */
+
+#define CLK_PMUSTS_CLRWK_Pos             (31)                                              /*!< CLK_T::PMUSTS: CLRWK Position          */
+#define CLK_PMUSTS_CLRWK_Msk             (0x1ul << CLK_PMUSTS_CLRWK_Pos)                   /*!< CLK_T::PMUSTS: CLRWK Mask              */
+
+#define CLK_HXTFSEL_HXTFSEL_Pos          (0)                                               /*!< CLK_T::HXTFSEL: HXTFSEL Position       */
+#define CLK_HXTFSEL_HXTFSEL_Msk          (0x1ul << CLK_HXTFSEL_HXTFSEL_Pos)                /*!< CLK_T::HXTFSEL: HXTFSEL Mask           */
+
+/** @} CLK_CONST */
+/** @} end of CLK register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __CLK_REG_H__ */

--- a/hal/m258ke/nuvoton/cmsis_armcc.h
+++ b/hal/m258ke/nuvoton/cmsis_armcc.h
@@ -1,0 +1,814 @@
+/**************************************************************************//**
+ * @file     cmsis_armcc.h
+ * @brief    CMSIS compiler ARMCC (ARM compiler V5) header file
+ * @version  V5.0.2
+ * @date     13. February 2017
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CMSIS_ARMCC_H
+#define __CMSIS_ARMCC_H
+
+
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 400677)
+  #error "Please use ARM Compiler Toolchain V4.0.677 or later!"
+#endif
+
+/* CMSIS compiler control architecture macros */
+#if ((defined (__TARGET_ARCH_6_M  ) && (__TARGET_ARCH_6_M   == 1)) || \
+     (defined (__TARGET_ARCH_6S_M ) && (__TARGET_ARCH_6S_M  == 1))   )
+  #define __ARM_ARCH_6M__           1
+#endif
+
+#if (defined (__TARGET_ARCH_7_M ) && (__TARGET_ARCH_7_M  == 1))
+  #define __ARM_ARCH_7M__           1
+#endif
+
+#if (defined (__TARGET_ARCH_7E_M) && (__TARGET_ARCH_7E_M == 1))
+  #define __ARM_ARCH_7EM__          1
+#endif
+
+  /* __ARM_ARCH_8M_BASE__  not applicable */
+  /* __ARM_ARCH_8M_MAIN__  not applicable */
+
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               __inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static __inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __declspec(noreturn)
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        __packed struct
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         __packed union
+#endif
+#ifndef   __UNALIGNED_UINT32        /* deprecated */
+  #define __UNALIGNED_UINT32(x)                  (*((__packed uint32_t *)(x)))
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    ((*((__packed uint16_t *)(addr))) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #define __UNALIGNED_UINT16_READ(addr)          (*((const __packed uint16_t *)(addr)))
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    ((*((__packed uint32_t *)(addr))) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #define __UNALIGNED_UINT32_READ(addr)          (*((const __packed uint32_t *)(addr)))
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+/* intrinsic void __enable_irq();     */
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+/* intrinsic void __disable_irq();    */
+
+/**
+  \brief   Get Control Register
+  \details Returns the content of the Control Register.
+  \return               Control Register value
+ */
+__STATIC_INLINE uint32_t __get_CONTROL(void)
+{
+  register uint32_t __regControl         __ASM("control");
+  return(__regControl);
+}
+
+
+/**
+  \brief   Set Control Register
+  \details Writes the given value to the Control Register.
+  \param [in]    control  Control Register value to set
+ */
+__STATIC_INLINE void __set_CONTROL(uint32_t control)
+{
+  register uint32_t __regControl         __ASM("control");
+  __regControl = control;
+}
+
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+__STATIC_INLINE uint32_t __get_IPSR(void)
+{
+  register uint32_t __regIPSR          __ASM("ipsr");
+  return(__regIPSR);
+}
+
+
+/**
+  \brief   Get APSR Register
+  \details Returns the content of the APSR Register.
+  \return               APSR Register value
+ */
+__STATIC_INLINE uint32_t __get_APSR(void)
+{
+  register uint32_t __regAPSR          __ASM("apsr");
+  return(__regAPSR);
+}
+
+
+/**
+  \brief   Get xPSR Register
+  \details Returns the content of the xPSR Register.
+  \return               xPSR Register value
+ */
+__STATIC_INLINE uint32_t __get_xPSR(void)
+{
+  register uint32_t __regXPSR          __ASM("xpsr");
+  return(__regXPSR);
+}
+
+
+/**
+  \brief   Get Process Stack Pointer
+  \details Returns the current value of the Process Stack Pointer (PSP).
+  \return               PSP Register value
+ */
+__STATIC_INLINE uint32_t __get_PSP(void)
+{
+  register uint32_t __regProcessStackPointer  __ASM("psp");
+  return(__regProcessStackPointer);
+}
+
+
+/**
+  \brief   Set Process Stack Pointer
+  \details Assigns the given value to the Process Stack Pointer (PSP).
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  register uint32_t __regProcessStackPointer  __ASM("psp");
+  __regProcessStackPointer = topOfProcStack;
+}
+
+
+/**
+  \brief   Get Main Stack Pointer
+  \details Returns the current value of the Main Stack Pointer (MSP).
+  \return               MSP Register value
+ */
+__STATIC_INLINE uint32_t __get_MSP(void)
+{
+  register uint32_t __regMainStackPointer     __ASM("msp");
+  return(__regMainStackPointer);
+}
+
+
+/**
+  \brief   Set Main Stack Pointer
+  \details Assigns the given value to the Main Stack Pointer (MSP).
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  register uint32_t __regMainStackPointer     __ASM("msp");
+  __regMainStackPointer = topOfMainStack;
+}
+
+
+/**
+  \brief   Get Priority Mask
+  \details Returns the current state of the priority mask bit from the Priority Mask Register.
+  \return               Priority Mask value
+ */
+__STATIC_INLINE uint32_t __get_PRIMASK(void)
+{
+  register uint32_t __regPriMask         __ASM("primask");
+  return(__regPriMask);
+}
+
+
+/**
+  \brief   Set Priority Mask
+  \details Assigns the given value to the Priority Mask Register.
+  \param [in]    priMask  Priority Mask
+ */
+__STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
+{
+  register uint32_t __regPriMask         __ASM("primask");
+  __regPriMask = (priMask);
+}
+
+
+#if ((defined (__ARM_ARCH_7M__ ) && (__ARM_ARCH_7M__  == 1)) || \
+     (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     )
+
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+#define __enable_fault_irq                __enable_fiq
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+#define __disable_fault_irq               __disable_fiq
+
+
+/**
+  \brief   Get Base Priority
+  \details Returns the current value of the Base Priority register.
+  \return               Base Priority register value
+ */
+__STATIC_INLINE uint32_t  __get_BASEPRI(void)
+{
+  register uint32_t __regBasePri         __ASM("basepri");
+  return(__regBasePri);
+}
+
+
+/**
+  \brief   Set Base Priority
+  \details Assigns the given value to the Base Priority register.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
+{
+  register uint32_t __regBasePri         __ASM("basepri");
+  __regBasePri = (basePri & 0xFFU);
+}
+
+
+/**
+  \brief   Set Base Priority with condition
+  \details Assigns the given value to the Base Priority register only if BASEPRI masking is disabled,
+           or the new value increases the BASEPRI priority level.
+  \param [in]    basePri  Base Priority value to set
+ */
+__STATIC_INLINE void __set_BASEPRI_MAX(uint32_t basePri)
+{
+  register uint32_t __regBasePriMax      __ASM("basepri_max");
+  __regBasePriMax = (basePri & 0xFFU);
+}
+
+
+/**
+  \brief   Get Fault Mask
+  \details Returns the current value of the Fault Mask register.
+  \return               Fault Mask register value
+ */
+__STATIC_INLINE uint32_t __get_FAULTMASK(void)
+{
+  register uint32_t __regFaultMask       __ASM("faultmask");
+  return(__regFaultMask);
+}
+
+
+/**
+  \brief   Set Fault Mask
+  \details Assigns the given value to the Fault Mask register.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  register uint32_t __regFaultMask       __ASM("faultmask");
+  __regFaultMask = (faultMask & (uint32_t)1U);
+}
+
+#endif /* ((defined (__ARM_ARCH_7M__ ) && (__ARM_ARCH_7M__  == 1)) || \
+           (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     ) */
+
+
+#if ((defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     )
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__STATIC_INLINE uint32_t __get_FPSCR(void)
+{
+#if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
+     (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
+  register uint32_t __regfpscr         __ASM("fpscr");
+  return(__regfpscr);
+#else
+   return(0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
+     (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
+  register uint32_t __regfpscr         __ASM("fpscr");
+  __regfpscr = (fpscr);
+#else
+  (void)fpscr;
+#endif
+}
+
+#endif /* ((defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     ) */
+
+
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP                             __nop
+
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI                             __wfi
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE                             __wfe
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV                             __sev
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+#define __ISB() do {\
+                   __schedule_barrier();\
+                   __isb(0xF);\
+                   __schedule_barrier();\
+                } while (0U)
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB() do {\
+                   __schedule_barrier();\
+                   __dsb(0xF);\
+                   __schedule_barrier();\
+                } while (0U)
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+#define __DMB() do {\
+                   __schedule_barrier();\
+                   __dmb(0xF);\
+                   __schedule_barrier();\
+                } while (0U)
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in integer value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV                             __rev
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in two unsigned short values.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#ifndef __NO_EMBEDDED_ASM
+__attribute__((section(".rev16_text"))) __STATIC_INLINE __ASM uint32_t __REV16(uint32_t value)
+{
+  rev16 r0, r0
+  bx lr
+}
+#endif
+
+
+/**
+  \brief   Reverse byte order in signed short value
+  \details Reverses the byte order in a signed short value with sign extension to integer.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#ifndef __NO_EMBEDDED_ASM
+__attribute__((section(".revsh_text"))) __STATIC_INLINE __ASM int32_t __REVSH(int32_t value)
+{
+  revsh r0, r0
+  bx lr
+}
+#endif
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+#define __ROR                             __ror
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)                       __breakpoint(value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#if ((defined (__ARM_ARCH_7M__ ) && (__ARM_ARCH_7M__  == 1)) || \
+     (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     )
+  #define __RBIT                          __rbit
+#else
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+  int32_t s = (4 /*sizeof(v)*/ * 8) - 1; /* extra shift needed at end */
+
+  result = value;                      /* r will be reversed bits of v; first get LSB of v */
+  for (value >>= 1U; value; value >>= 1U)
+  {
+    result <<= 1U;
+    result |= value & 1U;
+    s--;
+  }
+  result <<= s;                        /* shift when v's highest bits are zero */
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+#define __CLZ                             __clz
+
+
+#if ((defined (__ARM_ARCH_7M__ ) && (__ARM_ARCH_7M__  == 1)) || \
+     (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     )
+
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 5060020)
+  #define __LDREXB(ptr)                                                        ((uint8_t ) __ldrex(ptr))
+#else
+  #define __LDREXB(ptr)          _Pragma("push") _Pragma("diag_suppress 3731") ((uint8_t ) __ldrex(ptr))  _Pragma("pop")
+#endif
+
+
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 5060020)
+  #define __LDREXH(ptr)                                                        ((uint16_t) __ldrex(ptr))
+#else
+  #define __LDREXH(ptr)          _Pragma("push") _Pragma("diag_suppress 3731") ((uint16_t) __ldrex(ptr))  _Pragma("pop")
+#endif
+
+
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 5060020)
+  #define __LDREXW(ptr)                                                        ((uint32_t ) __ldrex(ptr))
+#else
+  #define __LDREXW(ptr)          _Pragma("push") _Pragma("diag_suppress 3731") ((uint32_t ) __ldrex(ptr))  _Pragma("pop")
+#endif
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 5060020)
+  #define __STREXB(value, ptr)                                                 __strex(value, ptr)
+#else
+  #define __STREXB(value, ptr)   _Pragma("push") _Pragma("diag_suppress 3731") __strex(value, ptr)        _Pragma("pop")
+#endif
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 5060020)
+  #define __STREXH(value, ptr)                                                 __strex(value, ptr)
+#else
+  #define __STREXH(value, ptr)   _Pragma("push") _Pragma("diag_suppress 3731") __strex(value, ptr)        _Pragma("pop")
+#endif
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION < 5060020)
+  #define __STREXW(value, ptr)                                                 __strex(value, ptr)
+#else
+  #define __STREXW(value, ptr)   _Pragma("push") _Pragma("diag_suppress 3731") __strex(value, ptr)        _Pragma("pop")
+#endif
+
+
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+#define __CLREX                           __clrex
+
+
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT                            __ssat
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT                            __usat
+
+
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+#ifndef __NO_EMBEDDED_ASM
+__attribute__((section(".rrx_text"))) __STATIC_INLINE __ASM uint32_t __RRX(uint32_t value)
+{
+  rrx r0, r0
+  bx lr
+}
+#endif
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define __LDRBT(ptr)                      ((uint8_t )  __ldrt(ptr))
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define __LDRHT(ptr)                      ((uint16_t)  __ldrt(ptr))
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define __LDRT(ptr)                       ((uint32_t ) __ldrt(ptr))
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+#define __STRBT(value, ptr)               __strt(value, ptr)
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+#define __STRHT(value, ptr)               __strt(value, ptr)
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+#define __STRT(value, ptr)                __strt(value, ptr)
+
+#endif /* ((defined (__ARM_ARCH_7M__ ) && (__ARM_ARCH_7M__  == 1)) || \
+           (defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     ) */
+
+/*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if ((defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     )
+
+#define __SADD8                           __sadd8
+#define __QADD8                           __qadd8
+#define __SHADD8                          __shadd8
+#define __UADD8                           __uadd8
+#define __UQADD8                          __uqadd8
+#define __UHADD8                          __uhadd8
+#define __SSUB8                           __ssub8
+#define __QSUB8                           __qsub8
+#define __SHSUB8                          __shsub8
+#define __USUB8                           __usub8
+#define __UQSUB8                          __uqsub8
+#define __UHSUB8                          __uhsub8
+#define __SADD16                          __sadd16
+#define __QADD16                          __qadd16
+#define __SHADD16                         __shadd16
+#define __UADD16                          __uadd16
+#define __UQADD16                         __uqadd16
+#define __UHADD16                         __uhadd16
+#define __SSUB16                          __ssub16
+#define __QSUB16                          __qsub16
+#define __SHSUB16                         __shsub16
+#define __USUB16                          __usub16
+#define __UQSUB16                         __uqsub16
+#define __UHSUB16                         __uhsub16
+#define __SASX                            __sasx
+#define __QASX                            __qasx
+#define __SHASX                           __shasx
+#define __UASX                            __uasx
+#define __UQASX                           __uqasx
+#define __UHASX                           __uhasx
+#define __SSAX                            __ssax
+#define __QSAX                            __qsax
+#define __SHSAX                           __shsax
+#define __USAX                            __usax
+#define __UQSAX                           __uqsax
+#define __UHSAX                           __uhsax
+#define __USAD8                           __usad8
+#define __USADA8                          __usada8
+#define __SSAT16                          __ssat16
+#define __USAT16                          __usat16
+#define __UXTB16                          __uxtb16
+#define __UXTAB16                         __uxtab16
+#define __SXTB16                          __sxtb16
+#define __SXTAB16                         __sxtab16
+#define __SMUAD                           __smuad
+#define __SMUADX                          __smuadx
+#define __SMLAD                           __smlad
+#define __SMLADX                          __smladx
+#define __SMLALD                          __smlald
+#define __SMLALDX                         __smlaldx
+#define __SMUSD                           __smusd
+#define __SMUSDX                          __smusdx
+#define __SMLSD                           __smlsd
+#define __SMLSDX                          __smlsdx
+#define __SMLSLD                          __smlsld
+#define __SMLSLDX                         __smlsldx
+#define __SEL                             __sel
+#define __QADD                            __qadd
+#define __QSUB                            __qsub
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+#define __SMMLA(ARG1,ARG2,ARG3)          ( (int32_t)((((int64_t)(ARG1) * (ARG2)) + \
+                                                      ((int64_t)(ARG3) << 32U)     ) >> 32U))
+
+#endif /* ((defined (__ARM_ARCH_7EM__) && (__ARM_ARCH_7EM__ == 1))     ) */
+/*@} end of group CMSIS_SIMD_intrinsics */
+
+
+#endif /* __CMSIS_ARMCC_H */

--- a/hal/m258ke/nuvoton/cmsis_armclang.h
+++ b/hal/m258ke/nuvoton/cmsis_armclang.h
@@ -1,0 +1,1802 @@
+/**************************************************************************//**
+ * @file     cmsis_armclang.h
+ * @brief    CMSIS compiler ARMCLANG (ARM compiler V6) header file
+ * @version  V5.0.3
+ * @date     27. March 2017
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*lint -esym(9058, IRQn)*/ /* disable MISRA 2012 Rule 2.4 for IRQn */
+
+#ifndef __CMSIS_ARMCLANG_H
+#define __CMSIS_ARMCLANG_H
+
+#ifndef __ARM_COMPAT_H
+#include <arm_compat.h>    /* Compatibility header for ARM Compiler 5 intrinsics */
+#endif
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               __inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static __inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((noreturn))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT32        /* deprecated */
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+/*lint -esym(9058, T_UINT32)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT32 */
+  struct __attribute__((packed)) T_UINT32 { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+/*lint -esym(9058, T_UINT16_WRITE)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT16_WRITE */
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+/*lint -esym(9058, T_UINT16_READ)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT16_READ */
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+/*lint -esym(9058, T_UINT32_WRITE)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT32_WRITE */
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wpacked"
+/*lint -esym(9058, T_UINT32_READ)*/ /* disable MISRA 2012 Rule 2.4 for T_UINT32_READ */
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma clang diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+/* intrinsic void __enable_irq();  see arm_compat.h */
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+/* intrinsic void __disable_irq();  see arm_compat.h */
+
+
+/**
+  \brief   Get Control Register
+  \details Returns the content of the Control Register.
+  \return               Control Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Control Register (non-secure)
+  \details Returns the content of the non-secure Control Register when in secure mode.
+  \return               non-secure Control Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_CONTROL_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Control Register
+  \details Writes the given value to the Control Register.
+  \param [in]    control  Control Register value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Control Register (non-secure)
+  \details Writes the given value to the non-secure Control Register when in secure state.
+  \param [in]    control  Control Register value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_CONTROL_NS(uint32_t control)
+{
+  __ASM volatile ("MSR control_ns, %0" : : "r" (control) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return(result);
+}
+
+
+/**
+  \brief   Get APSR Register
+  \details Returns the content of the APSR Register.
+  \return               APSR Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return(result);
+}
+
+
+/**
+  \brief   Get xPSR Register
+  \details Returns the content of the xPSR Register.
+  \return               xPSR Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return(result);
+}
+
+
+/**
+  \brief   Get Process Stack Pointer
+  \details Returns the current value of the Process Stack Pointer (PSP).
+  \return               PSP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_PSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Process Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
+  \return               PSP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_PSP_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer
+  \details Assigns the given value to the Process Stack Pointer (PSP).
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0" : : "r" (topOfProcStack) : );
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp_ns, %0" : : "r" (topOfProcStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer
+  \details Returns the current value of the Main Stack Pointer (MSP).
+  \return               MSP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_MSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Main Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
+  \return               MSP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_MSP_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer
+  \details Assigns the given value to the Main Stack Pointer (MSP).
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0" : : "r" (topOfMainStack) : );
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Main Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp_ns, %0" : : "r" (topOfMainStack) : );
+}
+#endif
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
+  \return               SP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_SP_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
+  return(result);
+}
+
+
+/**
+  \brief   Set Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Stack Pointer (SP) when in secure state.
+  \param [in]    topOfStack  Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_SP_NS(uint32_t topOfStack)
+{
+  __ASM volatile ("MSR sp_ns, %0" : : "r" (topOfStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Priority Mask
+  \details Returns the current state of the priority mask bit from the Priority Mask Register.
+  \return               Priority Mask value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Priority Mask (non-secure)
+  \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
+  \return               Priority Mask value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_PRIMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Priority Mask
+  \details Assigns the given value to the Priority Mask Register.
+  \param [in]    priMask  Priority Mask
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Priority Mask (non-secure)
+  \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
+  \param [in]    priMask  Priority Mask
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask_ns, %0" : : "r" (priMask) : "memory");
+}
+#endif
+
+
+#if ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+     (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+#define __enable_fault_irq                __enable_fiq   /* see arm_compat.h */
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+#define __disable_fault_irq               __disable_fiq   /* see arm_compat.h */
+
+
+/**
+  \brief   Get Base Priority
+  \details Returns the current value of the Base Priority register.
+  \return               Base Priority register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Base Priority (non-secure)
+  \details Returns the current value of the non-secure Base Priority register when in secure state.
+  \return               Base Priority register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_BASEPRI_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority
+  \details Assigns the given value to the Base Priority register.
+  \param [in]    basePri  Base Priority value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (basePri) : "memory");
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Base Priority (non-secure)
+  \details Assigns the given value to the non-secure Base Priority register when in secure state.
+  \param [in]    basePri  Base Priority value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_BASEPRI_NS(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_ns, %0" : : "r" (basePri) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority with condition
+  \details Assigns the given value to the Base Priority register only if BASEPRI masking is disabled,
+           or the new value increases the BASEPRI priority level.
+  \param [in]    basePri  Base Priority value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_BASEPRI_MAX(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_max, %0" : : "r" (basePri) : "memory");
+}
+
+
+/**
+  \brief   Get Fault Mask
+  \details Returns the current value of the Fault Mask register.
+  \return               Fault Mask register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Fault Mask (non-secure)
+  \details Returns the current value of the non-secure Fault Mask register when in secure state.
+  \return               Fault Mask register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_FAULTMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Fault Mask
+  \details Assigns the given value to the Fault Mask register.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Fault Mask (non-secure)
+  \details Assigns the given value to the non-secure Fault Mask register when in secure state.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask_ns, %0" : : "r" (faultMask) : "memory");
+}
+#endif
+
+#endif /* ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+           (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+           (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    ) */
+
+
+#if ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+
+/**
+  \brief   Get Process Stack Pointer Limit
+  \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
+  \return               PSPLIM Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_PSPLIM(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
+  return(result);
+}
+
+
+#if ((defined (__ARM_FEATURE_CMSE  ) && (__ARM_FEATURE_CMSE   == 3)) && \
+     (defined (__ARM_ARCH_8M_MAIN__) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Get Process Stack Pointer Limit (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \return               PSPLIM Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_PSPLIM_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer Limit
+  \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
+{
+  __ASM volatile ("MSR psplim, %0" : : "r" (ProcStackPtrLimit));
+}
+
+
+#if ((defined (__ARM_FEATURE_CMSE  ) && (__ARM_FEATURE_CMSE   == 3)) && \
+     (defined (__ARM_ARCH_8M_MAIN__) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
+{
+  __ASM volatile ("MSR psplim_ns, %0\n" : : "r" (ProcStackPtrLimit));
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer Limit
+  \details Returns the current value of the Main Stack Pointer Limit (MSPLIM).
+  \return               MSPLIM Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_MSPLIM(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msplim" : "=r" (result) );
+
+  return(result);
+}
+
+
+#if ((defined (__ARM_FEATURE_CMSE  ) && (__ARM_FEATURE_CMSE   == 3)) && \
+     (defined (__ARM_ARCH_8M_MAIN__) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Get Main Stack Pointer Limit (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer Limit(MSPLIM) when in secure state.
+  \return               MSPLIM Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_MSPLIM_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer Limit
+  \details Assigns the given value to the Main Stack Pointer Limit (MSPLIM).
+  \param [in]    MainStackPtrLimit  Main Stack Pointer Limit value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
+{
+  __ASM volatile ("MSR msplim, %0" : : "r" (MainStackPtrLimit));
+}
+
+
+#if ((defined (__ARM_FEATURE_CMSE  ) && (__ARM_FEATURE_CMSE   == 3)) && \
+     (defined (__ARM_ARCH_8M_MAIN__) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Set Main Stack Pointer Limit (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer Limit (MSPLIM) when in secure state.
+  \param [in]    MainStackPtrLimit  Main Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
+{
+  __ASM volatile ("MSR msplim_ns, %0" : : "r" (MainStackPtrLimit));
+}
+#endif
+
+#endif /* ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+           (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    ) */
+
+
+#if ((defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+/* #define __get_FPSCR      __builtin_arm_get_fpscr */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_FPSCR(void)
+{
+#if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
+     (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
+  uint32_t result;
+
+  __ASM volatile ("VMRS %0, fpscr" : "=r" (result) );
+  return(result);
+#else
+  return(0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+/* #define __set_FPSCR      __builtin_arm_set_fpscr */
+__attribute__((always_inline)) __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
+     (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
+  __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "memory");
+#else
+  (void)fpscr;
+#endif
+}
+
+#endif /* ((defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+           (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    ) */
+
+
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constraint "l"
+ * Otherwise, use general registers, specified by constraint "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+#define __NOP          __builtin_arm_nop
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+#define __WFI          __builtin_arm_wfi
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+#define __WFE          __builtin_arm_wfe
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+#define __SEV          __builtin_arm_sev
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+#define __ISB()        __builtin_arm_isb(0xF);
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+#define __DSB()        __builtin_arm_dsb(0xF);
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+#define __DMB()        __builtin_arm_dmb(0xF);
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in integer value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV          __builtin_bswap32
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in two unsigned short values.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+#define __REV16          __builtin_bswap16                /* ToDo ARMCLANG: check if __builtin_bswap16 could be used */
+#if 0
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __REV16(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rev16 %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Reverse byte order in signed short value
+  \details Reverses the byte order in a signed short value with sign extension to integer.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+                                                          /* ToDo ARMCLANG: check if __builtin_bswap16 could be used */
+__attribute__((always_inline)) __STATIC_INLINE int32_t __REVSH(int32_t value)
+{
+  int32_t result;
+
+  __ASM volatile ("revsh %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+}
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  return (op1 >> op2) | (op1 << (32U - op2));
+}
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)                       __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+                                                          /* ToDo ARMCLANG: check if __builtin_arm_rbit is supported */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+
+#if ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+     (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+   __ASM volatile ("rbit %0, %1" : "=r" (result) : "r" (value) );
+#else
+  int32_t s = (4 /*sizeof(v)*/ * 8) - 1; /* extra shift needed at end */
+
+  result = value;                      /* r will be reversed bits of v; first get LSB of v */
+  for (value >>= 1U; value; value >>= 1U)
+  {
+    result <<= 1U;
+    result |= value & 1U;
+    s--;
+  }
+  result <<= s;                        /* shift when v's highest bits are zero */
+#endif
+  return(result);
+}
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+#define __CLZ             __builtin_clz
+
+
+#if ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+     (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define __LDREXB        (uint8_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define __LDREXH        (uint16_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define __LDREXW        (uint32_t)__builtin_arm_ldrex
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXB        (uint32_t)__builtin_arm_strex
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXH        (uint32_t)__builtin_arm_strex
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define __STREXW        (uint32_t)__builtin_arm_strex
+
+
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+#define __CLREX             __builtin_arm_clrex
+
+#endif /* ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+           (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+           (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+           (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    ) */
+
+
+#if ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+     (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT             __builtin_arm_ssat
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT             __builtin_arm_usat
+
+
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return(result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("strbt %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("strht %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("strt %1, %0" : "=Q" (*ptr) : "r" (value) );
+}
+
+#endif /* ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+           (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+           (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    ) */
+
+
+#if ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+/**
+  \brief   Load-Acquire (8 bit)
+  \details Executes a LDAB instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint8_t __LDAB(volatile uint8_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldab %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint8_t) result);
+}
+
+
+/**
+  \brief   Load-Acquire (16 bit)
+  \details Executes a LDAH instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint16_t __LDAH(volatile uint16_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("ldah %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return ((uint16_t) result);
+}
+
+
+/**
+  \brief   Load-Acquire (32 bit)
+  \details Executes a LDA instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __LDA(volatile uint32_t *ptr)
+{
+  uint32_t result;
+
+  __ASM volatile ("lda %0, %1" : "=r" (result) : "Q" (*ptr) );
+  return(result);
+}
+
+
+/**
+  \brief   Store-Release (8 bit)
+  \details Executes a STLB instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STLB(uint8_t value, volatile uint8_t *ptr)
+{
+  __ASM volatile ("stlb %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   Store-Release (16 bit)
+  \details Executes a STLH instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STLH(uint16_t value, volatile uint16_t *ptr)
+{
+  __ASM volatile ("stlh %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   Store-Release (32 bit)
+  \details Executes a STL instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STL(uint32_t value, volatile uint32_t *ptr)
+{
+  __ASM volatile ("stl %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (8 bit)
+  \details Executes a LDAB exclusive instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+#define     __LDAEXB                 (uint8_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Load-Acquire Exclusive (16 bit)
+  \details Executes a LDAH exclusive instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+#define     __LDAEXH                 (uint16_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Load-Acquire Exclusive (32 bit)
+  \details Executes a LDA exclusive instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+#define     __LDAEX                  (uint32_t)__builtin_arm_ldaex
+
+
+/**
+  \brief   Store-Release Exclusive (8 bit)
+  \details Executes a STLB exclusive instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define     __STLEXB                 (uint32_t)__builtin_arm_stlex
+
+
+/**
+  \brief   Store-Release Exclusive (16 bit)
+  \details Executes a STLH exclusive instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define     __STLEXH                 (uint32_t)__builtin_arm_stlex
+
+
+/**
+  \brief   Store-Release Exclusive (32 bit)
+  \details Executes a STL exclusive instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+#define     __STLEX                  (uint32_t)__builtin_arm_stlex
+
+#endif /* ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+           (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    ) */
+
+/*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USAD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usad8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USADA8(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("usada8 %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+#define __SSAT16(ARG1,ARG2) \
+({                          \
+  int32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("ssat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+#define __USAT16(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("usat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMUAD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuad %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMUADX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuadx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMLAD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlad %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMLADX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smladx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint64_t __SMLALD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint64_t __SMLALDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMUSD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMUSDX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusdx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMLSD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsd %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMLSDX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsdx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint64_t __SMLSLD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint64_t __SMLSLDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SEL  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sel %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE  int32_t __QADD( int32_t op1,  int32_t op2)
+{
+  int32_t result;
+
+  __ASM volatile ("qadd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE  int32_t __QSUB( int32_t op1,  int32_t op2)
+{
+  int32_t result;
+
+  __ASM volatile ("qsub %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+#if 0
+#define __PKHBT(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+#endif
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+__attribute__((always_inline)) __STATIC_INLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+  int32_t result;
+
+  __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/*@} end of group CMSIS_SIMD_intrinsics */
+
+
+#endif /* __CMSIS_ARMCLANG_H */

--- a/hal/m258ke/nuvoton/cmsis_compiler.h
+++ b/hal/m258ke/nuvoton/cmsis_compiler.h
@@ -1,0 +1,353 @@
+/**************************************************************************//**
+ * @file     cmsis_compiler.h
+ * @brief    CMSIS compiler generic header file
+ * @version  V5.0.2
+ * @date     13. February 2017
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CMSIS_COMPILER_H
+#define __CMSIS_COMPILER_H
+
+#include <stdint.h>
+
+/*
+ * ARM Compiler 4/5
+ */
+#if   defined ( __CC_ARM )
+  #include "cmsis_armcc.h"
+
+
+/*
+ * ARM Compiler 6 (armclang)
+ */
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #include "cmsis_armclang.h"
+
+
+/*
+ * GNU Compiler
+ */
+#elif defined ( __GNUC__ )
+  #include "cmsis_gcc.h"
+
+
+/*
+ * IAR Compiler
+ */
+#elif defined ( __ICCARM__ )
+
+
+  #ifndef   __ASM
+    #define __ASM                                  __asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+
+  #include <cmsis_iar.h>
+
+  /* CMSIS compiler control architecture macros */
+  #if (__CORE__ == __ARM6M__) || (__CORE__ == __ARM6SM__)
+    #ifndef __ARM_ARCH_6M__
+      #define __ARM_ARCH_6M__                      1
+    #endif
+  #elif (__CORE__ == __ARM7M__)
+    #ifndef __ARM_ARCH_7M__
+      #define __ARM_ARCH_7M__                      1
+    #endif
+  #elif (__CORE__ == __ARM7EM__)
+    #ifndef __ARM_ARCH_7EM__
+      #define __ARM_ARCH_7EM__                     1
+    #endif
+  #endif
+
+  #ifndef   __NO_RETURN
+    #define __NO_RETURN                            __noreturn
+  #endif
+  #ifndef   __USED
+    #define __USED                                 __root
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __weak
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               __packed
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        __packed struct
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         __packed union
+  #endif
+  #ifndef   __UNALIGNED_UINT32        /* deprecated */
+    __packed struct T_UINT32 { uint32_t v; };
+    #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    //#warning No compiler specific solution for __ALIGNED. __ALIGNED is ignored.
+    #define __ALIGNED(x)
+  #endif
+  #ifndef   __RESTRICT
+    //#warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
+  #endif
+
+  // Workaround for missing __CLZ intrinsic in
+  // various versions of the IAR compilers.
+  // __IAR_FEATURE_CLZ__ should be defined by
+  // the compiler that supports __CLZ internally.
+  #if (defined (__ARM_ARCH_6M__)) && (__ARM_ARCH_6M__ == 1) && (!defined (__IAR_FEATURE_CLZ__))
+    __STATIC_INLINE uint32_t __CLZ(uint32_t data)
+    {
+      if (data == 0u) { return 32u; }
+      
+      uint32_t count = 0;
+      uint32_t mask = 0x80000000;
+      
+      while ((data & mask) == 0)
+      {
+        count += 1u;
+        mask = mask >> 1u;
+      }
+      
+      return (count);
+    }
+  #endif
+
+
+/*
+ * TI ARM Compiler
+ */
+#elif defined ( __TI_ARM__ )
+  #include <cmsis_ccs.h>
+
+  #ifndef   __ASM
+    #define __ASM                                  __asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __NO_RETURN
+    #define __NO_RETURN                            __attribute__((noreturn))
+  #endif
+  #ifndef   __USED
+    #define __USED                                 __attribute__((used))
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __attribute__((weak))
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               __attribute__((packed))
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        struct __attribute__((packed))
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __attribute__((packed))
+  #endif
+  #ifndef   __UNALIGNED_UINT32        /* deprecated */
+    struct __attribute__((packed)) T_UINT32 { uint32_t v; };
+    #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void*)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #define __ALIGNED(x)                           __attribute__((aligned(x)))
+  #endif
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
+  #endif
+
+
+/*
+ * TASKING Compiler
+ */
+#elif defined ( __TASKING__ )
+  /*
+   * The CMSIS functions have been implemented as intrinsics in the compiler.
+   * Please use "carm -?i" to get an up to date list of all intrinsics,
+   * Including the CMSIS ones.
+   */
+
+  #ifndef   __ASM
+    #define __ASM                                  __asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __NO_RETURN
+    #define __NO_RETURN                            __attribute__((noreturn))
+  #endif
+  #ifndef   __USED
+    #define __USED                                 __attribute__((used))
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __attribute__((weak))
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               __packed__
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        struct __packed__
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         union __packed__
+  #endif
+  #ifndef   __UNALIGNED_UINT32        /* deprecated */
+    struct __packed__ T_UINT32 { uint32_t v; };
+    #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #define __ALIGNED(x)              __align(x)
+  #endif
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
+  #endif
+
+
+/*
+ * COSMIC Compiler
+ */
+#elif defined ( __CSMC__ )
+   #include <cmsis_csm.h>
+
+ #ifndef   __ASM
+    #define __ASM                                  _asm
+  #endif
+  #ifndef   __INLINE
+    #define __INLINE                               inline
+  #endif
+  #ifndef   __STATIC_INLINE
+    #define __STATIC_INLINE                        static inline
+  #endif
+  #ifndef   __NO_RETURN
+    // NO RETURN is automatically detected hence no warning here
+    #define __NO_RETURN
+  #endif
+  #ifndef   __USED
+    #warning No compiler specific solution for __USED. __USED is ignored.
+    #define __USED
+  #endif
+  #ifndef   __WEAK
+    #define __WEAK                                 __weak
+  #endif
+  #ifndef   __PACKED
+    #define __PACKED                               @packed
+  #endif
+  #ifndef   __PACKED_STRUCT
+    #define __PACKED_STRUCT                        @packed struct
+  #endif
+  #ifndef   __PACKED_UNION
+    #define __PACKED_UNION                         @packed union
+  #endif
+  #ifndef   __UNALIGNED_UINT32        /* deprecated */
+    @packed struct T_UINT32 { uint32_t v; };
+    #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT16_WRITE
+    __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+    #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT16_READ
+    __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+    #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __UNALIGNED_UINT32_WRITE
+    __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+    #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+  #endif
+  #ifndef   __UNALIGNED_UINT32_READ
+    __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+    #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+  #endif
+  #ifndef   __ALIGNED
+    #warning No compiler specific solution for __ALIGNED. __ALIGNED is ignored.
+    #define __ALIGNED(x)
+  #endif
+  #ifndef   __RESTRICT
+    #warning No compiler specific solution for __RESTRICT. __RESTRICT is ignored.
+    #define __RESTRICT
+  #endif
+
+
+#else
+  #error Unknown compiler.
+#endif
+
+
+#endif /* __CMSIS_COMPILER_H */
+

--- a/hal/m258ke/nuvoton/cmsis_gcc.h
+++ b/hal/m258ke/nuvoton/cmsis_gcc.h
@@ -1,0 +1,1979 @@
+/**************************************************************************//**
+ * @file     cmsis_gcc.h
+ * @brief    CMSIS compiler GCC header file
+ * @version  V5.0.2
+ * @date     13. February 2017
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CMSIS_GCC_H
+#define __CMSIS_GCC_H
+
+/* ignore some GCC warnings */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+/* Fallback for __has_builtin */
+#ifndef __has_builtin
+  #define __has_builtin(x) (0)
+#endif
+
+/* CMSIS compiler specific defines */
+#ifndef   __ASM
+  #define __ASM                                  __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                               inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                        static inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                            __attribute__((noreturn))
+#endif
+#ifndef   __USED
+  #define __USED                                 __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                                 __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                               __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                        struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                         union __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __UNALIGNED_UINT32        /* deprecated */
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  struct __attribute__((packed)) T_UINT32 { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32(x)                  (((struct T_UINT32 *)(x))->v)
+#endif
+#ifndef   __UNALIGNED_UINT16_WRITE
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT16_WRITE { uint16_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT16_WRITE(addr, val)    (void)((((struct T_UINT16_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT16_READ
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT16_READ { uint16_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT16_READ(addr)          (((const struct T_UINT16_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __UNALIGNED_UINT32_WRITE
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT32_WRITE { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32_WRITE(addr, val)    (void)((((struct T_UINT32_WRITE *)(void *)(addr))->v) = (val))
+#endif
+#ifndef   __UNALIGNED_UINT32_READ
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wpacked"
+  #pragma GCC diagnostic ignored "-Wattributes"
+  __PACKED_STRUCT T_UINT32_READ { uint32_t v; };
+  #pragma GCC diagnostic pop
+  #define __UNALIGNED_UINT32_READ(addr)          (((const struct T_UINT32_READ *)(const void *)(addr))->v)
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                           __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                             __restrict
+#endif
+
+
+/* ###########################  Core Function Access  ########################### */
+/** \ingroup  CMSIS_Core_FunctionInterface
+    \defgroup CMSIS_Core_RegAccFunctions CMSIS Core Register Access Functions
+  @{
+ */
+
+/**
+  \brief   Enable IRQ Interrupts
+  \details Enables IRQ interrupts by clearing the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __enable_irq(void)
+{
+  __ASM volatile ("cpsie i" : : : "memory");
+}
+
+
+/**
+  \brief   Disable IRQ Interrupts
+  \details Disables IRQ interrupts by setting the I-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __disable_irq(void)
+{
+  __ASM volatile ("cpsid i" : : : "memory");
+}
+
+
+/**
+  \brief   Get Control Register
+  \details Returns the content of the Control Register.
+  \return               Control Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_CONTROL(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Control Register (non-secure)
+  \details Returns the content of the non-secure Control Register when in secure mode.
+  \return               non-secure Control Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_CONTROL_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, control_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Control Register
+  \details Writes the given value to the Control Register.
+  \param [in]    control  Control Register value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_CONTROL(uint32_t control)
+{
+  __ASM volatile ("MSR control, %0" : : "r" (control) : "memory");
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Control Register (non-secure)
+  \details Writes the given value to the non-secure Control Register when in secure state.
+  \param [in]    control  Control Register value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_CONTROL_NS(uint32_t control)
+{
+  __ASM volatile ("MSR control_ns, %0" : : "r" (control) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_IPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, ipsr" : "=r" (result) );
+  return(result);
+}
+
+
+/**
+  \brief   Get APSR Register
+  \details Returns the content of the APSR Register.
+  \return               APSR Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_APSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, apsr" : "=r" (result) );
+  return(result);
+}
+
+
+/**
+  \brief   Get xPSR Register
+  \details Returns the content of the xPSR Register.
+  \return               xPSR Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_xPSR(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, xpsr" : "=r" (result) );
+  return(result);
+}
+
+
+/**
+  \brief   Get Process Stack Pointer
+  \details Returns the current value of the Process Stack Pointer (PSP).
+  \return               PSP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_PSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psp"  : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Process Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer (PSP) when in secure state.
+  \return               PSP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_PSP_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psp_ns"  : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer
+  \details Assigns the given value to the Process Stack Pointer (PSP).
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp, %0" : : "r" (topOfProcStack) : );
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer (PSP) when in secure state.
+  \param [in]    topOfProcStack  Process Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_PSP_NS(uint32_t topOfProcStack)
+{
+  __ASM volatile ("MSR psp_ns, %0" : : "r" (topOfProcStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer
+  \details Returns the current value of the Main Stack Pointer (MSP).
+  \return               MSP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_MSP(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msp" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Main Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer (MSP) when in secure state.
+  \return               MSP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_MSP_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msp_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer
+  \details Assigns the given value to the Main Stack Pointer (MSP).
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp, %0" : : "r" (topOfMainStack) : );
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Main Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer (MSP) when in secure state.
+  \param [in]    topOfMainStack  Main Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_MSP_NS(uint32_t topOfMainStack)
+{
+  __ASM volatile ("MSR msp_ns, %0" : : "r" (topOfMainStack) : );
+}
+#endif
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Stack Pointer (non-secure)
+  \details Returns the current value of the non-secure Stack Pointer (SP) when in secure state.
+  \return               SP Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_SP_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, sp_ns" : "=r" (result) );
+  return(result);
+}
+
+
+/**
+  \brief   Set Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Stack Pointer (SP) when in secure state.
+  \param [in]    topOfStack  Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_SP_NS(uint32_t topOfStack)
+{
+  __ASM volatile ("MSR sp_ns, %0" : : "r" (topOfStack) : );
+}
+#endif
+
+
+/**
+  \brief   Get Priority Mask
+  \details Returns the current state of the priority mask bit from the Priority Mask Register.
+  \return               Priority Mask value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_PRIMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Priority Mask (non-secure)
+  \details Returns the current state of the non-secure priority mask bit from the Priority Mask Register when in secure state.
+  \return               Priority Mask value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_PRIMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, primask_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Priority Mask
+  \details Assigns the given value to the Priority Mask Register.
+  \param [in]    priMask  Priority Mask
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Priority Mask (non-secure)
+  \details Assigns the given value to the non-secure Priority Mask Register when in secure state.
+  \param [in]    priMask  Priority Mask
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_PRIMASK_NS(uint32_t priMask)
+{
+  __ASM volatile ("MSR primask_ns, %0" : : "r" (priMask) : "memory");
+}
+#endif
+
+
+#if ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+     (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Enable FIQ
+  \details Enables FIQ interrupts by clearing the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __enable_fault_irq(void)
+{
+  __ASM volatile ("cpsie f" : : : "memory");
+}
+
+
+/**
+  \brief   Disable FIQ
+  \details Disables FIQ interrupts by setting the F-bit in the CPSR.
+           Can only be executed in Privileged modes.
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __disable_fault_irq(void)
+{
+  __ASM volatile ("cpsid f" : : : "memory");
+}
+
+
+/**
+  \brief   Get Base Priority
+  \details Returns the current value of the Base Priority register.
+  \return               Base Priority register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_BASEPRI(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Base Priority (non-secure)
+  \details Returns the current value of the non-secure Base Priority register when in secure state.
+  \return               Base Priority register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_BASEPRI_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, basepri_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority
+  \details Assigns the given value to the Base Priority register.
+  \param [in]    basePri  Base Priority value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri, %0" : : "r" (basePri) : "memory");
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Base Priority (non-secure)
+  \details Assigns the given value to the non-secure Base Priority register when in secure state.
+  \param [in]    basePri  Base Priority value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_BASEPRI_NS(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_ns, %0" : : "r" (basePri) : "memory");
+}
+#endif
+
+
+/**
+  \brief   Set Base Priority with condition
+  \details Assigns the given value to the Base Priority register only if BASEPRI masking is disabled,
+           or the new value increases the BASEPRI priority level.
+  \param [in]    basePri  Base Priority value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_BASEPRI_MAX(uint32_t basePri)
+{
+  __ASM volatile ("MSR basepri_max, %0" : : "r" (basePri) : "memory");
+}
+
+
+/**
+  \brief   Get Fault Mask
+  \details Returns the current value of the Fault Mask register.
+  \return               Fault Mask register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_FAULTMASK(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask" : "=r" (result) );
+  return(result);
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Get Fault Mask (non-secure)
+  \details Returns the current value of the non-secure Fault Mask register when in secure state.
+  \return               Fault Mask register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_FAULTMASK_NS(void)
+{
+  uint32_t result;
+
+  __ASM volatile ("MRS %0, faultmask_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Fault Mask
+  \details Assigns the given value to the Fault Mask register.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask, %0" : : "r" (faultMask) : "memory");
+}
+
+
+#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
+/**
+  \brief   Set Fault Mask (non-secure)
+  \details Assigns the given value to the non-secure Fault Mask register when in secure state.
+  \param [in]    faultMask  Fault Mask value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_FAULTMASK_NS(uint32_t faultMask)
+{
+  __ASM volatile ("MSR faultmask_ns, %0" : : "r" (faultMask) : "memory");
+}
+#endif
+
+#endif /* ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+           (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+           (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    ) */
+
+
+#if ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+
+/**
+  \brief   Get Process Stack Pointer Limit
+  \details Returns the current value of the Process Stack Pointer Limit (PSPLIM).
+  \return               PSPLIM Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_PSPLIM(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psplim"  : "=r" (result) );
+  return(result);
+}
+
+
+#if ((defined (__ARM_FEATURE_CMSE  ) && (__ARM_FEATURE_CMSE   == 3)) && \
+     (defined (__ARM_ARCH_8M_MAIN__) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Get Process Stack Pointer Limit (non-secure)
+  \details Returns the current value of the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \return               PSPLIM Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_PSPLIM_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, psplim_ns"  : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Process Stack Pointer Limit
+  \details Assigns the given value to the Process Stack Pointer Limit (PSPLIM).
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_PSPLIM(uint32_t ProcStackPtrLimit)
+{
+  __ASM volatile ("MSR psplim, %0" : : "r" (ProcStackPtrLimit));
+}
+
+
+#if ((defined (__ARM_FEATURE_CMSE  ) && (__ARM_FEATURE_CMSE   == 3)) && \
+     (defined (__ARM_ARCH_8M_MAIN__) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Set Process Stack Pointer (non-secure)
+  \details Assigns the given value to the non-secure Process Stack Pointer Limit (PSPLIM) when in secure state.
+  \param [in]    ProcStackPtrLimit  Process Stack Pointer Limit value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_PSPLIM_NS(uint32_t ProcStackPtrLimit)
+{
+  __ASM volatile ("MSR psplim_ns, %0\n" : : "r" (ProcStackPtrLimit));
+}
+#endif
+
+
+/**
+  \brief   Get Main Stack Pointer Limit
+  \details Returns the current value of the Main Stack Pointer Limit (MSPLIM).
+  \return               MSPLIM Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_MSPLIM(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msplim" : "=r" (result) );
+
+  return(result);
+}
+
+
+#if ((defined (__ARM_FEATURE_CMSE  ) && (__ARM_FEATURE_CMSE   == 3)) && \
+     (defined (__ARM_ARCH_8M_MAIN__) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Get Main Stack Pointer Limit (non-secure)
+  \details Returns the current value of the non-secure Main Stack Pointer Limit(MSPLIM) when in secure state.
+  \return               MSPLIM Register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __TZ_get_MSPLIM_NS(void)
+{
+  register uint32_t result;
+
+  __ASM volatile ("MRS %0, msplim_ns" : "=r" (result) );
+  return(result);
+}
+#endif
+
+
+/**
+  \brief   Set Main Stack Pointer Limit
+  \details Assigns the given value to the Main Stack Pointer Limit (MSPLIM).
+  \param [in]    MainStackPtrLimit  Main Stack Pointer Limit value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_MSPLIM(uint32_t MainStackPtrLimit)
+{
+  __ASM volatile ("MSR msplim, %0" : : "r" (MainStackPtrLimit));
+}
+
+
+#if ((defined (__ARM_FEATURE_CMSE  ) && (__ARM_FEATURE_CMSE   == 3)) && \
+     (defined (__ARM_ARCH_8M_MAIN__) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Set Main Stack Pointer Limit (non-secure)
+  \details Assigns the given value to the non-secure Main Stack Pointer Limit (MSPLIM) when in secure state.
+  \param [in]    MainStackPtrLimit  Main Stack Pointer value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __TZ_set_MSPLIM_NS(uint32_t MainStackPtrLimit)
+{
+  __ASM volatile ("MSR msplim_ns, %0" : : "r" (MainStackPtrLimit));
+}
+#endif
+
+#endif /* ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+           (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    ) */
+
+
+#if ((defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+
+/**
+  \brief   Get FPSCR
+  \details Returns the current value of the Floating Point Status/Control register.
+  \return               Floating Point Status/Control register value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __get_FPSCR(void)
+{
+#if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
+     (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
+#if __has_builtin(__builtin_arm_get_fpscr) || (__GNUC__ > 7) || (__GNUC__ == 7 && __GNUC_MINOR__ >= 2)
+  /* see https://gcc.gnu.org/ml/gcc-patches/2017-04/msg00443.html */
+  return __builtin_arm_get_fpscr();
+#else
+  uint32_t result;
+
+  __ASM volatile ("VMRS %0, fpscr" : "=r" (result) );
+  return(result);
+#endif
+#else
+  return(0U);
+#endif
+}
+
+
+/**
+  \brief   Set FPSCR
+  \details Assigns the given value to the Floating Point Status/Control register.
+  \param [in]    fpscr  Floating Point Status/Control value to set
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
+{
+#if ((defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)) && \
+     (defined (__FPU_USED   ) && (__FPU_USED    == 1U))     )
+#if __has_builtin(__builtin_arm_set_fpscr) || (__GNUC__ > 7) || (__GNUC__ == 7 && __GNUC_MINOR__ >= 2)
+  /* see https://gcc.gnu.org/ml/gcc-patches/2017-04/msg00443.html */
+  __builtin_arm_set_fpscr(fpscr);
+#else
+  __ASM volatile ("VMSR fpscr, %0" : : "r" (fpscr) : "vfpcc", "memory");
+#endif
+#else
+  (void)fpscr;
+#endif
+}
+
+#endif /* ((defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+           (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    ) */
+
+
+
+/*@} end of CMSIS_Core_RegAccFunctions */
+
+
+/* ##########################  Core Instruction Access  ######################### */
+/** \defgroup CMSIS_Core_InstructionInterface CMSIS Core Instruction Interface
+  Access to dedicated instructions
+  @{
+*/
+
+/* Define macros for porting to both thumb1 and thumb2.
+ * For thumb1, use low register (r0-r7), specified by constraint "l"
+ * Otherwise, use general registers, specified by constraint "r" */
+#if defined (__thumb__) && !defined (__thumb2__)
+#define __CMSIS_GCC_OUT_REG(r) "=l" (r)
+#define __CMSIS_GCC_RW_REG(r) "+l" (r)
+#define __CMSIS_GCC_USE_REG(r) "l" (r)
+#else
+#define __CMSIS_GCC_OUT_REG(r) "=r" (r)
+#define __CMSIS_GCC_RW_REG(r) "+r" (r)
+#define __CMSIS_GCC_USE_REG(r) "r" (r)
+#endif
+
+/**
+  \brief   No Operation
+  \details No Operation does nothing. This instruction can be used for code alignment purposes.
+ */
+//__attribute__((always_inline)) __STATIC_INLINE void __NOP(void)
+//{
+//  __ASM volatile ("nop");
+//}
+#define __NOP()                             __ASM volatile ("nop")       /* This implementation generates debug information */
+
+/**
+  \brief   Wait For Interrupt
+  \details Wait For Interrupt is a hint instruction that suspends execution until one of a number of events occurs.
+ */
+//__attribute__((always_inline)) __STATIC_INLINE void __WFI(void)
+//{
+//  __ASM volatile ("wfi");
+//}
+#define __WFI()                             __ASM volatile ("wfi")       /* This implementation generates debug information */
+
+
+/**
+  \brief   Wait For Event
+  \details Wait For Event is a hint instruction that permits the processor to enter
+           a low-power state until one of a number of events occurs.
+ */
+//__attribute__((always_inline)) __STATIC_INLINE void __WFE(void)
+//{
+//  __ASM volatile ("wfe");
+//}
+#define __WFE()                             __ASM volatile ("wfe")       /* This implementation generates debug information */
+
+
+/**
+  \brief   Send Event
+  \details Send Event is a hint instruction. It causes an event to be signaled to the CPU.
+ */
+//__attribute__((always_inline)) __STATIC_INLINE void __SEV(void)
+//{
+//  __ASM volatile ("sev");
+//}
+#define __SEV()                             __ASM volatile ("sev")       /* This implementation generates debug information */
+
+
+/**
+  \brief   Instruction Synchronization Barrier
+  \details Instruction Synchronization Barrier flushes the pipeline in the processor,
+           so that all instructions following the ISB are fetched from cache or memory,
+           after the instruction has been completed.
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __ISB(void)
+{
+  __ASM volatile ("isb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Synchronization Barrier
+  \details Acts as a special kind of Data Memory Barrier.
+           It completes when all explicit memory accesses before this instruction complete.
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __DSB(void)
+{
+  __ASM volatile ("dsb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Data Memory Barrier
+  \details Ensures the apparent order of the explicit memory operations before
+           and after the instruction, without ensuring their completion.
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __DMB(void)
+{
+  __ASM volatile ("dmb 0xF":::"memory");
+}
+
+
+/**
+  \brief   Reverse byte order (32 bit)
+  \details Reverses the byte order in integer value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __REV(uint32_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+  return __builtin_bswap32(value);
+#else
+  uint32_t result;
+
+  __ASM volatile ("rev %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+#endif
+}
+
+
+/**
+  \brief   Reverse byte order (16 bit)
+  \details Reverses the byte order in two unsigned short values.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __REV16(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rev16 %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+}
+
+
+/**
+  \brief   Reverse byte order in signed short value
+  \details Reverses the byte order in a signed short value with sign extension to integer.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__attribute__((always_inline)) __STATIC_INLINE int32_t __REVSH(int32_t value)
+{
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+  return (short)__builtin_bswap16(value);
+#else
+  int32_t result;
+
+  __ASM volatile ("revsh %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+#endif
+}
+
+
+/**
+  \brief   Rotate Right in unsigned value (32 bit)
+  \details Rotate Right (immediate) provides the value of the contents of a register rotated by a variable number of bits.
+  \param [in]    op1  Value to rotate
+  \param [in]    op2  Number of Bits to rotate
+  \return               Rotated value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
+{
+  return (op1 >> op2) | (op1 << (32U - op2));
+}
+
+
+/**
+  \brief   Breakpoint
+  \details Causes the processor to enter Debug state.
+           Debug tools can use this to investigate system state when the instruction at a particular address is reached.
+  \param [in]    value  is ignored by the processor.
+                 If required, a debugger can use it to store additional information about the breakpoint.
+ */
+#define __BKPT(value)                       __ASM volatile ("bkpt "#value)
+
+
+/**
+  \brief   Reverse bit order of value
+  \details Reverses the bit order of the given value.
+  \param [in]    value  Value to reverse
+  \return               Reversed value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __RBIT(uint32_t value)
+{
+  uint32_t result;
+
+#if ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+     (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+   __ASM volatile ("rbit %0, %1" : "=r" (result) : "r" (value) );
+#else
+  int32_t s = (4 /*sizeof(v)*/ * 8) - 1; /* extra shift needed at end */
+
+  result = value;                      /* r will be reversed bits of v; first get LSB of v */
+  for (value >>= 1U; value; value >>= 1U)
+  {
+    result <<= 1U;
+    result |= value & 1U;
+    s--;
+  }
+  result <<= s;                        /* shift when v's highest bits are zero */
+#endif
+  return(result);
+}
+
+
+/**
+  \brief   Count leading zeros
+  \details Counts the number of leading zeros of a data value.
+  \param [in]  value  Value to count the leading zeros
+  \return             number of leading zeros in value
+ */
+#define __CLZ             __builtin_clz
+
+
+#if ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+     (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+/**
+  \brief   LDR Exclusive (8 bit)
+  \details Executes a exclusive LDR instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint8_t __LDREXB(volatile uint8_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrexb %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrexb %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDR Exclusive (16 bit)
+  \details Executes a exclusive LDR instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint16_t __LDREXH(volatile uint16_t *addr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrexh %0, %1" : "=r" (result) : "Q" (*addr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrexh %0, [%1]" : "=r" (result) : "r" (addr) : "memory" );
+#endif
+   return ((uint16_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDR Exclusive (32 bit)
+  \details Executes a exclusive LDR instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __LDREXW(volatile uint32_t *addr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrex %0, %1" : "=r" (result) : "Q" (*addr) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (8 bit)
+  \details Executes a exclusive STR instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __STREXB(uint8_t value, volatile uint8_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexb %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (16 bit)
+  \details Executes a exclusive STR instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __STREXH(uint16_t value, volatile uint16_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strexh %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/**
+  \brief   STR Exclusive (32 bit)
+  \details Executes a exclusive STR instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __STREXW(uint32_t value, volatile uint32_t *addr)
+{
+   uint32_t result;
+
+   __ASM volatile ("strex %0, %2, %1" : "=&r" (result), "=Q" (*addr) : "r" (value) );
+   return(result);
+}
+
+
+/**
+  \brief   Remove the exclusive lock
+  \details Removes the exclusive lock which is created by LDREX.
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __CLREX(void)
+{
+  __ASM volatile ("clrex" ::: "memory");
+}
+
+#endif /* ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+           (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+           (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+           (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    ) */
+
+
+#if ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+     (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+     (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    )
+/**
+  \brief   Signed Saturate
+  \details Saturates a signed value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (1..32)
+  \return             Saturated value
+ */
+#define __SSAT(ARG1,ARG2) \
+({                          \
+  int32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("ssat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+
+/**
+  \brief   Unsigned Saturate
+  \details Saturates an unsigned value.
+  \param [in]  value  Value to be saturated
+  \param [in]    sat  Bit position to saturate to (0..31)
+  \return             Saturated value
+ */
+#define __USAT(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("usat %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+
+/**
+  \brief   Rotate Right with Extend (32 bit)
+  \details Moves each bit of a bitstring right by one bit.
+           The carry input is shifted in at the left end of the bitstring.
+  \param [in]    value  Value to rotate
+  \return               Rotated value
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __RRX(uint32_t value)
+{
+  uint32_t result;
+
+  __ASM volatile ("rrx %0, %1" : __CMSIS_GCC_OUT_REG (result) : __CMSIS_GCC_USE_REG (value) );
+  return(result);
+}
+
+
+/**
+  \brief   LDRT Unprivileged (8 bit)
+  \details Executes a Unprivileged LDRT instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint8_t __LDRBT(volatile uint8_t *ptr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrbt %0, %1" : "=r" (result) : "Q" (*ptr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrbt %0, [%1]" : "=r" (result) : "r" (ptr) : "memory" );
+#endif
+   return ((uint8_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (16 bit)
+  \details Executes a Unprivileged LDRT instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint16_t __LDRHT(volatile uint16_t *ptr)
+{
+    uint32_t result;
+
+#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+   __ASM volatile ("ldrht %0, %1" : "=r" (result) : "Q" (*ptr) );
+#else
+    /* Prior to GCC 4.8, "Q" will be expanded to [rx, #0] which is not
+       accepted by assembler. So has to use following less efficient pattern.
+    */
+   __ASM volatile ("ldrht %0, [%1]" : "=r" (result) : "r" (ptr) : "memory" );
+#endif
+   return ((uint16_t) result);    /* Add explicit type cast here */
+}
+
+
+/**
+  \brief   LDRT Unprivileged (32 bit)
+  \details Executes a Unprivileged LDRT instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __LDRT(volatile uint32_t *ptr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldrt %0, %1" : "=r" (result) : "Q" (*ptr) );
+   return(result);
+}
+
+
+/**
+  \brief   STRT Unprivileged (8 bit)
+  \details Executes a Unprivileged STRT instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STRBT(uint8_t value, volatile uint8_t *ptr)
+{
+   __ASM volatile ("strbt %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (16 bit)
+  \details Executes a Unprivileged STRT instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STRHT(uint16_t value, volatile uint16_t *ptr)
+{
+   __ASM volatile ("strht %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   STRT Unprivileged (32 bit)
+  \details Executes a Unprivileged STRT instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STRT(uint32_t value, volatile uint32_t *ptr)
+{
+   __ASM volatile ("strt %1, %0" : "=Q" (*ptr) : "r" (value) );
+}
+
+#endif /* ((defined (__ARM_ARCH_7M__      ) && (__ARM_ARCH_7M__      == 1)) || \
+           (defined (__ARM_ARCH_7EM__     ) && (__ARM_ARCH_7EM__     == 1)) || \
+           (defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1))    ) */
+
+
+#if ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+     (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    )
+/**
+  \brief   Load-Acquire (8 bit)
+  \details Executes a LDAB instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint8_t __LDAB(volatile uint8_t *ptr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldab %0, %1" : "=r" (result) : "Q" (*ptr) );
+   return ((uint8_t) result);
+}
+
+
+/**
+  \brief   Load-Acquire (16 bit)
+  \details Executes a LDAH instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint16_t __LDAH(volatile uint16_t *ptr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldah %0, %1" : "=r" (result) : "Q" (*ptr) );
+   return ((uint16_t) result);
+}
+
+
+/**
+  \brief   Load-Acquire (32 bit)
+  \details Executes a LDA instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __LDA(volatile uint32_t *ptr)
+{
+    uint32_t result;
+
+   __ASM volatile ("lda %0, %1" : "=r" (result) : "Q" (*ptr) );
+   return(result);
+}
+
+
+/**
+  \brief   Store-Release (8 bit)
+  \details Executes a STLB instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STLB(uint8_t value, volatile uint8_t *ptr)
+{
+   __ASM volatile ("stlb %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   Store-Release (16 bit)
+  \details Executes a STLH instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STLH(uint16_t value, volatile uint16_t *ptr)
+{
+   __ASM volatile ("stlh %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   Store-Release (32 bit)
+  \details Executes a STL instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+ */
+__attribute__((always_inline)) __STATIC_INLINE void __STL(uint32_t value, volatile uint32_t *ptr)
+{
+   __ASM volatile ("stl %1, %0" : "=Q" (*ptr) : "r" ((uint32_t)value) );
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (8 bit)
+  \details Executes a LDAB exclusive instruction for 8 bit value.
+  \param [in]    ptr  Pointer to data
+  \return             value of type uint8_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint8_t __LDAEXB(volatile uint8_t *ptr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldaexb %0, %1" : "=r" (result) : "Q" (*ptr) );
+   return ((uint8_t) result);
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (16 bit)
+  \details Executes a LDAH exclusive instruction for 16 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint16_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint16_t __LDAEXH(volatile uint16_t *ptr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldaexh %0, %1" : "=r" (result) : "Q" (*ptr) );
+   return ((uint16_t) result);
+}
+
+
+/**
+  \brief   Load-Acquire Exclusive (32 bit)
+  \details Executes a LDA exclusive instruction for 32 bit values.
+  \param [in]    ptr  Pointer to data
+  \return        value of type uint32_t at (*ptr)
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __LDAEX(volatile uint32_t *ptr)
+{
+    uint32_t result;
+
+   __ASM volatile ("ldaex %0, %1" : "=r" (result) : "Q" (*ptr) );
+   return(result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (8 bit)
+  \details Executes a STLB exclusive instruction for 8 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __STLEXB(uint8_t value, volatile uint8_t *ptr)
+{
+   uint32_t result;
+
+   __ASM volatile ("stlexb %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (16 bit)
+  \details Executes a STLH exclusive instruction for 16 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __STLEXH(uint16_t value, volatile uint16_t *ptr)
+{
+   uint32_t result;
+
+   __ASM volatile ("stlexh %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+
+/**
+  \brief   Store-Release Exclusive (32 bit)
+  \details Executes a STL exclusive instruction for 32 bit values.
+  \param [in]  value  Value to store
+  \param [in]    ptr  Pointer to location
+  \return          0  Function succeeded
+  \return          1  Function failed
+ */
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __STLEX(uint32_t value, volatile uint32_t *ptr)
+{
+   uint32_t result;
+
+   __ASM volatile ("stlex %0, %2, %1" : "=&r" (result), "=Q" (*ptr) : "r" ((uint32_t)value) );
+   return(result);
+}
+
+#endif /* ((defined (__ARM_ARCH_8M_MAIN__ ) && (__ARM_ARCH_8M_MAIN__ == 1)) || \
+           (defined (__ARM_ARCH_8M_BASE__ ) && (__ARM_ARCH_8M_BASE__ == 1))    ) */
+
+/*@}*/ /* end of group CMSIS_Core_InstructionInterface */
+
+
+/* ###################  Compiler specific Intrinsics  ########################### */
+/** \defgroup CMSIS_SIMD_intrinsics CMSIS SIMD Intrinsics
+  Access to dedicated SIMD instructions
+  @{
+*/
+
+#if (__ARM_FEATURE_DSP == 1)                             /* ToDo ARMCLANG: This should be ARCH >= ARMv7-M + SIMD */
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHADD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHSUB8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHADD16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhadd16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHSUB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsub16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHASX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhasx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("ssax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __QSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("qsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("shsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UQSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uqsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UHSAX(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uhsax %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USAD8(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("usad8 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __USADA8(uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("usada8 %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+#define __SSAT16(ARG1,ARG2) \
+({                          \
+  int32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("ssat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+#define __USAT16(ARG1,ARG2) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1); \
+  __ASM ("usat16 %0, %1, %2" : "=r" (__RES) :  "I" (ARG2), "r" (__ARG1) ); \
+  __RES; \
+ })
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __UXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("uxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SXTB16(uint32_t op1)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtb16 %0, %1" : "=r" (result) : "r" (op1));
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SXTAB16(uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sxtab16 %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMUAD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuad %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMUADX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smuadx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMLAD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlad %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMLADX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smladx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint64_t __SMLALD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlald %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint64_t __SMLALDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlaldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMUSD  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMUSDX (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("smusdx %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMLSD (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsd %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SMLSDX (uint32_t op1, uint32_t op2, uint32_t op3)
+{
+  uint32_t result;
+
+  __ASM volatile ("smlsdx %0, %1, %2, %3" : "=r" (result) : "r" (op1), "r" (op2), "r" (op3) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint64_t __SMLSLD (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlsld %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint64_t __SMLSLDX (uint32_t op1, uint32_t op2, uint64_t acc)
+{
+  union llreg_u{
+    uint32_t w32[2];
+    uint64_t w64;
+  } llr;
+  llr.w64 = acc;
+
+#ifndef __ARMEB__   /* Little endian */
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (llr.w32[0]), "=r" (llr.w32[1]): "r" (op1), "r" (op2) , "0" (llr.w32[0]), "1" (llr.w32[1]) );
+#else               /* Big endian */
+  __ASM volatile ("smlsldx %0, %1, %2, %3" : "=r" (llr.w32[1]), "=r" (llr.w32[0]): "r" (op1), "r" (op2) , "0" (llr.w32[1]), "1" (llr.w32[0]) );
+#endif
+
+  return(llr.w64);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE uint32_t __SEL  (uint32_t op1, uint32_t op2)
+{
+  uint32_t result;
+
+  __ASM volatile ("sel %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE  int32_t __QADD( int32_t op1,  int32_t op2)
+{
+  int32_t result;
+
+  __ASM volatile ("qadd %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+__attribute__((always_inline)) __STATIC_INLINE  int32_t __QSUB( int32_t op1,  int32_t op2)
+{
+  int32_t result;
+
+  __ASM volatile ("qsub %0, %1, %2" : "=r" (result) : "r" (op1), "r" (op2) );
+  return(result);
+}
+
+#if 0
+#define __PKHBT(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  __ASM ("pkhbt %0, %1, %2, lsl %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+
+#define __PKHTB(ARG1,ARG2,ARG3) \
+({                          \
+  uint32_t __RES, __ARG1 = (ARG1), __ARG2 = (ARG2); \
+  if (ARG3 == 0) \
+    __ASM ("pkhtb %0, %1, %2" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2)  ); \
+  else \
+    __ASM ("pkhtb %0, %1, %2, asr %3" : "=r" (__RES) :  "r" (__ARG1), "r" (__ARG2), "I" (ARG3)  ); \
+  __RES; \
+ })
+#endif
+
+#define __PKHBT(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0x0000FFFFUL) |  \
+                                           ((((uint32_t)(ARG2)) << (ARG3)) & 0xFFFF0000UL)  )
+
+#define __PKHTB(ARG1,ARG2,ARG3)          ( ((((uint32_t)(ARG1))          ) & 0xFFFF0000UL) |  \
+                                           ((((uint32_t)(ARG2)) >> (ARG3)) & 0x0000FFFFUL)  )
+
+__attribute__((always_inline)) __STATIC_INLINE int32_t __SMMLA (int32_t op1, int32_t op2, int32_t op3)
+{
+ int32_t result;
+
+ __ASM volatile ("smmla %0, %1, %2, %3" : "=r" (result): "r"  (op1), "r" (op2), "r" (op3) );
+ return(result);
+}
+
+#endif /* (__ARM_FEATURE_DSP == 1) */
+/*@} end of group CMSIS_SIMD_intrinsics */
+
+
+#pragma GCC diagnostic pop
+
+#endif /* __CMSIS_GCC_H */

--- a/hal/m258ke/nuvoton/cmsis_version.h
+++ b/hal/m258ke/nuvoton/cmsis_version.h
@@ -1,0 +1,39 @@
+/**************************************************************************//**
+ * @file     cmsis_version.h
+ * @brief    CMSIS Core(M) Version definitions
+ * @version  V5.0.2
+ * @date     19. April 2017
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if   defined ( __ICCARM__ )
+ #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifndef __CMSIS_VERSION_H
+#define __CMSIS_VERSION_H
+
+/*  CMSIS Version definitions */
+#define __CM_CMSIS_VERSION_MAIN  ( 5U)                                      /*!< [31:16] CMSIS Core(M) main version */
+#define __CM_CMSIS_VERSION_SUB   ( 0U)                                      /*!< [15:0]  CMSIS Core(M) sub version */
+#define __CM_CMSIS_VERSION       ((__CM_CMSIS_VERSION_MAIN << 16U) | \
+                                   __CM_CMSIS_VERSION_SUB           )       /*!< CMSIS Core(M) version number */
+#endif

--- a/hal/m258ke/nuvoton/core_cm23.h
+++ b/hal/m258ke/nuvoton/core_cm23.h
@@ -1,0 +1,1878 @@
+/**************************************************************************//**
+ * @file     core_cm23.h
+ * @brief    CMSIS Cortex-M23 Core Peripheral Access Layer Header File
+ * @version  V5.0.2
+ * @date     19. April 2017
+ ******************************************************************************/
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if   defined ( __ICCARM__ )
+ #pragma system_include         /* treat file as system include file for MISRA check */
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang system_header   /* treat file as system include file */
+#endif
+
+#ifndef __CORE_CM23_H_GENERIC
+#define __CORE_CM23_H_GENERIC
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
+ */
+
+
+/*******************************************************************************
+ *                 CMSIS definitions
+ ******************************************************************************/
+/**
+  \ingroup Cortex_M23
+  @{
+ */
+
+#include "cmsis_version.h"
+
+/*  CMSIS definitions */
+#define __CM23_CMSIS_VERSION_MAIN  (__CM_CMSIS_VERSION_MAIN)                   /*!< \deprecated [31:16] CMSIS HAL main version */
+#define __CM23_CMSIS_VERSION_SUB   (__CM_CMSIS_VERSION_SUB)                    /*!< \deprecated [15:0]  CMSIS HAL sub version */
+#define __CM23_CMSIS_VERSION       ((__CM23_CMSIS_VERSION_MAIN << 16U) | \
+                                     __CM23_CMSIS_VERSION_SUB           )      /*!< \deprecated CMSIS HAL version number */
+
+#define __CORTEX_M                     (23U)                                   /*!< Cortex-M Core */
+
+/** __FPU_USED indicates whether an FPU is used or not.
+    This core does not support an FPU at all
+*/
+#define __FPU_USED       0U
+
+#if defined ( __CC_ARM )
+  #if defined __TARGET_FPU_VFP
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined __ARM_PCS_VFP
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined __ARMVFP__
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined __TI_VFP_SUPPORT__
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined __FPU_VFP__
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM23_H_GENERIC */
+
+#ifndef __CMSIS_GENERIC
+
+#ifndef __CORE_CM23_H_DEPENDANT
+#define __CORE_CM23_H_DEPENDANT
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/* check device defines and use defaults */
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM23_REV
+    #define __CM23_REV                0x0000U
+    #warning "__CM23_REV not defined in device header file; using default!"
+  #endif
+
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT            0U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          2U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
+
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+
+  #ifndef __ETM_PRESENT
+    #define __ETM_PRESENT             0U
+    #warning "__ETM_PRESENT not defined in device header file; using default!"
+  #endif
+
+  #ifndef __MTB_PRESENT
+    #define __MTB_PRESENT             0U
+    #warning "__MTB_PRESENT not defined in device header file; using default!"
+  #endif
+
+#endif
+
+/* IO definitions (access restrictions to peripheral registers) */
+/**
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+
+/* following defines should be used for structure members */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+
+/*@} end of group Cortex_M23 */
+
+
+
+/*******************************************************************************
+ *                 Register Abstraction
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core MPU Register
+  - Core SAU Register
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
+ */
+
+/**
+  \brief  Union type to access the Application Program Status Register (APSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:28;              /*!< bit:  0..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
+
+/* APSR Register Definitions */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+
+
+/**
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
+
+/* IPSR Register Definitions */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:15;              /*!< bit:  9..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t _reserved1:3;               /*!< bit: 25..27  Reserved */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
+
+/* xPSR Register Definitions */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+
+
+/**
+  \brief  Union type to access the Control Registers (CONTROL).
+ */
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t _reserved1:30;              /*!< bit:  2..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
+
+/* CONTROL Register Definitions */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+
+/*@} end of group CMSIS_CORE */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ */
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RSERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint32_t IPR[124U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register */
+}  NVIC_Type;
+
+/*@} end of group CMSIS_NVIC */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Control Block (SCB).
+ */
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+#else
+        uint32_t RESERVED0;
+#endif
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+        uint32_t RESERVED1;
+  __IOM uint32_t SHPR[2U];               /*!< Offset: 0x01C (R/W)  System Handlers Priority Registers. [0] is RESERVED */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+} SCB_Type;
+
+/* SCB CPUID Register Definitions */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+
+/* SCB Interrupt Control State Register Definitions */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+/* SCB Vector Table Offset Register Definitions */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+#endif
+
+/* SCB Application Interrupt and Reset Control Register Definitions */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+
+/* SCB System Control Register Definitions */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+
+/* SCB Configuration Control Register Definitions */
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+
+/* SCB System Handler Control and State Register Definitions */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+
+/*@} end of group CMSIS_SCB */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
+ */
+
+/**
+  \brief  Structure type to access the System Timer (SysTick).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
+
+/* SysTick Control / Status Register Definitions */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+
+/* SysTick Reload Register Definitions */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+
+/* SysTick Current Register Definitions */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+
+/* SysTick Calibration Register Definitions */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+
+/*@} end of group CMSIS_SysTick */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+        uint32_t RESERVED0[6U];
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+        uint32_t RESERVED8[1U];
+  __IOM uint32_t COMP4;                  /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+        uint32_t RESERVED9[1U];
+  __IOM uint32_t FUNCTION4;              /*!< Offset: 0x068 (R/W)  Function Register 4 */
+        uint32_t RESERVED10[1U];
+  __IOM uint32_t COMP5;                  /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+        uint32_t RESERVED11[1U];
+  __IOM uint32_t FUNCTION5;              /*!< Offset: 0x078 (R/W)  Function Register 5 */
+        uint32_t RESERVED12[1U];
+  __IOM uint32_t COMP6;                  /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+        uint32_t RESERVED13[1U];
+  __IOM uint32_t FUNCTION6;              /*!< Offset: 0x088 (R/W)  Function Register 6 */
+        uint32_t RESERVED14[1U];
+  __IOM uint32_t COMP7;                  /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+        uint32_t RESERVED15[1U];
+  __IOM uint32_t FUNCTION7;              /*!< Offset: 0x098 (R/W)  Function Register 7 */
+        uint32_t RESERVED16[1U];
+  __IOM uint32_t COMP8;                  /*!< Offset: 0x0A0 (R/W)  Comparator Register 8 */
+        uint32_t RESERVED17[1U];
+  __IOM uint32_t FUNCTION8;              /*!< Offset: 0x0A8 (R/W)  Function Register 8 */
+        uint32_t RESERVED18[1U];
+  __IOM uint32_t COMP9;                  /*!< Offset: 0x0B0 (R/W)  Comparator Register 9 */
+        uint32_t RESERVED19[1U];
+  __IOM uint32_t FUNCTION9;              /*!< Offset: 0x0B8 (R/W)  Function Register 9 */
+        uint32_t RESERVED20[1U];
+  __IOM uint32_t COMP10;                 /*!< Offset: 0x0C0 (R/W)  Comparator Register 10 */
+        uint32_t RESERVED21[1U];
+  __IOM uint32_t FUNCTION10;             /*!< Offset: 0x0C8 (R/W)  Function Register 10 */
+        uint32_t RESERVED22[1U];
+  __IOM uint32_t COMP11;                 /*!< Offset: 0x0D0 (R/W)  Comparator Register 11 */
+        uint32_t RESERVED23[1U];
+  __IOM uint32_t FUNCTION11;             /*!< Offset: 0x0D8 (R/W)  Function Register 11 */
+        uint32_t RESERVED24[1U];
+  __IOM uint32_t COMP12;                 /*!< Offset: 0x0E0 (R/W)  Comparator Register 12 */
+        uint32_t RESERVED25[1U];
+  __IOM uint32_t FUNCTION12;             /*!< Offset: 0x0E8 (R/W)  Function Register 12 */
+        uint32_t RESERVED26[1U];
+  __IOM uint32_t COMP13;                 /*!< Offset: 0x0F0 (R/W)  Comparator Register 13 */
+        uint32_t RESERVED27[1U];
+  __IOM uint32_t FUNCTION13;             /*!< Offset: 0x0F8 (R/W)  Function Register 13 */
+        uint32_t RESERVED28[1U];
+  __IOM uint32_t COMP14;                 /*!< Offset: 0x100 (R/W)  Comparator Register 14 */
+        uint32_t RESERVED29[1U];
+  __IOM uint32_t FUNCTION14;             /*!< Offset: 0x108 (R/W)  Function Register 14 */
+        uint32_t RESERVED30[1U];
+  __IOM uint32_t COMP15;                 /*!< Offset: 0x110 (R/W)  Comparator Register 15 */
+        uint32_t RESERVED31[1U];
+  __IOM uint32_t FUNCTION15;             /*!< Offset: 0x118 (R/W)  Function Register 15 */
+} DWT_Type;
+
+/* DWT Control Register Definitions */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (0x1UL << DWT_CTRL_NOTRCPKT_Pos)            /*!< DWT CTRL: NOTRCPKT Mask */
+
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (0x1UL << DWT_CTRL_NOEXTTRIG_Pos)           /*!< DWT CTRL: NOEXTTRIG Mask */
+
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (0x1UL << DWT_CTRL_NOCYCCNT_Pos)            /*!< DWT CTRL: NOCYCCNT Mask */
+
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (0x1UL << DWT_CTRL_NOPRFCNT_Pos)            /*!< DWT CTRL: NOPRFCNT Mask */
+
+/* DWT Comparator Function Register Definitions */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (0x1UL << DWT_FUNCTION_MATCHED_Pos)         /*!< DWT FUNCTION: MATCHED Mask */
+
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+
+/*@}*/ /* end of group CMSIS_DWT */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPI     Trace Port Interface (TPI)
+  \brief    Type definitions for the Trace Port Interface (TPI)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Trace Port Interface Register (TPI).
+ */
+typedef struct
+{
+  __IOM uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Size Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Size Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IM  uint32_t FSCR;                   /*!< Offset: 0x308 (R/ )  Formatter Synchronization Counter Register */
+        uint32_t RESERVED3[759U];
+  __IM  uint32_t TRIGGER;                /*!< Offset: 0xEE8 (R/ )  TRIGGER */
+  __IM  uint32_t FIFO0;                  /*!< Offset: 0xEEC (R/ )  Integration ETM Data */
+  __IM  uint32_t ITATBCTR2;              /*!< Offset: 0xEF0 (R/ )  ITATBCTR2 */
+        uint32_t RESERVED4[1U];
+  __IM  uint32_t ITATBCTR0;              /*!< Offset: 0xEF8 (R/ )  ITATBCTR0 */
+  __IM  uint32_t FIFO1;                  /*!< Offset: 0xEFC (R/ )  Integration ITM Data */
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  Integration Mode Control */
+        uint32_t RESERVED5[39U];
+  __IOM uint32_t CLAIMSET;               /*!< Offset: 0xFA0 (R/W)  Claim tag set */
+  __IOM uint32_t CLAIMCLR;               /*!< Offset: 0xFA4 (R/W)  Claim tag clear */
+        uint32_t RESERVED7[8U];
+  __IM  uint32_t DEVID;                  /*!< Offset: 0xFC8 (R/ )  TPIU_DEVID */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  TPIU_DEVTYPE */
+} TPI_Type;
+
+/* TPI Asynchronous Clock Prescaler Register Definitions */
+#define TPI_ACPR_PRESCALER_Pos              0U                                         /*!< TPI ACPR: PRESCALER Position */
+#define TPI_ACPR_PRESCALER_Msk             (0x1FFFUL /*<< TPI_ACPR_PRESCALER_Pos*/)    /*!< TPI ACPR: PRESCALER Mask */
+
+/* TPI Selected Pin Protocol Register Definitions */
+#define TPI_SPPR_TXMODE_Pos                 0U                                         /*!< TPI SPPR: TXMODE Position */
+#define TPI_SPPR_TXMODE_Msk                (0x3UL /*<< TPI_SPPR_TXMODE_Pos*/)          /*!< TPI SPPR: TXMODE Mask */
+
+/* TPI Formatter and Flush Status Register Definitions */
+#define TPI_FFSR_FtNonStop_Pos              3U                                         /*!< TPI FFSR: FtNonStop Position */
+#define TPI_FFSR_FtNonStop_Msk             (0x1UL << TPI_FFSR_FtNonStop_Pos)           /*!< TPI FFSR: FtNonStop Mask */
+
+#define TPI_FFSR_TCPresent_Pos              2U                                         /*!< TPI FFSR: TCPresent Position */
+#define TPI_FFSR_TCPresent_Msk             (0x1UL << TPI_FFSR_TCPresent_Pos)           /*!< TPI FFSR: TCPresent Mask */
+
+#define TPI_FFSR_FtStopped_Pos              1U                                         /*!< TPI FFSR: FtStopped Position */
+#define TPI_FFSR_FtStopped_Msk             (0x1UL << TPI_FFSR_FtStopped_Pos)           /*!< TPI FFSR: FtStopped Mask */
+
+#define TPI_FFSR_FlInProg_Pos               0U                                         /*!< TPI FFSR: FlInProg Position */
+#define TPI_FFSR_FlInProg_Msk              (0x1UL /*<< TPI_FFSR_FlInProg_Pos*/)        /*!< TPI FFSR: FlInProg Mask */
+
+/* TPI Formatter and Flush Control Register Definitions */
+#define TPI_FFCR_TrigIn_Pos                 8U                                         /*!< TPI FFCR: TrigIn Position */
+#define TPI_FFCR_TrigIn_Msk                (0x1UL << TPI_FFCR_TrigIn_Pos)              /*!< TPI FFCR: TrigIn Mask */
+
+#define TPI_FFCR_EnFCont_Pos                1U                                         /*!< TPI FFCR: EnFCont Position */
+#define TPI_FFCR_EnFCont_Msk               (0x1UL << TPI_FFCR_EnFCont_Pos)             /*!< TPI FFCR: EnFCont Mask */
+
+/* TPI TRIGGER Register Definitions */
+#define TPI_TRIGGER_TRIGGER_Pos             0U                                         /*!< TPI TRIGGER: TRIGGER Position */
+#define TPI_TRIGGER_TRIGGER_Msk            (0x1UL /*<< TPI_TRIGGER_TRIGGER_Pos*/)      /*!< TPI TRIGGER: TRIGGER Mask */
+
+/* TPI Integration ETM Data Register Definitions (FIFO0) */
+#define TPI_FIFO0_ITM_ATVALID_Pos          29U                                         /*!< TPI FIFO0: ITM_ATVALID Position */
+#define TPI_FIFO0_ITM_ATVALID_Msk          (0x3UL << TPI_FIFO0_ITM_ATVALID_Pos)        /*!< TPI FIFO0: ITM_ATVALID Mask */
+
+#define TPI_FIFO0_ITM_bytecount_Pos        27U                                         /*!< TPI FIFO0: ITM_bytecount Position */
+#define TPI_FIFO0_ITM_bytecount_Msk        (0x3UL << TPI_FIFO0_ITM_bytecount_Pos)      /*!< TPI FIFO0: ITM_bytecount Mask */
+
+#define TPI_FIFO0_ETM_ATVALID_Pos          26U                                         /*!< TPI FIFO0: ETM_ATVALID Position */
+#define TPI_FIFO0_ETM_ATVALID_Msk          (0x3UL << TPI_FIFO0_ETM_ATVALID_Pos)        /*!< TPI FIFO0: ETM_ATVALID Mask */
+
+#define TPI_FIFO0_ETM_bytecount_Pos        24U                                         /*!< TPI FIFO0: ETM_bytecount Position */
+#define TPI_FIFO0_ETM_bytecount_Msk        (0x3UL << TPI_FIFO0_ETM_bytecount_Pos)      /*!< TPI FIFO0: ETM_bytecount Mask */
+
+#define TPI_FIFO0_ETM2_Pos                 16U                                         /*!< TPI FIFO0: ETM2 Position */
+#define TPI_FIFO0_ETM2_Msk                 (0xFFUL << TPI_FIFO0_ETM2_Pos)              /*!< TPI FIFO0: ETM2 Mask */
+
+#define TPI_FIFO0_ETM1_Pos                  8U                                         /*!< TPI FIFO0: ETM1 Position */
+#define TPI_FIFO0_ETM1_Msk                 (0xFFUL << TPI_FIFO0_ETM1_Pos)              /*!< TPI FIFO0: ETM1 Mask */
+
+#define TPI_FIFO0_ETM0_Pos                  0U                                         /*!< TPI FIFO0: ETM0 Position */
+#define TPI_FIFO0_ETM0_Msk                 (0xFFUL /*<< TPI_FIFO0_ETM0_Pos*/)          /*!< TPI FIFO0: ETM0 Mask */
+
+/* TPI ITATBCTR2 Register Definitions */
+#define TPI_ITATBCTR2_ATREADY_Pos           0U                                         /*!< TPI ITATBCTR2: ATREADY Position */
+#define TPI_ITATBCTR2_ATREADY_Msk          (0x1UL /*<< TPI_ITATBCTR2_ATREADY_Pos*/)    /*!< TPI ITATBCTR2: ATREADY Mask */
+
+/* TPI Integration ITM Data Register Definitions (FIFO1) */
+#define TPI_FIFO1_ITM_ATVALID_Pos          29U                                         /*!< TPI FIFO1: ITM_ATVALID Position */
+#define TPI_FIFO1_ITM_ATVALID_Msk          (0x3UL << TPI_FIFO1_ITM_ATVALID_Pos)        /*!< TPI FIFO1: ITM_ATVALID Mask */
+
+#define TPI_FIFO1_ITM_bytecount_Pos        27U                                         /*!< TPI FIFO1: ITM_bytecount Position */
+#define TPI_FIFO1_ITM_bytecount_Msk        (0x3UL << TPI_FIFO1_ITM_bytecount_Pos)      /*!< TPI FIFO1: ITM_bytecount Mask */
+
+#define TPI_FIFO1_ETM_ATVALID_Pos          26U                                         /*!< TPI FIFO1: ETM_ATVALID Position */
+#define TPI_FIFO1_ETM_ATVALID_Msk          (0x3UL << TPI_FIFO1_ETM_ATVALID_Pos)        /*!< TPI FIFO1: ETM_ATVALID Mask */
+
+#define TPI_FIFO1_ETM_bytecount_Pos        24U                                         /*!< TPI FIFO1: ETM_bytecount Position */
+#define TPI_FIFO1_ETM_bytecount_Msk        (0x3UL << TPI_FIFO1_ETM_bytecount_Pos)      /*!< TPI FIFO1: ETM_bytecount Mask */
+
+#define TPI_FIFO1_ITM2_Pos                 16U                                         /*!< TPI FIFO1: ITM2 Position */
+#define TPI_FIFO1_ITM2_Msk                 (0xFFUL << TPI_FIFO1_ITM2_Pos)              /*!< TPI FIFO1: ITM2 Mask */
+
+#define TPI_FIFO1_ITM1_Pos                  8U                                         /*!< TPI FIFO1: ITM1 Position */
+#define TPI_FIFO1_ITM1_Msk                 (0xFFUL << TPI_FIFO1_ITM1_Pos)              /*!< TPI FIFO1: ITM1 Mask */
+
+#define TPI_FIFO1_ITM0_Pos                  0U                                         /*!< TPI FIFO1: ITM0 Position */
+#define TPI_FIFO1_ITM0_Msk                 (0xFFUL /*<< TPI_FIFO1_ITM0_Pos*/)          /*!< TPI FIFO1: ITM0 Mask */
+
+/* TPI ITATBCTR0 Register Definitions */
+#define TPI_ITATBCTR0_ATREADY_Pos           0U                                         /*!< TPI ITATBCTR0: ATREADY Position */
+#define TPI_ITATBCTR0_ATREADY_Msk          (0x1UL /*<< TPI_ITATBCTR0_ATREADY_Pos*/)    /*!< TPI ITATBCTR0: ATREADY Mask */
+
+/* TPI Integration Mode Control Register Definitions */
+#define TPI_ITCTRL_Mode_Pos                 0U                                         /*!< TPI ITCTRL: Mode Position */
+#define TPI_ITCTRL_Mode_Msk                (0x1UL /*<< TPI_ITCTRL_Mode_Pos*/)          /*!< TPI ITCTRL: Mode Mask */
+
+/* TPI DEVID Register Definitions */
+#define TPI_DEVID_NRZVALID_Pos             11U                                         /*!< TPI DEVID: NRZVALID Position */
+#define TPI_DEVID_NRZVALID_Msk             (0x1UL << TPI_DEVID_NRZVALID_Pos)           /*!< TPI DEVID: NRZVALID Mask */
+
+#define TPI_DEVID_MANCVALID_Pos            10U                                         /*!< TPI DEVID: MANCVALID Position */
+#define TPI_DEVID_MANCVALID_Msk            (0x1UL << TPI_DEVID_MANCVALID_Pos)          /*!< TPI DEVID: MANCVALID Mask */
+
+#define TPI_DEVID_PTINVALID_Pos             9U                                         /*!< TPI DEVID: PTINVALID Position */
+#define TPI_DEVID_PTINVALID_Msk            (0x1UL << TPI_DEVID_PTINVALID_Pos)          /*!< TPI DEVID: PTINVALID Mask */
+
+#define TPI_DEVID_MinBufSz_Pos              6U                                         /*!< TPI DEVID: MinBufSz Position */
+#define TPI_DEVID_MinBufSz_Msk             (0x7UL << TPI_DEVID_MinBufSz_Pos)           /*!< TPI DEVID: MinBufSz Mask */
+
+#define TPI_DEVID_AsynClkIn_Pos             5U                                         /*!< TPI DEVID: AsynClkIn Position */
+#define TPI_DEVID_AsynClkIn_Msk            (0x1UL << TPI_DEVID_AsynClkIn_Pos)          /*!< TPI DEVID: AsynClkIn Mask */
+
+#define TPI_DEVID_NrTraceInput_Pos          0U                                         /*!< TPI DEVID: NrTraceInput Position */
+#define TPI_DEVID_NrTraceInput_Msk         (0x1FUL /*<< TPI_DEVID_NrTraceInput_Pos*/)  /*!< TPI DEVID: NrTraceInput Mask */
+
+/* TPI DEVTYPE Register Definitions */
+#define TPI_DEVTYPE_MajorType_Pos           4U                                         /*!< TPI DEVTYPE: MajorType Position */
+#define TPI_DEVTYPE_MajorType_Msk          (0xFUL << TPI_DEVTYPE_MajorType_Pos)        /*!< TPI DEVTYPE: MajorType Mask */
+
+#define TPI_DEVTYPE_SubType_Pos             0U                                         /*!< TPI DEVTYPE: SubType Position */
+#define TPI_DEVTYPE_SubType_Msk            (0xFUL /*<< TPI_DEVTYPE_SubType_Pos*/)      /*!< TPI DEVTYPE: SubType Mask */
+
+/*@}*/ /* end of group CMSIS_TPI */
+
+
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Memory Protection Unit (MPU).
+ */
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+        uint32_t RESERVED0[7U];
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+} MPU_Type;
+
+/* MPU Type Register Definitions */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+
+/* MPU Control Register Definitions */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+
+/* MPU Region Number Register Definitions */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+
+/* MPU Region Base Address Register Definitions */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+
+/* MPU Region Limit Address Register Definitions */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (0x7UL << MPU_RLAR_AttrIndx_Pos)               /*!< MPU RLAR: AttrIndx Mask */
+
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: EN Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: EN Mask */
+
+/* MPU Memory Attribute Indirection Register 0 Definitions */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+
+/* MPU Memory Attribute Indirection Register 1 Definitions */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+
+/*@} end of group CMSIS_MPU */
+#endif
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Security Attribution Unit (SAU).
+ */
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#endif
+} SAU_Type;
+
+/* SAU Control Register Definitions */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+
+/* SAU Type Register Definitions */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+/* SAU Region Number Register Definitions */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+
+/* SAU Region Base Address Register Definitions */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+
+/* SAU Region Limit Address Register Definitions */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+
+/*@} end of group CMSIS_SAU */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+  \brief    Type definitions for the Core Debug Registers
+  @{
+ */
+
+/**
+  \brief  Structure type to access the Core Debug Register (CoreDebug).
+ */
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} CoreDebug_Type;
+
+/* Debug Halting Control and Status Register Definitions */
+#define CoreDebug_DHCSR_DBGKEY_Pos         16U                                            /*!< CoreDebug DHCSR: DBGKEY Position */
+#define CoreDebug_DHCSR_DBGKEY_Msk         (0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos)       /*!< CoreDebug DHCSR: DBGKEY Mask */
+
+#define CoreDebug_DHCSR_S_RESTART_ST_Pos   26U                                            /*!< CoreDebug DHCSR: S_RESTART_ST Position */
+#define CoreDebug_DHCSR_S_RESTART_ST_Msk   (1UL << CoreDebug_DHCSR_S_RESTART_ST_Pos)      /*!< CoreDebug DHCSR: S_RESTART_ST Mask */
+
+#define CoreDebug_DHCSR_S_RESET_ST_Pos     25U                                            /*!< CoreDebug DHCSR: S_RESET_ST Position */
+#define CoreDebug_DHCSR_S_RESET_ST_Msk     (1UL << CoreDebug_DHCSR_S_RESET_ST_Pos)        /*!< CoreDebug DHCSR: S_RESET_ST Mask */
+
+#define CoreDebug_DHCSR_S_RETIRE_ST_Pos    24U                                            /*!< CoreDebug DHCSR: S_RETIRE_ST Position */
+#define CoreDebug_DHCSR_S_RETIRE_ST_Msk    (1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos)       /*!< CoreDebug DHCSR: S_RETIRE_ST Mask */
+
+#define CoreDebug_DHCSR_S_LOCKUP_Pos       19U                                            /*!< CoreDebug DHCSR: S_LOCKUP Position */
+#define CoreDebug_DHCSR_S_LOCKUP_Msk       (1UL << CoreDebug_DHCSR_S_LOCKUP_Pos)          /*!< CoreDebug DHCSR: S_LOCKUP Mask */
+
+#define CoreDebug_DHCSR_S_SLEEP_Pos        18U                                            /*!< CoreDebug DHCSR: S_SLEEP Position */
+#define CoreDebug_DHCSR_S_SLEEP_Msk        (1UL << CoreDebug_DHCSR_S_SLEEP_Pos)           /*!< CoreDebug DHCSR: S_SLEEP Mask */
+
+#define CoreDebug_DHCSR_S_HALT_Pos         17U                                            /*!< CoreDebug DHCSR: S_HALT Position */
+#define CoreDebug_DHCSR_S_HALT_Msk         (1UL << CoreDebug_DHCSR_S_HALT_Pos)            /*!< CoreDebug DHCSR: S_HALT Mask */
+
+#define CoreDebug_DHCSR_S_REGRDY_Pos       16U                                            /*!< CoreDebug DHCSR: S_REGRDY Position */
+#define CoreDebug_DHCSR_S_REGRDY_Msk       (1UL << CoreDebug_DHCSR_S_REGRDY_Pos)          /*!< CoreDebug DHCSR: S_REGRDY Mask */
+
+#define CoreDebug_DHCSR_C_MASKINTS_Pos      3U                                            /*!< CoreDebug DHCSR: C_MASKINTS Position */
+#define CoreDebug_DHCSR_C_MASKINTS_Msk     (1UL << CoreDebug_DHCSR_C_MASKINTS_Pos)        /*!< CoreDebug DHCSR: C_MASKINTS Mask */
+
+#define CoreDebug_DHCSR_C_STEP_Pos          2U                                            /*!< CoreDebug DHCSR: C_STEP Position */
+#define CoreDebug_DHCSR_C_STEP_Msk         (1UL << CoreDebug_DHCSR_C_STEP_Pos)            /*!< CoreDebug DHCSR: C_STEP Mask */
+
+#define CoreDebug_DHCSR_C_HALT_Pos          1U                                            /*!< CoreDebug DHCSR: C_HALT Position */
+#define CoreDebug_DHCSR_C_HALT_Msk         (1UL << CoreDebug_DHCSR_C_HALT_Pos)            /*!< CoreDebug DHCSR: C_HALT Mask */
+
+#define CoreDebug_DHCSR_C_DEBUGEN_Pos       0U                                            /*!< CoreDebug DHCSR: C_DEBUGEN Position */
+#define CoreDebug_DHCSR_C_DEBUGEN_Msk      (1UL /*<< CoreDebug_DHCSR_C_DEBUGEN_Pos*/)     /*!< CoreDebug DHCSR: C_DEBUGEN Mask */
+
+/* Debug Core Register Selector Register Definitions */
+#define CoreDebug_DCRSR_REGWnR_Pos         16U                                            /*!< CoreDebug DCRSR: REGWnR Position */
+#define CoreDebug_DCRSR_REGWnR_Msk         (1UL << CoreDebug_DCRSR_REGWnR_Pos)            /*!< CoreDebug DCRSR: REGWnR Mask */
+
+#define CoreDebug_DCRSR_REGSEL_Pos          0U                                            /*!< CoreDebug DCRSR: REGSEL Position */
+#define CoreDebug_DCRSR_REGSEL_Msk         (0x1FUL /*<< CoreDebug_DCRSR_REGSEL_Pos*/)     /*!< CoreDebug DCRSR: REGSEL Mask */
+
+/* Debug Exception and Monitor Control Register */
+#define CoreDebug_DEMCR_DWTENA_Pos         24U                                            /*!< CoreDebug DEMCR: DWTENA Position */
+#define CoreDebug_DEMCR_DWTENA_Msk         (1UL << CoreDebug_DEMCR_DWTENA_Pos)            /*!< CoreDebug DEMCR: DWTENA Mask */
+
+#define CoreDebug_DEMCR_VC_HARDERR_Pos     10U                                            /*!< CoreDebug DEMCR: VC_HARDERR Position */
+#define CoreDebug_DEMCR_VC_HARDERR_Msk     (1UL << CoreDebug_DEMCR_VC_HARDERR_Pos)        /*!< CoreDebug DEMCR: VC_HARDERR Mask */
+
+#define CoreDebug_DEMCR_VC_CORERESET_Pos    0U                                            /*!< CoreDebug DEMCR: VC_CORERESET Position */
+#define CoreDebug_DEMCR_VC_CORERESET_Msk   (1UL /*<< CoreDebug_DEMCR_VC_CORERESET_Pos*/)  /*!< CoreDebug DEMCR: VC_CORERESET Mask */
+
+/* Debug Authentication Control Register Definitions */
+#define CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos  3U                                            /*!< CoreDebug DAUTHCTRL: INTSPNIDEN, Position */
+#define CoreDebug_DAUTHCTRL_INTSPNIDEN_Msk (1UL << CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos)    /*!< CoreDebug DAUTHCTRL: INTSPNIDEN, Mask */
+
+#define CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos  2U                                            /*!< CoreDebug DAUTHCTRL: SPNIDENSEL Position */
+#define CoreDebug_DAUTHCTRL_SPNIDENSEL_Msk (1UL << CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos)    /*!< CoreDebug DAUTHCTRL: SPNIDENSEL Mask */
+
+#define CoreDebug_DAUTHCTRL_INTSPIDEN_Pos   1U                                            /*!< CoreDebug DAUTHCTRL: INTSPIDEN Position */
+#define CoreDebug_DAUTHCTRL_INTSPIDEN_Msk  (1UL << CoreDebug_DAUTHCTRL_INTSPIDEN_Pos)     /*!< CoreDebug DAUTHCTRL: INTSPIDEN Mask */
+
+#define CoreDebug_DAUTHCTRL_SPIDENSEL_Pos   0U                                            /*!< CoreDebug DAUTHCTRL: SPIDENSEL Position */
+#define CoreDebug_DAUTHCTRL_SPIDENSEL_Msk  (1UL /*<< CoreDebug_DAUTHCTRL_SPIDENSEL_Pos*/) /*!< CoreDebug DAUTHCTRL: SPIDENSEL Mask */
+
+/* Debug Security Control and Status Register Definitions */
+#define CoreDebug_DSCSR_CDS_Pos            16U                                            /*!< CoreDebug DSCSR: CDS Position */
+#define CoreDebug_DSCSR_CDS_Msk            (1UL << CoreDebug_DSCSR_CDS_Pos)               /*!< CoreDebug DSCSR: CDS Mask */
+
+#define CoreDebug_DSCSR_SBRSEL_Pos          1U                                            /*!< CoreDebug DSCSR: SBRSEL Position */
+#define CoreDebug_DSCSR_SBRSEL_Msk         (1UL << CoreDebug_DSCSR_SBRSEL_Pos)            /*!< CoreDebug DSCSR: SBRSEL Mask */
+
+#define CoreDebug_DSCSR_SBRSELEN_Pos        0U                                            /*!< CoreDebug DSCSR: SBRSELEN Position */
+#define CoreDebug_DSCSR_SBRSELEN_Msk       (1UL /*<< CoreDebug_DSCSR_SBRSELEN_Pos*/)      /*!< CoreDebug DSCSR: SBRSELEN Mask */
+
+/*@} end of group CMSIS_CoreDebug */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
+ */
+
+/**
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+
+/**
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+
+/*@} end of group CMSIS_core_bitfield */
+
+
+/**
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
+ */
+
+/* Memory mapping of Core Hardware */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define TPI_BASE            (0xE0040000UL)                             /*!< TPI Base Address */
+  #define CoreDebug_BASE      (0xE000EDF0UL)                             /*!< Core Debug Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+
+
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPI                 ((TPI_Type       *)     TPI_BASE         ) /*!< TPI configuration struct */
+  #define CoreDebug           ((CoreDebug_Type *)     CoreDebug_BASE   ) /*!< Core Debug configuration struct */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
+
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define CoreDebug_BASE_NS   (0xE002EDF0UL)                             /*!< Core Debug Base Address           (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define CoreDebug_NS        ((CoreDebug_Type *)     CoreDebug_BASE_NS) /*!< Core Debug configuration struct   (non-secure address space) */
+
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+/*@} */
+
+
+
+/*******************************************************************************
+ *                Hardware Abstraction Layer
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Register Access Functions
+ ******************************************************************************/
+/**
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
+
+
+
+/* ##########################   NVIC functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
+ */
+
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+/*#define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping   not available for Cortex-M23 */
+/*#define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping   not available for Cortex-M23 */
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
+
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+
+#define NVIC_USER_IRQ_OFFSET          16
+
+
+/* Interrupt Priorities are WORD accessible only under ARMv6M                   */
+/* The following MACROS handle generation of the register offset and byte masks */
+#define _BIT_SHIFT(IRQn)         (  ((((uint32_t)(int32_t)(IRQn))         )      &  0x03UL) * 8UL)
+#define _SHP_IDX(IRQn)           ( (((((uint32_t)(int32_t)(IRQn)) & 0x0FUL)-8UL) >>    2UL)      )
+#define _IP_IDX(IRQn)            (   (((uint32_t)(int32_t)(IRQn))                >>    2UL)      )
+
+
+/**
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)(int32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)(int32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+
+/**
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
+ */
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[_IP_IDX(IRQn)]  = ((uint32_t)(NVIC->IPR[_IP_IDX(IRQn)]  & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+  else
+  {
+    SCB->SHPR[_SHP_IDX(IRQn)] = ((uint32_t)(SCB->SHPR[_SHP_IDX(IRQn)] & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IPR[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return((uint32_t)(((SCB->SHPR[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+           If VTOR is not present address 0 must be mapped to SRAM.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
+ */
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  uint32_t *vectors = (uint32_t *)SCB->VTOR;
+#else
+  uint32_t *vectors = (uint32_t *)0x0U;
+#endif
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+}
+
+
+/**
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
+ */
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+  uint32_t *vectors = (uint32_t *)SCB->VTOR;
+#else
+  uint32_t *vectors = (uint32_t *)0x0U;
+#endif
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
+
+
+/**
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
+ */
+__STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = ((0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                 SCB_AIRCR_SYSRESETREQ_Msk);
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+}
+
+
+/**
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)(int32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL));
+  }
+}
+
+
+/**
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)(int32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)(int32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+
+
+/**
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[_IP_IDX(IRQn)]  = ((uint32_t)(NVIC_NS->IPR[_IP_IDX(IRQn)]  & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+  else
+  {
+    SCB_NS->SHPR[_SHP_IDX(IRQn)] = ((uint32_t)(SCB_NS->SHPR[_SHP_IDX(IRQn)] & ~(0xFFUL << _BIT_SHIFT(IRQn))) |
+       (((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL) << _BIT_SHIFT(IRQn)));
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IPR[ _IP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return((uint32_t)(((SCB_NS->SHPR[_SHP_IDX(IRQn)] >> _BIT_SHIFT(IRQn) ) & (uint32_t)0xFFUL) >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_NVICFunctions */
+
+
+/* ##########################  FPU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
+ */
+
+/**
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
+ */
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+    return 0U;           /* No FPU */
+}
+
+
+/*@} end of CMSIS_Core_FpuFunctions */
+
+
+
+/* ##########################   SAU functions  #################################### */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
+ */
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+/**
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
+
+
+
+/**
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
+ */
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
+
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+/*@} end of CMSIS_Core_SAUFunctions */
+
+
+
+
+/* ##################################    SysTick function  ############################################ */
+/**
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
+ */
+
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
+
+/**
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+ */
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
+
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
+ */
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
+
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+#endif
+
+/*@} end of CMSIS_Core_SysTickFunctions */
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM23_H_DEPENDANT */
+
+#endif /* __CMSIS_GENERIC */

--- a/hal/m258ke/nuvoton/crc_reg.h
+++ b/hal/m258ke/nuvoton/crc_reg.h
@@ -1,0 +1,151 @@
+/**************************************************************************//**
+ * @file     crc_reg.h
+ * @version  V1.00
+ * @brief    CRC register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __CRC_REG_H__
+#define __CRC_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup CRC Cyclic Redundancy Check Controller (CRC)
+    Memory Mapped Structure for CRC Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var CRC_T::CTL
+     * Offset: 0x00  CRC Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CRCEN     |CRC Channel Enable Bit
+     * |        |          |0 = No effect.
+     * |        |          |1 = CRC operation Enabled.
+     * |[1]     |CHKSINIT  |Checksum Initialization
+     * |        |          |0 = No effect.
+     * |        |          |1 = Initial checksum value by auto reload CRC_SEED register value to CRC_CHECKSUM register value.
+     * |        |          |Note: This bit will be cleared automatically.
+     * |[24]    |DATREV    |Write Data Bit Order Reverse
+     * |        |          |This bit is used to enable the bit order reverse function per byte for write data value in CRC_DAT register.
+     * |        |          |0 = Bit order reversed for CRC write data in Disabled.
+     * |        |          |1 = Bit order reversed for CRC write data in Enabled (per byte).
+     * |        |          |Note: If the write data is 0xAABBCCDD, the bit order reverse for CRC write data in is 0x55DD33BB.
+     * |[25]    |CHKSREV   |Checksum Bit Order Reverse
+     * |        |          |This bit is used to enable the bit order reverse function for checksum result in CRC_CHECKSUM register.
+     * |        |          |0 = Bit order reverse for CRC checksum Disabled.
+     * |        |          |1 = Bit order reverse for CRC checksum Enabled.
+     * |        |          |Note: If the checksum result is 0xDD7B0F2E, the bit order reverse for CRC checksum is 0x74F0DEBB.
+     * |[26]    |DATFMT    |Write Data 1's Complement
+     * |        |          |This bit is used to enable the 1's complement function for write data value in CRC_DAT register.
+     * |        |          |0 = 1's complement for CRC writes data in Disabled.
+     * |        |          |1 = 1's complement for CRC writes data in Enabled.
+     * |[27]    |CHKSFMT   |Checksum 1's Complement
+     * |        |          |This bit is used to enable the 1's complement function for checksum result in CRC_CHECKSUM register.
+     * |        |          |0 = 1's complement for CRC checksum Disabled.
+     * |        |          |1 = 1's complement for CRC checksum Enabled.
+     * |[29:28] |DATLEN    |CPU Write Data Length
+     * |        |          |This field indicates the write data length.
+     * |        |          |00 = Data length is 8-bit mode.
+     * |        |          |01 = Data length is 16-bit mode.
+     * |        |          |1x = Data length is 32-bit mode.
+     * |        |          |Note: When the write data length is 8-bit mode, the valid data in CRC_DAT register is only DATA[7:0] bits; if the write data length is 16-bit mode, the valid data in CRC_DAT register is only DATA[15:0]
+     * |[31:30] |CRCMODE   |CRC Polynomial Mode
+     * |        |          |This field indicates the CRC operation polynomial mode.
+     * |        |          |00 = CRC-CCITT Polynomial mode.
+     * |        |          |01 = CRC-8 Polynomial mode.
+     * |        |          |10 = CRC-16 Polynomial mode.
+     * |        |          |11 = CRC-32 Polynomial mode.
+     * @var CRC_T::DAT
+     * Offset: 0x04  CRC Write Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |DATA      |CRC Write Data Bits
+     * |        |          |User can write data directly by CPU mode or use PDMA function to write data to this field to perform CRC operation.
+     * |        |          |Note: When the write data length is 8-bit mode, the valid data in CRC_DAT register is only DATA[7:0] bits; if the write data length is 16-bit mode, the valid data in CRC_DAT register is only DATA[15:0].
+     * @var CRC_T::SEED
+     * Offset: 0x08  CRC Seed Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |SEED      |CRC Seed Value
+     * |        |          |This field indicates the CRC seed value.
+     * |        |          |Note: This field will be reloaded as checksum initial value (CRC_CHECKSUM register) after perform CHKSINIT (CRC_CTL[1]).
+     * @var CRC_T::CHECKSUM
+     * Offset: 0x0C  CRC Checksum Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |CHECKSUM  |CRC Checksum Results
+     * |        |          |This field indicates the CRC checksum result.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] CRC Control Register                                             */
+    __IO uint32_t DAT;                   /*!< [0x0004] CRC Write Data Register                                          */
+    __IO uint32_t SEED;                  /*!< [0x0008] CRC Seed Register                                                */
+    __I  uint32_t CHECKSUM;              /*!< [0x000c] CRC Checksum Register                                            */
+} CRC_T;
+
+/**
+    @addtogroup CRC_CONST CRC Bit Field Definition
+    Constant Definitions for CRC Controller
+@{ */
+
+#define CRC_CTL_CRCEN_Pos                (0)                                               /*!< CRC_T::CTL: CRCEN Position             */
+#define CRC_CTL_CRCEN_Msk                (0x1ul << CRC_CTL_CRCEN_Pos)                      /*!< CRC_T::CTL: CRCEN Mask                 */
+
+#define CRC_CTL_CHKSINIT_Pos             (1)                                               /*!< CRC_T::CTL: CHKSINIT Position          */
+#define CRC_CTL_CHKSINIT_Msk             (0x1ul << CRC_CTL_CHKSINIT_Pos)                   /*!< CRC_T::CTL: CHKSINIT Mask              */
+
+#define CRC_CTL_DATREV_Pos               (24)                                              /*!< CRC_T::CTL: DATREV Position            */
+#define CRC_CTL_DATREV_Msk               (0x1ul << CRC_CTL_DATREV_Pos)                     /*!< CRC_T::CTL: DATREV Mask                */
+
+#define CRC_CTL_CHKSREV_Pos              (25)                                              /*!< CRC_T::CTL: CHKSREV Position           */
+#define CRC_CTL_CHKSREV_Msk              (0x1ul << CRC_CTL_CHKSREV_Pos)                    /*!< CRC_T::CTL: CHKSREV Mask               */
+
+#define CRC_CTL_DATFMT_Pos               (26)                                              /*!< CRC_T::CTL: DATFMT Position            */
+#define CRC_CTL_DATFMT_Msk               (0x1ul << CRC_CTL_DATFMT_Pos)                     /*!< CRC_T::CTL: DATFMT Mask                */
+
+#define CRC_CTL_CHKSFMT_Pos              (27)                                              /*!< CRC_T::CTL: CHKSFMT Position           */
+#define CRC_CTL_CHKSFMT_Msk              (0x1ul << CRC_CTL_CHKSFMT_Pos)                    /*!< CRC_T::CTL: CHKSFMT Mask               */
+
+#define CRC_CTL_DATLEN_Pos               (28)                                              /*!< CRC_T::CTL: DATLEN Position            */
+#define CRC_CTL_DATLEN_Msk               (0x3ul << CRC_CTL_DATLEN_Pos)                     /*!< CRC_T::CTL: DATLEN Mask                */
+
+#define CRC_CTL_CRCMODE_Pos              (30)                                              /*!< CRC_T::CTL: CRCMODE Position           */
+#define CRC_CTL_CRCMODE_Msk              (0x3ul << CRC_CTL_CRCMODE_Pos)                    /*!< CRC_T::CTL: CRCMODE Mask               */
+
+#define CRC_DAT_DATA_Pos                 (0)                                               /*!< CRC_T::DAT: DATA Position              */
+#define CRC_DAT_DATA_Msk                 (0xfffffffful << CRC_DAT_DATA_Pos)                /*!< CRC_T::DAT: DATA Mask                  */
+
+#define CRC_SEED_SEED_Pos                (0)                                               /*!< CRC_T::SEED: SEED Position             */
+#define CRC_SEED_SEED_Msk                (0xfffffffful << CRC_SEED_SEED_Pos)               /*!< CRC_T::SEED: SEED Mask                 */
+
+#define CRC_CHECKSUM_CHECKSUM_Pos        (0)                                               /*!< CRC_T::CHECKSUM: CHECKSUM Position     */
+#define CRC_CHECKSUM_CHECKSUM_Msk        (0xfffffffful << CRC_CHECKSUM_CHECKSUM_Pos)       /*!< CRC_T::CHECKSUM: CHECKSUM Mask         */
+
+/** @} CRC_CONST */
+/** @} end of CRC register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __CRC_REG_H__ */

--- a/hal/m258ke/nuvoton/crypto_reg.h
+++ b/hal/m258ke/nuvoton/crypto_reg.h
@@ -1,0 +1,385 @@
+/**************************************************************************//**
+ * @file     crypto_reg.h
+ * @version  V1.00
+ * @brief    CRYPTO register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __CRYPTO_REG_H__
+#define __CRYPTO_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup CRPT Cryptographic Accelerator (CRPT)
+    Memory Mapped Structure for Cryptographic Accelerator
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var CRPT_T::INTEN
+     * Offset: 0x00  Crypto Interrupt Enable Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |AESIEN    |AES Interrupt Enable Bit
+     * |        |          |0 = AES interrupt Disabled.
+     * |        |          |1 = AES interrupt Enabled.
+     * |        |          |In DMA mode, an interrupt will be triggered when amount of data set in AES_DMA_CNT is fed into the AES engine.
+     * |        |          |In Non-DMA mode, an interrupt will be triggered when the AES engine finishes the operation.
+     * |[1]     |AESEIEN   |AES Error Flag Enable Bit
+     * |        |          |0 = AES error interrupt flag Disabled.
+     * |        |          |1 = AES error interrupt flag Enabled.
+     * @var CRPT_T::INTSTS
+     * Offset: 0x04  Crypto Interrupt Flag
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |AESIF     |AES Finish Interrupt Flag
+     * |        |          |This bit is cleared by writing 1, and it has no effect by writing 0.
+     * |        |          |0 = No AES interrupt.
+     * |        |          |1 = AES encryption/decryption done interrupt.
+     * |[1]     |AESEIF    |AES Error Flag
+     * |        |          |This bit is cleared by writing 1, and it has no effect by writing 0.
+     * |        |          |0 = No AES error.
+     * |        |          |1 = AES encryption/decryption error interrupt.
+     * @var CRPT_T::AES_FDBCK[4]
+     * Offset: 0x50 ~ 0x5C  AES Engine Output Feedback Data After Cryptographic Operation
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |FDBCK     |AES Feedback Information
+     * |        |          |The feedback value is 128 bits in size.
+     * |        |          |The AES engine uses the data from CRPT_AES_FDBCKx as the data inputted to CRPT_AES_IVx for the next block in DMA cascade mode.
+     * |        |          |The AES engine outputs feedback information for IV in the next block's operation
+     * |        |          |Software can store that feedback value temporarily
+     * |        |          |After switching back, fill the stored feedback value to CRPT_AES_IVx in the same operation, and then continue the operation with the original setting.
+     * @var CRPT_T::AES_CTL
+     * Offset: 0x100  AES Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |START     |AES Engine Start
+     * |        |          |0 = No effect.
+     * |        |          |1 = Start AES engine. BUSY flag will be set.
+     * |        |          |Note: This bit is always 0 when it's read back.
+     * |[1]     |STOP      |AES Engine Stop
+     * |        |          |0 = No effect.
+     * |        |          |1 = Stop AES engine.
+     * |        |          |Note: This bit is always 0 when it's read back.
+     * |[3:2]   |KEYSZ     |AES Key Size
+     * |        |          |This bit defines three different key size for AES operation.
+     * |        |          |2'b00 = 128 bits key.
+     * |        |          |2'b01 = 192 bits key.
+     * |        |          |2'b10 = 256 bits key.
+     * |        |          |2'b11 = Reserved.
+     * |        |          |If the AES accelerator is operating and the corresponding flag BUSY is 1, updating this register has no effect.
+     * |[5]     |DMALAST   |AES Last Block
+     * |        |          |In DMA mode, this bit must be set as beginning the last DMA cascade round.
+     * |        |          |In Non-DMA mode, this bit must be set when feeding in the last block of data in ECB, CBC, CTR, OFB, and CFB mode, and feeding in the (last-1) block of data at CBC-CS1, CBC-CS2, and CBC-CS3 mode.
+     * |        |          |This bit is always 0 when it's read back. Must be written again once START is triggered.
+     * |[6]     |DMACSCAD  |AES Engine DMA with Cascade Mode
+     * |        |          |0 = DMA cascade function Disabled.
+     * |        |          |1 = In DMA cascade mode, software can update DMA source address register, destination address register, and byte count register during a cascade operation, without finishing the accelerator operation.
+     * |[7]     |DMAEN     |AES Engine DMA Enable Bit
+     * |        |          |0 = AES DMA engine Disabled.
+     * |        |          |The AES engine operates in Non-DMA mode. The data need to be written in CRPT_AES_DATIN.
+     * |        |          |1 = AES_DMA engine Enabled.
+     * |        |          |The AES engine operates in DMA mode, and data movement from/to the engine is done by DMA logic.
+     * |[15:8]  |OPMODE    |AES Engine Operation Modes
+     * |        |          |0x00 = ECB (Electronic Codebook Mode)  0x01 = CBC (Cipher Block Chaining Mode).
+     * |        |          |0x02 = CFB (Cipher Feedback Mode).
+     * |        |          |0x03 = OFB (Output Feedback Mode).
+     * |        |          |0x04 = CTR (Counter Mode).
+     * |        |          |0x10 = CBC-CS1 (CBC Ciphertext-Stealing 1 Mode).
+     * |        |          |0x11 = CBC-CS2 (CBC Ciphertext-Stealing 2 Mode).
+     * |        |          |0x12 = CBC-CS3 (CBC Ciphertext-Stealing 3 Mode).
+     * |[16]    |ENCRYPTO  |AES Encryption/Decryption
+     * |        |          |0 = AES engine executes decryption operation.
+     * |        |          |1 = AES engine executes encryption operation.
+     * |[22]    |OUTSWAP   |AES Engine Output Data Swap
+     * |        |          |0 = Keep the original order.
+     * |        |          |1 = The order that CPU outputs data from the accelerator will be changed from {byte3, byte2, byte1, byte0} to {byte0, byte1, byte2, byte3}.
+     * |[23]    |INSWAP    |AES Engine Input Data Swap
+     * |        |          |0 = Keep the original order.
+     * |        |          |1 = The order that CPU feeds data to the accelerator will be changed from {byte3, byte2, byte1, byte0} to {byte0, byte1, byte2, byte3}.
+     * |[30:26] |KEYUNPRT  |Unprotect Key
+     * |        |          |Writing 0 to CRPT_AES_CTL[31] and "10110" to CRPT_AES_CTL[30:26] is to unprotect the AES key.
+     * |        |          |The KEYUNPRT can be read and written
+     * |        |          |When it is written as the AES engine is operating, BUSY flag is 1, there would be no effect on KEYUNPRT.
+     * |[31]    |KEYPRT    |Protect Key
+     * |        |          |Read as a flag to reflect KEYPRT.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Protect the content of the AES key from reading
+     * |        |          |The return value for reading CRPT_AES_KEYx is not the content of the registers CRPT_AES_KEYx
+     * |        |          |Once it is set, it can be cleared by asserting KEYUNPRT
+     * |        |          |And the key content would be cleared as well.
+     * @var CRPT_T::AES_STS
+     * Offset: 0x104  AES Engine Flag
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BUSY      |AES Engine Busy
+     * |        |          |0 = The AES engine is idle or finished.
+     * |        |          |1 = The AES engine is under processing.
+     * |[8]     |INBUFEMPTY|AES Input Buffer Empty
+     * |        |          |0 = There are some data in input buffer waiting for the AES engine to process.
+     * |        |          |1 = AES input buffer is empty
+     * |        |          |Software needs to feed data to the AES engine
+     * |        |          |Otherwise, the AES engine will be pending to wait for input data.
+     * |[9]     |INBUFFULL |AES Input Buffer Full Flag
+     * |        |          |0 = AES input buffer is not full. Software can feed the data into the AES engine.
+     * |        |          |1 = AES input buffer is full
+     * |        |          |Software cannot feed data to the AES engine
+     * |        |          |Otherwise, the flag INBUFERR will be set to 1.
+     * |[10]    |INBUFERR  |AES Input Buffer Error Flag
+     * |        |          |0 = No error.
+     * |        |          |1 = Error happens during feeding data to the AES engine.
+     * |[12]    |CNTERR    |CRPT_AES_CNT Setting Error
+     * |        |          |0 = No error in CRPT_AES_CNT setting.
+     * |        |          |1 = CRPT_AES_CNT is 0 if DMAEN (CRPT_AES_CTL[7]) is enabled.
+     * |[16]    |OUTBUFEMPTY|AES Out Buffer Empty
+     * |        |          |0 = AES output buffer is not empty. There are some valid data kept in output buffer.
+     * |        |          |1 = AES output buffer is empty
+     * |        |          |Software cannot get data from CRPT_AES_DATOUT
+     * |        |          |Otherwise, the flag OUTBUFERR will be set to 1 since the output buffer is empty.
+     * |[17]    |OUTBUFFULL|AES Out Buffer Full Flag
+     * |        |          |0 = AES output buffer is not full.
+     * |        |          |1 = AES output buffer is full, and software needs to get data from CRPT_AES_DATOUT
+     * |        |          |Otherwise, the AES engine will be pending since the output buffer is full.
+     * |[18]    |OUTBUFERR |AES Out Buffer Error Flag
+     * |        |          |0 = No error.
+     * |        |          |1 = Error happens during getting the result from AES engine.
+     * |[20]    |BUSERR    |AES DMA Access Bus Error Flag
+     * |        |          |0 = No error.
+     * |        |          |1 = Bus error will stop DMA operation and AES engine.
+     * @var CRPT_T::AES_DATIN
+     * Offset: 0x108  AES Engine Data Input Port Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |DATIN     |AES Engine Input Port
+     * |        |          |CPU feeds data to AES engine through this port by checking CRPT_AES_STS. Feed data as INBUFFULL is 0.
+     * @var CRPT_T::AES_DATOUT
+     * Offset: 0x10C  AES Engine Data Output Port Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |DATOUT    |AES Engine Output Port
+     * |        |          |CPU gets results from the AES engine through this port by checking CRPT_AES_STS
+     * |        |          |Get data as OUTBUFEMPTY is 0.
+     * @var CRPT_T::AES_KEY[8]
+     * Offset: 0x110 ~ 0x12C  AES Key Word 0 ~ 7 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |KEY       |CRPT_AESn_KEYx
+     * |        |          |The KEY keeps the security key for AES operation.
+     * |        |          |x = 0, 1..7.
+     * |        |          |The security key for AES accelerator can be 128, 192, or 256 bits and four, six, or eight 32-bit registers are to store each security key
+     * |        |          |{CRPT_AES_KEY3, CRPT_AES_KEY2, CRPT_AES_KEY1, CRPT_AES_KEY0} stores the 128-bit security key for AES operation
+     * |        |          |{CRPT_AES_KEY5, CRPT_AES_KEY4, CRPT_AES_KEY3, CRPT_AES_KEY2, CRPT_AES_KEY1, CRPT_AES_KEY0} stores the 192-bit security key for AES operation
+     * |        |          |{CRPT_AES_KEY7, CRPT_AES_KEY6, CRPT_AES_KEY5, CRPT_AES_KEY4, CRPT_AES_KEY3, CRPT_AES_KEY2, CRPT_AES_KEY1, CRPT_AES_KEY0} stores the 256-bit security key for AES operation.
+     * @var CRPT_T::AES_IV[4]
+     * Offset: 0x130 ~ 0x13C  AES Initial Vector Word 0 ~ 3 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |IV        |AES Initial Vectors
+     * |        |          |x = 0, 1..3.
+     * |        |          |Four initial vectors (CRPT_AES_IV0, CRPT_AES_IV1, CRPT_AES_IV2, and CRPT_AES_IV3) are for AES operating in CBC, CFB, and OFB mode
+     * |        |          |Four registers (CRPT_AES_IV0, CRPT_AES_IV1, CRPT_AES_IV2, and CRPT_AES_IV3) act as Nonce counter when the AES engine is operating in CTR mode.
+     * @var CRPT_T::AES_SADDR
+     * Offset: 0x140  AES DMA Source Address Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |SADDR     |AES DMA Source Address
+     * |        |          |The AES accelerator supports DMA function to transfer the plain text between SRAM memory space and embedded FIFO
+     * |        |          |The SADDR keeps the source address of the data buffer where the source text is stored
+     * |        |          |Based on the source address, the AES accelerator can read the plain text (encryption) / cipher text (descryption) from SRAM memory space and do AES operation
+     * |        |          |The start of source address should be located at word boundary
+     * |        |          |In other words, bit 1 and 0 of SADDR are ignored.
+     * |        |          |SADDR can be read and written
+     * |        |          |Writing to SADDR while the AES accelerator is operating doesn't affect the current AES operation
+     * |        |          |But the value of SADDR will be updated later on
+     * |        |          |Consequently, software can prepare the DMA source address for the next AES operation.
+     * |        |          |In DMA mode, software can update the next CRPT_AES_SADDR before triggering START.
+     * |        |          |The value of CRPT_AES_SADDR and CRPT_AES_DADDR can be the same.
+     * @var CRPT_T::AES_DADDR
+     * Offset: 0x144  AES DMA Destination Address Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |DADDR     |AES DMA Destination Address
+     * |        |          |The AES accelerator supports DMA function to transfer the cipher text between SRAM memory space and embedded FIFO
+     * |        |          |The DADDR keeps the destination address of the data buffer where the engine output's text will be stored
+     * |        |          |Based on the destination address, the AES accelerator can write the cipher text (encryption) / plain text (decryption) back to SRAM memory space after the AES operation is finished
+     * |        |          |The start of destination address should be located at word boundary
+     * |        |          |In other words, bit 1 and 0 of DADDR are ignored.
+     * |        |          |DADDR can be read and written
+     * |        |          |Writing to DADDR while the AES accelerator is operating doesn't affect the current AES operation
+     * |        |          |But the value of DADDR will be updated later on
+     * |        |          |Consequently, software can prepare the destination address for the next AES operation.
+     * |        |          |In DMA mode, software can update the next CRPT_AES_DADDR before triggering START.
+     * |        |          |The value of CRPT_AES_SADDR and CRPT_AES_DADDR can be the same.
+     * @var CRPT_T::AES_CNT
+     * Offset: 0x148  AES Byte Count Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |CNT       |AES Byte Count
+     * |        |          |The CRPT_AES_CNT keeps the byte count of source text that is for the AES engine operating in DMA mode
+     * |        |          |The CRPT_AES_CNT is 32-bit and the maximum of byte count is 4G bytes.
+     * |        |          |CRPT_AESn_CNT can be read and written
+     * |        |          |Writing to CRPT_AES_CNT while the AES accelerator is operating doesn't affect the current AES operation
+     * |        |          |But the value of CRPT_AESn_CNT will be updated later on
+     * |        |          |Consequently, software can prepare the byte count of data for the next AES operation.
+     * |        |          |According to CBC-CS1, CBC-CS2, and CBC-CS3 standard, the count of operation data must be more than 16 bytes
+     * |        |          |Operations that are qual or less than one block will output unexpected result.
+     * |        |          |In Non-DMA ECB, CBC, CFB, OFB, and CTR mode, CRPT_AES_CNT must be set as byte count for the last block of data before feeding in the last block of data
+     * |        |          |In Non-DMA CBC-CS1, CBC-CS2, and CBC-CS3 mode, CRPT_AES_CNT must be set as byte count for the last two blocks of data before feeding in the last two blocks of data.
+     */
+    __IO uint32_t INTEN;                 /*!< [0x0000] Crypto Interrupt Enable Control Register                         */
+    __IO uint32_t INTSTS;                /*!< [0x0004] Crypto Interrupt Flag                                            */
+    __I  uint32_t RESERVE0[18];
+    __I  uint32_t AES_FDBCK[4];          /*!< [0x0050 ~ 0x005c] AES Engine Output Feedback Data After Cryptographic Operation*/
+    __I  uint32_t RESERVE1[40];
+    __IO uint32_t AES_CTL;               /*!< [0x0100] AES Control Register                                             */
+    __I  uint32_t AES_STS;               /*!< [0x0104] AES Engine Flag                                                  */
+    __IO uint32_t AES_DATIN;             /*!< [0x0108] AES Engine Data Input Port Register                              */
+    __I  uint32_t AES_DATOUT;            /*!< [0x010c] AES Engine Data Output Port Register                             */
+    __IO uint32_t AES_KEY[8];            /*!< [0x0110 ~ 0x012c] AES Key Word 0 ~ 7 Register                             */
+    __IO uint32_t AES_IV[4];             /*!< [0x0130 ~ 0x013c] AES Initial Vector Word 0 ~3 Register                   */
+    __IO uint32_t AES_SADDR;             /*!< [0x0140] AES DMA Source Address Register                                  */
+    __IO uint32_t AES_DADDR;             /*!< [0x0144] AES DMA Destination Address Register                             */
+    __IO uint32_t AES_CNT;               /*!< [0x0148] AES Byte Count Register                              */
+
+} CRPT_T;
+
+/**
+    @addtogroup CRPT_CONST CRYPTO Bit Field Definition
+    Constant Definitions for CRYPTO Controller
+@{ */
+
+#define CRPT_INTEN_AESIEN_Pos          (0)                                               /*!< CRPT_T::INTEN: AESIEN Position       */
+#define CRPT_INTEN_AESIEN_Msk          (0x1ul << CRPT_INTEN_AESIEN_Pos)                  /*!< CRPT_T::INTEN: AESIEN Mask           */
+
+#define CRPT_INTEN_AESEIEN_Pos         (1)                                               /*!< CRPT_T::INTEN: AESEIEN Position      */
+#define CRPT_INTEN_AESEIEN_Msk         (0x1ul << CRPT_INTEN_AESEIEN_Pos)                 /*!< CRPT_T::INTEN: AESEIEN Mask          */
+
+#define CRPT_INTSTS_AESIF_Pos          (0)                                               /*!< CRPT_T::INTSTS: AESIF Position       */
+#define CRPT_INTSTS_AESIF_Msk          (0x1ul << CRPT_INTSTS_AESIF_Pos)                  /*!< CRPT_T::INTSTS: AESIF Mask           */
+
+#define CRPT_INTSTS_AESEIF_Pos         (1)                                               /*!< CRPT_T::INTSTS: AESEIF Position      */
+#define CRPT_INTSTS_AESEIF_Msk         (0x1ul << CRPT_INTSTS_AESEIF_Pos)                 /*!< CRPT_T::INTSTS: AESEIF Mask          */
+
+#define CRPT_AES_FDBCKx_FDBCK_Pos      (0)                                               /*!< CRPT_T::AES_FDBCK[4]: FDBCK Position */
+#define CRPT_AES_FDBCKx_FDBCK_Msk      (0xfffffffful << CRPT_AES_FDBCKx_FDBCK_Pos)       /*!< CRPT_T::AES_FDBCK[4]: FDBCK Mask     */
+
+#define CRPT_AES_CTL_START_Pos         (0)                                               /*!< CRPT_T::AES_CTL: START Position      */
+#define CRPT_AES_CTL_START_Msk         (0x1ul << CRPT_AES_CTL_START_Pos)                 /*!< CRPT_T::AES_CTL: START Mask          */
+
+#define CRPT_AES_CTL_STOP_Pos          (1)                                               /*!< CRPT_T::AES_CTL: STOP Position       */
+#define CRPT_AES_CTL_STOP_Msk          (0x1ul << CRPT_AES_CTL_STOP_Pos)                  /*!< CRPT_T::AES_CTL: STOP Mask           */
+
+#define CRPT_AES_CTL_KEYSZ_Pos         (2)                                               /*!< CRPT_T::AES_CTL: KEYSZ Position      */
+#define CRPT_AES_CTL_KEYSZ_Msk         (0x3ul << CRPT_AES_CTL_KEYSZ_Pos)                 /*!< CRPT_T::AES_CTL: KEYSZ Mask          */
+
+#define CRPT_AES_CTL_DMALAST_Pos       (5)                                               /*!< CRPT_T::AES_CTL: DMALAST Position    */
+#define CRPT_AES_CTL_DMALAST_Msk       (0x1ul << CRPT_AES_CTL_DMALAST_Pos)               /*!< CRPT_T::AES_CTL: DMALAST Mask        */
+
+#define CRPT_AES_CTL_DMACSCAD_Pos      (6)                                               /*!< CRPT_T::AES_CTL: DMACSCAD Position   */
+#define CRPT_AES_CTL_DMACSCAD_Msk      (0x1ul << CRPT_AES_CTL_DMACSCAD_Pos)              /*!< CRPT_T::AES_CTL: DMACSCAD Mask       */
+
+#define CRPT_AES_CTL_DMAEN_Pos         (7)                                               /*!< CRPT_T::AES_CTL: DMAEN Position      */
+#define CRPT_AES_CTL_DMAEN_Msk         (0x1ul << CRPT_AES_CTL_DMAEN_Pos)                 /*!< CRPT_T::AES_CTL: DMAEN Mask          */
+
+#define CRPT_AES_CTL_OPMODE_Pos        (8)                                               /*!< CRPT_T::AES_CTL: OPMODE Position     */
+#define CRPT_AES_CTL_OPMODE_Msk        (0xfful << CRPT_AES_CTL_OPMODE_Pos)               /*!< CRPT_T::AES_CTL: OPMODE Mask         */
+
+#define CRPT_AES_CTL_ENCRYPTO_Pos      (16)                                              /*!< CRPT_T::AES_CTL: ENCRYPTO Position   */
+#define CRPT_AES_CTL_ENCRYPTO_Msk      (0x1ul << CRPT_AES_CTL_ENCRYPTO_Pos)              /*!< CRPT_T::AES_CTL: ENCRYPTO Mask       */
+
+#define CRPT_AES_CTL_OUTSWAP_Pos       (22)                                              /*!< CRPT_T::AES_CTL: OUTSWAP Position    */
+#define CRPT_AES_CTL_OUTSWAP_Msk       (0x1ul << CRPT_AES_CTL_OUTSWAP_Pos)               /*!< CRPT_T::AES_CTL: OUTSWAP Mask        */
+
+#define CRPT_AES_CTL_INSWAP_Pos        (23)                                              /*!< CRPT_T::AES_CTL: INSWAP Position     */
+#define CRPT_AES_CTL_INSWAP_Msk        (0x1ul << CRPT_AES_CTL_INSWAP_Pos)                /*!< CRPT_T::AES_CTL: INSWAP Mask         */
+
+#define CRPT_AES_CTL_KEYUNPRT_Pos      (26)                                              /*!< CRPT_T::AES_CTL: KEYUNPRT Position   */
+#define CRPT_AES_CTL_KEYUNPRT_Msk      (0x1ful << CRPT_AES_CTL_KEYUNPRT_Pos)             /*!< CRPT_T::AES_CTL: KEYUNPRT Mask       */
+
+#define CRPT_AES_CTL_KEYPRT_Pos        (31)                                              /*!< CRPT_T::AES_CTL: KEYPRT Position     */
+#define CRPT_AES_CTL_KEYPRT_Msk        (0x1ul << CRPT_AES_CTL_KEYPRT_Pos)                /*!< CRPT_T::AES_CTL: KEYPRT Mask         */
+
+#define CRPT_AES_STS_BUSY_Pos          (0)                                               /*!< CRPT_T::AES_STS: BUSY Position       */
+#define CRPT_AES_STS_BUSY_Msk          (0x1ul << CRPT_AES_STS_BUSY_Pos)                  /*!< CRPT_T::AES_STS: BUSY Mask           */
+
+#define CRPT_AES_STS_INBUFEMPTY_Pos    (8)                                               /*!< CRPT_T::AES_STS: INBUFEMPTY Position */
+#define CRPT_AES_STS_INBUFEMPTY_Msk    (0x1ul << CRPT_AES_STS_INBUFEMPTY_Pos)            /*!< CRPT_T::AES_STS: INBUFEMPTY Mask     */
+
+#define CRPT_AES_STS_INBUFFULL_Pos     (9)                                               /*!< CRPT_T::AES_STS: INBUFFULL Position  */
+#define CRPT_AES_STS_INBUFFULL_Msk     (0x1ul << CRPT_AES_STS_INBUFFULL_Pos)             /*!< CRPT_T::AES_STS: INBUFFULL Mask      */
+
+#define CRPT_AES_STS_INBUFERR_Pos      (10)                                              /*!< CRPT_T::AES_STS: INBUFERR Position   */
+#define CRPT_AES_STS_INBUFERR_Msk      (0x1ul << CRPT_AES_STS_INBUFERR_Pos)              /*!< CRPT_T::AES_STS: INBUFERR Mask       */
+
+#define CRPT_AES_STS_CNTERR_Pos        (12)                                              /*!< CRPT_T::AES_STS: CNTERR Position     */
+#define CRPT_AES_STS_CNTERR_Msk        (0x1ul << CRPT_AES_STS_CNTERR_Pos)                /*!< CRPT_T::AES_STS: CNTERR Mask         */
+
+#define CRPT_AES_STS_OUTBUFEMPTY_Pos   (16)                                              /*!< CRPT_T::AES_STS: OUTBUFEMPTY Position*/
+#define CRPT_AES_STS_OUTBUFEMPTY_Msk   (0x1ul << CRPT_AES_STS_OUTBUFEMPTY_Pos)           /*!< CRPT_T::AES_STS: OUTBUFEMPTY Mask    */
+
+#define CRPT_AES_STS_OUTBUFFULL_Pos    (17)                                              /*!< CRPT_T::AES_STS: OUTBUFFULL Position */
+#define CRPT_AES_STS_OUTBUFFULL_Msk    (0x1ul << CRPT_AES_STS_OUTBUFFULL_Pos)            /*!< CRPT_T::AES_STS: OUTBUFFULL Mask     */
+
+#define CRPT_AES_STS_OUTBUFERR_Pos     (18)                                              /*!< CRPT_T::AES_STS: OUTBUFERR Position  */
+#define CRPT_AES_STS_OUTBUFERR_Msk     (0x1ul << CRPT_AES_STS_OUTBUFERR_Pos)             /*!< CRPT_T::AES_STS: OUTBUFERR Mask      */
+
+#define CRPT_AES_STS_BUSERR_Pos        (20)                                              /*!< CRPT_T::AES_STS: BUSERR Position     */
+#define CRPT_AES_STS_BUSERR_Msk        (0x1ul << CRPT_AES_STS_BUSERR_Pos)                /*!< CRPT_T::AES_STS: BUSERR Mask         */
+
+#define CRPT_AES_DATIN_DATIN_Pos       (0)                                               /*!< CRPT_T::AES_DATIN: DATIN Position    */
+#define CRPT_AES_DATIN_DATIN_Msk       (0xfffffffful << CRPT_AES_DATIN_DATIN_Pos)        /*!< CRPT_T::AES_DATIN: DATIN Mask        */
+
+#define CRPT_AES_DATOUT_DATOUT_Pos     (0)                                               /*!< CRPT_T::AES_DATOUT: DATOUT Position  */
+#define CRPT_AES_DATOUT_DATOUT_Msk     (0xfffffffful << CRPT_AES_DATOUT_DATOUT_Pos)      /*!< CRPT_T::AES_DATOUT: DATOUT Mask      */
+
+#define CRPT_AES_KEYx_KEY_Pos          (0)                                               /*!< CRPT_T::AES_KEY[8]: KEY Position     */
+#define CRPT_AES_KEYx_KEY_Msk          (0xfffffffful << CRPT_AES_KEYx_KEY_Pos)           /*!< CRPT_T::AES_KEY[8]: KEY Mask         */
+
+#define CRPT_AES_IVx_IV_Pos            (0)                                               /*!< CRPT_T::AES_IV[4]: IV Position       */
+#define CRPT_AES_IVx_IV_Msk            (0xfffffffful << CRPT_AES_IVx_IV_Pos)             /*!< CRPT_T::AES_IV[4]: IV Mask           */
+
+#define CRPT_AES_SADDR_SADDR_Pos       (0)                                               /*!< CRPT_T::AES_SADDR: SADDR Position    */
+#define CRPT_AES_SADDR_SADDR_Msk       (0xfffffffful << CRPT_AES_SADDR_SADDR_Pos)        /*!< CRPT_T::AES_SADDR: SADDR Mask        */
+
+#define CRPT_AES_DADDR_DADDR_Pos       (0)                                               /*!< CRPT_T::AES_DADDR: DADDR Position    */
+#define CRPT_AES_DADDR_DADDR_Msk       (0xfffffffful << CRPT_AES_DADDR_DADDR_Pos)        /*!< CRPT_T::AES_DADDR: DADDR Mask        */
+
+#define CRPT_AES_CNT_CNT_Pos           (0)                                               /*!< CRPT_T::AES_CNT: CNT Position        */
+#define CRPT_AES_CNT_CNT_Msk           (0xfffffffful << CRPT_AES_CNT_CNT_Pos)            /*!< CRPT_T::AES_CNT: CNT Mask            */
+
+/** @} CRPT_CONST CRYPTO */
+/** @} end of CRYPTO register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __CRYPTO_REG_H__ */

--- a/hal/m258ke/nuvoton/dac_reg.h
+++ b/hal/m258ke/nuvoton/dac_reg.h
@@ -1,0 +1,212 @@
+/**************************************************************************//**
+ * @file     dac_reg.h
+ * @version  V1.00
+ * @brief    DAC register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __DAC_REG_H__
+#define __DAC_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup DAC Digital to Analog Converter (DAC)
+    Memory Mapped Structure for DAC Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var DAC_T::CTL
+     * Offset: 0x00  DAC Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |DACEN     |DAC Enable Bit
+     * |        |          |0 = DAC is Disabled.
+     * |        |          |1 = DAC is Enabled.
+     * |[1]     |DACIEN    |DAC Interrupt Enable Bit
+     * |        |          |0 = Interrupt is Disabled.
+     * |        |          |1 = Interrupt is Enabled.
+     * |[2]     |DMAEN     |DMA Mode Enable Bit
+     * |        |          |0 = DMA mode Disabled.
+     * |        |          |1 = DMA mode Enabled.
+     * |[3]     |DMAURIEN  |DMA Under-run Interrupt Enable Bit
+     * |        |          |0 = DMA underrun interrupt Disabled.
+     * |        |          |1 = DMA underrun interrupt Enabled.
+     * |[4]     |TRGEN     |Trigger Mode Enable Bit
+     * |        |          |0 = DAC event trigger mode Disabled.
+     * |        |          |1 = DAC event trigger mode Enabled.
+     * |[7:5]   |TRGSEL    |Trigger Source Selection
+     * |        |          |000 = Software trigger.
+     * |        |          |001 = External pin DAC_ST trigger.
+     * |        |          |010 = Timer 0 trigger.
+     * |        |          |011 = Timer 1 trigger.
+     * |        |          |100 = Timer 2 trigger.
+     * |        |          |101 = Timer 3 trigger.
+     * |        |          |Others = reserved.
+     * |[8]     |BYPASS    |Bypass Buffer Mode
+     * |        |          |0 = Output voltage buffer Enabled.
+     * |        |          |1 = Output voltage buffer Disabled.
+     * |[10]    |LALIGN    |DAC Data Left-aligned Enabled Control
+     * |        |          |0 = Right alignment.
+     * |        |          |1 = Left alignment.
+     * |[13:12] |ETRGSEL   |External Pin Trigger Selection
+     * |        |          |00 = Low level trigger.
+     * |        |          |01 = High level trigger.
+     * |        |          |10 = Falling edge trigger.
+     * |        |          |11 = Rising edge trigger.
+     * |[15:14] |BWSEL     |DAC Data Bit-width Selection
+     * |        |          |00 = data is 12 bits.
+     * |        |          |01 = data is 8 bits.
+     * |        |          |Others = reserved.
+     * |[16]    |GRPEN     |DAC Group Mode Enable Bit
+     * |        |          |0 = DAC0 and DAC1 are not grouped.
+     * |        |          |1 = DAC0 and DAC1 are grouped.
+     * |        |          |Note:This function only supports having two DAC channels.
+     * @var DAC_T::SWTRG
+     * Offset: 0x04  DAC Software Trigger Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SWTRG     |Software Trigger
+     * |        |          |0 = Software trigger Disabled.
+     * |        |          |1 = Software trigger Enabled.
+     * |        |          |User writes this bit to generate one shot pulse and it is cleared to 0 by hardware automatically; Reading this bit will always get 0.
+     * @var DAC_T::DAT
+     * Offset: 0x08  DAC Data Holding Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |DACDAT    |DAC 12-bit Holding Data
+     * |        |          |The unused bits (DAC_DAT[3:0] in left-alignment mode and DAC_DAT[15:12] in right alignment mode) are ignored by DAC controller hardware.
+     * |        |          |12 bit left alignment: user has to load data into DAC_DAT[15:4] bits.
+     * |        |          |12 bit right alignment: user has to load data into DAC_DAT[11:0] bits.
+     * |        |          |DAC 8-bit Holding Data
+     * |        |          |The unused bits DAC_DAT[15:8] are ignored by DAC controller hardware.
+     * |        |          |Note: Conversion data and DAC output data is 12-bit
+     * @var DAC_T::DATOUT
+     * Offset: 0x0C  DAC Data Output Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[11:0]  |DATOUT    |DAC 12-bit Output Data
+     * |        |          |These bits are current digital data for DAC output conversion.
+     * |        |          |It is loaded from DAC_DAT register and user cannot write it directly.
+     * @var DAC_T::STATUS
+     * Offset: 0x10  DAC Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |FINISH    |DAC Conversion Complete Finish Flag
+     * |        |          |0 = DAC is in conversion state.
+     * |        |          |1 = DAC conversion finish.
+     * |        |          |This bit set to 1 when conversion time counter counts to SETTLET
+     * |        |          |It is cleared to 0 when DAC starts a new conversion
+     * |        |          |User writes 1 to clear this bit to 0.
+     * |[1]     |DMAUDR    |DMA Under Run Interrupt Flag
+     * |        |          |0 = No DMA under-run error condition occurred.
+     * |        |          |1 = DMA under-run error condition occurred.
+     * |        |          |User writes 1 to clear this bit.
+     * |[8]     |BUSY      |DAC Busy Flag (Read Only)
+     * |        |          |0 = DAC is ready for next conversion.
+     * |        |          |1 = DAC is busy in conversion.
+     * |        |          |This is read only bit.
+     * @var DAC_T::TCTL
+     * Offset: 0x14  DAC Timing Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9:0]   |SETTLET   |DAC Output Settling Time
+     * |        |          |User software needs to write appropriate value to these bits to meet DAC conversion settling time base on PCLK (APB clock) speed.
+     * |        |          |For example, DAC controller clock speed is 50MHz and DAC conversion setting time is 1 us, SETTLET value must be greater than 0x32.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] DAC Control Register                                            */
+    __IO uint32_t SWTRG;                 /*!< [0x0004] DAC Software Trigger Control Register                           */
+    __IO uint32_t DAT;                   /*!< [0x0008] DAC Data Holding Register                                       */
+    __I  uint32_t DATOUT;                /*!< [0x000c] DAC Data Output Register                                        */
+    __IO uint32_t STATUS;                /*!< [0x0010] DAC Status Register                                             */
+    __IO uint32_t TCTL;                  /*!< [0x0014] DAC Timing Control Register                                     */
+} DAC_T;
+
+/**
+    @addtogroup DAC_CONST DAC Bit Field Definition
+    Constant Definitions for DAC Controller
+@{ */
+
+#define DAC_CTL_DACEN_Pos                (0)                                               /*!< DAC_T::CTL: DACEN Position             */
+#define DAC_CTL_DACEN_Msk                (0x1ul << DAC_CTL_DACEN_Pos)                      /*!< DAC_T::CTL: DACEN Mask                 */
+
+#define DAC_CTL_DACIEN_Pos               (1)                                               /*!< DAC_T::CTL: DACIEN Position            */
+#define DAC_CTL_DACIEN_Msk               (0x1ul << DAC_CTL_DACIEN_Pos)                     /*!< DAC_T::CTL: DACIEN Mask                */
+
+#define DAC_CTL_DMAEN_Pos                (2)                                               /*!< DAC_T::CTL: DMAEN Position             */
+#define DAC_CTL_DMAEN_Msk                (0x1ul << DAC_CTL_DMAEN_Pos)                      /*!< DAC_T::CTL: DMAEN Mask                 */
+
+#define DAC_CTL_DMAURIEN_Pos             (3)                                               /*!< DAC_T::CTL: DMAURIEN Position          */
+#define DAC_CTL_DMAURIEN_Msk             (0x1ul << DAC_CTL_DMAURIEN_Pos)                   /*!< DAC_T::CTL: DMAURIEN Mask              */
+
+#define DAC_CTL_TRGEN_Pos                (4)                                               /*!< DAC_T::CTL: TRGEN Position             */
+#define DAC_CTL_TRGEN_Msk                (0x1ul << DAC_CTL_TRGEN_Pos)                      /*!< DAC_T::CTL: TRGEN Mask                 */
+
+#define DAC_CTL_TRGSEL_Pos               (5)                                               /*!< DAC_T::CTL: TRGSEL Position            */
+#define DAC_CTL_TRGSEL_Msk               (0x7ul << DAC_CTL_TRGSEL_Pos)                     /*!< DAC_T::CTL: TRGSEL Mask                */
+
+#define DAC_CTL_BYPASS_Pos               (8)                                               /*!< DAC_T::CTL: BYPASS Position            */
+#define DAC_CTL_BYPASS_Msk               (0x1ul << DAC_CTL_BYPASS_Pos)                     /*!< DAC_T::CTL: BYPASS Mask                */
+
+#define DAC_CTL_LALIGN_Pos               (10)                                              /*!< DAC_T::CTL: LALIGN Position            */
+#define DAC_CTL_LALIGN_Msk               (0x1ul << DAC_CTL_LALIGN_Pos)                     /*!< DAC_T::CTL: LALIGN Mask                */
+
+#define DAC_CTL_ETRGSEL_Pos              (12)                                              /*!< DAC_T::CTL: ETRGSEL Position           */
+#define DAC_CTL_ETRGSEL_Msk              (0x3ul << DAC_CTL_ETRGSEL_Pos)                    /*!< DAC_T::CTL: ETRGSEL Mask               */
+
+#define DAC_CTL_BWSEL_Pos                (14)                                              /*!< DAC_T::CTL: BWSEL Position             */
+#define DAC_CTL_BWSEL_Msk                (0x3ul << DAC_CTL_BWSEL_Pos)                      /*!< DAC_T::CTL: BWSEL Mask                 */
+
+#define DAC_CTL_GRPEN_Pos                (16)                                              /*!< DAC_T::CTL: GRPEN Position             */
+#define DAC_CTL_GRPEN_Msk                (0x1ul << DAC_CTL_GRPEN_Pos)                      /*!< DAC_T::CTL: GRPEN Mask                 */
+
+#define DAC_SWTRG_SWTRG_Pos              (0)                                               /*!< DAC_T::SWTRG: SWTRG Position           */
+#define DAC_SWTRG_SWTRG_Msk              (0x1ul << DAC_SWTRG_SWTRG_Pos)                    /*!< DAC_T::SWTRG: SWTRG Mask               */
+
+#define DAC_DAT_DACDAT_Pos               (0)                                               /*!< DAC_T::DAT: DACDAT Position            */
+#define DAC_DAT_DACDAT_Msk               (0xfffful << DAC_DAT_DACDAT_Pos)                  /*!< DAC_T::DAT: DACDAT Mask                */
+
+#define DAC_DATOUT_DATOUT_Pos            (0)                                               /*!< DAC_T::DATOUT: DATOUT Position         */
+#define DAC_DATOUT_DATOUT_Msk            (0xffful << DAC_DATOUT_DATOUT_Pos)                /*!< DAC_T::DATOUT: DATOUT Mask             */
+
+#define DAC_STATUS_FINISH_Pos            (0)                                               /*!< DAC_T::STATUS: FINISH Position         */
+#define DAC_STATUS_FINISH_Msk            (0x1ul << DAC_STATUS_FINISH_Pos)                  /*!< DAC_T::STATUS: FINISH Mask             */
+
+#define DAC_STATUS_DMAUDR_Pos            (1)                                               /*!< DAC_T::STATUS: DMAUDR Position         */
+#define DAC_STATUS_DMAUDR_Msk            (0x1ul << DAC_STATUS_DMAUDR_Pos)                  /*!< DAC_T::STATUS: DMAUDR Mask             */
+
+#define DAC_STATUS_BUSY_Pos              (8)                                               /*!< DAC_T::STATUS: BUSY Position           */
+#define DAC_STATUS_BUSY_Msk              (0x1ul << DAC_STATUS_BUSY_Pos)                    /*!< DAC_T::STATUS: BUSY Mask               */
+
+#define DAC_TCTL_SETTLET_Pos             (0)                                               /*!< DAC_T::TCTL: SETTLET Position          */
+#define DAC_TCTL_SETTLET_Msk             (0x3fful << DAC_TCTL_SETTLET_Pos)                 /*!< DAC_T::TCTL: SETTLET Mask              */
+
+/** @} DAC_CONST */
+/** @} end of DAC register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __DAC_REG_H__ */

--- a/hal/m258ke/nuvoton/eadc_reg.h
+++ b/hal/m258ke/nuvoton/eadc_reg.h
@@ -1,0 +1,828 @@
+/**************************************************************************//**
+ * @file     eadc_reg.h
+ * @version  V1.00
+ * @brief    EADC register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __EADC_REG_H__
+#define __EADC_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup EADC Enhanced Analog to Digital Converter (EADC)
+    Memory Mapped Structure for EADC Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var EADC_T::DAT[19]
+     * Offset: 0x00~0x48  A/D Data Register 0~18 for Sample Module 0 ~ 18
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |RESULT    |A/D Conversion Result
+     * |        |          |This field contains 12 bits conversion result.
+     * |[16]    |OV        |Overrun Flag
+     * |        |          |If converted data in RESULT[11:0] has not been read before new conversion result is loaded to this register, OV is set to 1.
+     * |        |          |0 = Data in RESULT[11:0] is recent conversion result.
+     * |        |          |1 = Data in RESULT[11:0] is overwrite.
+     * |        |          |Note: It is cleared by hardware after EADC_DAT register is read.
+     * |[17]    |VALID     |Valid Flag
+     * |        |          |This bit is set to 1 when corresponding sample module channel analog input conversion is completed and cleared by hardware after EADC_DAT register is read.
+     * |        |          |0 = Data in RESULT[11:0] bits is not valid.
+     * |        |          |1 = Data in RESULT[11:0] bits is valid.
+     * @var EADC_T::CURDAT
+     * Offset: 0x4C  EADC PDMA Current Transfer Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[18:0]  |CURDAT    |ADC PDMA Current Transfer Data (Read Only)
+     * |        |          |This register is a shadow register of EADC_DATn (n=0~18) for PDMA support.
+     * |        |          |This is a read only register.
+     * |        |          |NOTE: After PDMA read this register, the VAILD of the shadow EADC_DAT register will be automatically cleared.
+     * @var EADC_T::CTL
+     * Offset: 0x50  A/D Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ADCEN     |A/D Converter Enable Bit
+     * |        |          |0 = ADC Disabled.
+     * |        |          |1 = ADC Enabled.
+     * |        |          |Note: Before starting A/D conversion function, this bit should be set to 1
+     * |        |          |Clear it to 0 to disable A/D converter analog circuit power consumption.
+     * |[1]     |ADCRST    |ADC A/D Converter Control Circuits Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Cause ADC control circuits reset to initial state, but not change the ADC registers value.
+     * |        |          |Note: ADCRST bit remains 1 during ADC reset, when ADC reset end, the ADCRST bit is automatically cleared to 0.
+     * |[2]     |ADCIEN0   |Specific Sample Module A/D ADINT0 Interrupt Enable Bit
+     * |        |          |The A/D converter generates a conversion end ADIF0 (EADC_STATUS2[0]) upon the end of specific sample module A/D conversion
+     * |        |          |If ADCIEN0 bit is set then conversion end interrupt request ADINT0 is generated.
+     * |        |          |0 = Specific sample module A/D ADINT0 interrupt function Disabled.
+     * |        |          |1 = Specific sample module A/D ADINT0 interrupt function Enabled.
+     * |[3]     |ADCIEN1   |Specific Sample Module A/D ADINT1 Interrupt Enable Bit
+     * |        |          |The A/D converter generates a conversion end ADIF1 (EADC_STATUS2[1]) upon the end of specific sample module A/D conversion
+     * |        |          |If ADCIEN1 bit is set then conversion end interrupt request ADINT1 is generated.
+     * |        |          |0 = Specific sample module A/D ADINT1 interrupt function Disabled.
+     * |        |          |1 = Specific sample module A/D ADINT1 interrupt function Enabled.
+     * |[4]     |ADCIEN2   |Specific Sample Module A/D ADINT2 Interrupt Enable Bit
+     * |        |          |The A/D converter generates a conversion end ADIF2 (EADC_STATUS2[2]) upon the end of specific sample module A/D conversion
+     * |        |          |If ADCIEN2 bit is set then conversion end interrupt request ADINT2 is generated.
+     * |        |          |0 = Specific sample module A/D ADINT2 interrupt function Disabled.
+     * |        |          |1 = Specific sample module A/D ADINT2 interrupt function Enabled.
+     * |[5]     |ADCIEN3   |Specific Sample Module A/D ADINT3 Interrupt Enable Bit
+     * |        |          |The A/D converter generates a conversion end ADIF3 (EADC_STATUS2[3]) upon the end of specific sample module A/D conversion
+     * |        |          |If ADCIEN3 bit is set then conversion end interrupt request ADINT3 is generated.
+     * |        |          |0 = Specific sample module A/D ADINT3 interrupt function Disabled.
+     * |        |          |1 = Specific sample module A/D ADINT3 interrupt function Enabled.
+     * @var EADC_T::SWTRG
+     * Offset: 0x54  A/D Sample Module Software Start Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[18:0]  |SWTRG     |A/D Sample Module 0~18 Software Force to Start ADC Conversion
+     * |        |          |0 = No effect.
+     * |        |          |1 = Cause an ADC conversion when the priority is given to sample module.
+     * |        |          |Note: After writing this register to start ADC conversion, the EADC_PENDSTS register will show which sample module will conversion
+     * |        |          |If user want to disable the conversion of the sample module, user can write EADC_PENDSTS register to clear it.
+     * @var EADC_T::PENDSTS
+     * Offset: 0x58  A/D Start of Conversion Pending Flag Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[18:0]  |STPF      |A/D Sample Module 0~18 Start of Conversion Pending Flag
+     * |        |          |Read:
+     * |        |          |0 = There is no pending conversion for sample module.
+     * |        |          |1 = Sample module ADC start of conversion is pending.
+     * |        |          |Write:
+     * |        |          |1 = Clear pending flag and stop conversion for corresponding sample module.
+     * |        |          |Note1: This bit remains 1 during pending state, when the respective ADC conversion is end, the STPFn (n=0~18) bit is automatically cleared to 0.
+     * |        |          |Note2: After stopping current conversion, the corresponding EADC_DATn (n=0~18) keeps its original value
+     * @var EADC_T::OVSTS
+     * Offset: 0x5C  A/D Sample Module Start of Conversion Overrun Flag Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[18:0]  |SPOVF     |A/D SAMPLE0~18 Overrun Flag
+     * |        |          |0 = No sample module event overrun.
+     * |        |          |1 = Indicates a new sample module event is generated while an old one event is pending.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * @var EADC_T::SCTL[16]
+     * Offset: 0x80~0xBC  A/D Sample Module 0 ~ 15 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |CHSEL     |A/D Sample Module Channel Selection
+     * |        |          |00H = EADC_CH0.
+     * |        |          |01H = EADC_CH1.
+     * |        |          |02H = EADC_CH2.
+     * |        |          |03H = EADC_CH3.
+     * |        |          |04H = EADC_CH4.
+     * |        |          |05H = EADC_CH5.
+     * |        |          |06H = EADC_CH6.
+     * |        |          |07H = EADC_CH7.
+     * |        |          |08H = EADC_CH8.
+     * |        |          |09H = EADC_CH9.
+     * |        |          |0AH = EADC_CH10.
+     * |        |          |0BH = EADC_CH11.
+     * |        |          |0CH = EADC_CH12.
+     * |        |          |0DH = EADC_CH13.
+     * |        |          |0EH = EADC_CH14.
+     * |        |          |0FH = EADC_CH15.
+     * |        |          |Note: when internal ADC channel16, 17 or 18 is selected, EADC_CH15 is useless.
+     * |[4]     |EXTREN    |A/D External Trigger Rising Edge Enable Bit
+     * |        |          |0 = Rising edge Disabled when A/D selects EADC0_ST as trigger source.
+     * |        |          |1 = Rising edge Enabled when A/D selects EADC0_ST trigger source.
+     * |[5]     |EXTFEN    |A/D External Trigger Falling Edge Enable Bit
+     * |        |          |0 = Falling edge Disabled when A/D selects EADC0_ST as trigger source.
+     * |        |          |1 = Falling edge Enabled when A/D selects EADC0_ST as trigger source.
+     * |[7:6]   |TRGDLYDIV |A/D Sample Module Start of Conversion Trigger Delay Clock Divider Selection
+     * |        |          |Trigger delay clock frequency:
+     * |        |          |00 = ADC_CLK/1.
+     * |        |          |01 = ADC_CLK/2.
+     * |        |          |10 = ADC_CLK/4.
+     * |        |          |11 = ADC_CLK/16.
+     * |[15:8]  |TRGDLYCNT |A/D Sample Module Start of Conversion Trigger Delay Time
+     * |        |          |Trigger delay time = TRGDLYCNT x ADC_CLK x n (n=1,2,4,16 from TRGDLYDIV setting).
+     * |        |          |Note: If TRGDLYCNT is set to 1, Trigger delay time is actually the same as TRGDLYCNT is set to 2 for hardware operation.
+     * |[20:16] |TRGSEL    |A/D Sample Module Start of Conversion Trigger Source Selection
+     * |        |          |0H = Disable trigger.
+     * |        |          |1H = External trigger from EADC0_ST pin input.
+     * |        |          |2H = ADC ADINT0 interrupt EOC (End of conversion) pulse trigger.
+     * |        |          |3H = ADC ADINT1 interrupt EOC (End of conversion) pulse trigger.
+     * |        |          |4H = Timer0 overflow pulse trigger.
+     * |        |          |5H = Timer1 overflow pulse trigger.
+     * |        |          |6H = Timer2 overflow pulse trigger.
+     * |        |          |7H = Timer3 overflow pulse trigger.
+     * |        |          |8H = PWM0TG0.
+     * |        |          |9H = PWM0TG1.
+     * |        |          |AH = PWM0TG2.
+     * |        |          |BH = PWM0TG3.
+     * |        |          |CH = PWM0TG4.
+     * |        |          |DH = PWM0TG5.
+     * |        |          |EH = PWM1TG0.
+     * |        |          |FH = PWM1TG1.
+     * |        |          |10H = PWM1TG2.
+     * |        |          |11H = PWM1TG3.
+     * |        |          |12H = PWM1TG4.
+     * |        |          |13H = PWM1TG5.
+     * |        |          |14H =BPWM0TG.
+     * |        |          |15H =BPWM1TG.
+     * |        |          |other = Reserved.
+     * |        |          |NOTE: Refer PWM_EADCTS0, PWM_EADCTS1, BPWM_EADCTS0, BPWM_ EADCTS1 and TIMERn_CTL (n=0~3) to get more information for PWM, BPWM trigger and timer trigger.
+     * |[22]    |INTPOS    |Interrupt Flag Position Select
+     * |        |          |0 = Set ADIFn (EADC_STATUS2[n], n=0~3) at A/D end of conversion.
+     * |        |          |1 = Set ADIFn (EADC_STATUS2[n], n=0~3) at A/D start of conversion.
+     * |[31:24] |EXTSMPT   |ADC Sampling Time Extend
+     * |        |          |When A/D converting at high conversion rate, the sampling time of analog input voltage may not enough if input channel loading is heavy, user can extend A/D sampling time after trigger source is coming to get enough sampling time
+     * |        |          |EXTSMPT can be set from 0~8'd251.
+     * @var EADC_T::SCTL0[3]
+     * Offset: 0xc0~0xC8  A/D Sample Module 16 ~ 18 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PDMAEN    |PDMA Transfer Enable Bit
+     * |        |          |When ADC conversion is completed, the converted data is loaded into EADC_DATn (n: 16 ~ 18) register, user can enable this bit to generate a PDMA data transfer request.
+     * |        |          |0 = PDMA data transfer Disabled.
+     * |        |          |1 = PDMA data transfer Enabled.
+     * |        |          |Note: When set this bit field to 1, user must set ADCIENn (EADC_CTL[5:2], n=0~3) = 0 to disable interrupt.
+     * |[31:24] |EXTSMPT   |ADC Sampling Time Extend
+     * |        |          |When A/D converting at high conversion rate, the sampling time of analog input voltage may not enough if input channel loading is heavy, user can extend A/D sampling time after trigger source is coming to get enough sampling time
+     * |        |          |EXTSMPT can be set from 0~8'd251.
+     * @var EADC_T::INTSRC[4]
+     * Offset: 0xD0~0xDC  ADC Interrupt 0~4 Source Enable Control Register.
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SPLIE0    |Sample Module 0 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 0 interrupt Disabled.
+     * |        |          |1 = Sample Module 0 interrupt Enabled.
+     * |[1]     |SPLIE1    |Sample Module 1 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 1 interrupt Disabled.
+     * |        |          |1 = Sample Module 1 interrupt Enabled.
+     * |[2]     |SPLIE2    |Sample Module 2 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 2 interrupt Disabled.
+     * |        |          |1 = Sample Module 2 interrupt Enabled.
+     * |[3]     |SPLIE3    |Sample Module 3 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 3 interrupt Disabled.
+     * |        |          |1 = Sample Module 3 interrupt Enabled.
+     * |[4]     |SPLIE4    |Sample Module 4 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 4 interrupt Disabled.
+     * |        |          |1 = Sample Module 4 interrupt Enabled.
+     * |[5]     |SPLIE5    |Sample Module 5 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 5 interrupt Disabled.
+     * |        |          |1 = Sample Module 5 interrupt Enabled.
+     * |[6]     |SPLIE6    |Sample Module 6 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 6 interrupt Disabled.
+     * |        |          |1 = Sample Module 6 interrupt Enabled.
+     * |[7]     |SPLIE7    |Sample Module 7 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 7 interrupt Disabled.
+     * |        |          |1 = Sample Module 7 interrupt Enabled.
+     * |[8]     |SPLIE8    |Sample Module 8 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 8 interrupt Disabled.
+     * |        |          |1 = Sample Module 8 interrupt Enabled.
+     * |[9]     |SPLIE9    |Sample Module 9 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 9 interrupt Disabled.
+     * |        |          |1 = Sample Module 9 interrupt Enabled.
+     * |[10]    |SPLIE10   |Sample Module 10 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 10 interrupt Disabled.
+     * |        |          |1 = Sample Module 10 interrupt Enabled.
+     * |[11]    |SPLIE11   |Sample Module 11 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 11 interrupt Disabled.
+     * |        |          |1 = Sample Module 11 interrupt Enabled.
+     * |[12]    |SPLIE12   |Sample Module 12 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 12 interrupt Disabled.
+     * |        |          |1 = Sample Module 12 interrupt Enabled.
+     * |[13]    |SPLIE13   |Sample Module 13 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 13 interrupt Disabled.
+     * |        |          |1 = Sample Module 13 interrupt Enabled.
+     * |[14]    |SPLIE14   |Sample Module 14 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 14 interrupt Disabled.
+     * |        |          |1 = Sample Module 14 interrupt Enabled.
+     * |[15]    |SPLIE15   |Sample Module 15 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 15 interrupt Disabled.
+     * |        |          |1 = Sample Module 15 interrupt Enabled.
+     * |[16]    |SPLIE16   |Sample Module 16 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 16 interrupt Disabled.
+     * |        |          |1 = Sample Module 16 interrupt Enabled.
+     * |[17]    |SPLIE17   |Sample Module 17 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 17 interrupt Disabled.
+     * |        |          |1 = Sample Module 17 interrupt Enabled.
+     * |[18]    |SPLIE18   |Sample Module 18 Interrupt Enable Bit
+     * |        |          |0 = Sample Module 18 interrupt Disabled.
+     * |        |          |1 = Sample Module 18 interrupt Enabled.
+     * @var EADC_T::CMP[4]
+     * Offset: 0xE0~0xEC  A/D Result Compare Register 0 ~ 3
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ADCMPEN   |A/D Result Compare Enable Bit
+     * |        |          |0 = Compare Disabled.
+     * |        |          |1 = Compare Enabled.
+     * |        |          |Set this bit to 1 to enable compare CMPDAT (EADC_CMPn[27:16], n=0~3) with specified sample module conversion result when converted data is loaded into EADC_DAT register.
+     * |[1]     |ADCMPIE   |A/D Result Compare Interrupt Enable Bit
+     * |        |          |0 = Compare function interrupt Disabled.
+     * |        |          |1 = Compare function interrupt Enabled.
+     * |        |          |If the compare function is enabled and the compare condition matches the setting of CMPCOND (EADC_CMPn[2], n=0~3) and CMPMCNT (EADC_CMPn[11:8], n=0~3), ADCMPFn (EADC_STATUS2[7:4], n=0~3) will be asserted, in the meanwhile, if ADCMPIE is set to 1, a compare interrupt request is generated.
+     * |[2]     |CMPCOND   |Compare Condition
+     * |        |          |0= Set the compare condition as that when a 12-bit A/D conversion result is less than the 12-bit CMPDAT (EADC_CMPn [27:16]), the internal match counter will increase one.
+     * |        |          |1= Set the compare condition as that when a 12-bit A/D conversion result is greater or equal to the 12-bit CMPDAT (EADC_CMPn [27:16]), the internal match counter will increase one.
+     * |        |          |Note: When the internal counter reaches the value to (CMPMCNT (EADC_CMPn[11:8], n=0~3) +1), the ADCMPFn bit will be set.
+     * |[7:3]   |CMPSPL    |Compare Sample Module Selection
+     * |        |          |00000 = Sample Module 0 conversion result EADC_DAT0 is selected to be compared.
+     * |        |          |00001 = Sample Module 1 conversion result EADC_DAT1 is selected to be compared.
+     * |        |          |00010 = Sample Module 2 conversion result EADC_DAT2 is selected to be compared.
+     * |        |          |00011 = Sample Module 3 conversion result EADC_DAT3 is selected to be compared.
+     * |        |          |00100 = Sample Module 4 conversion result EADC_DAT4 is selected to be compared.
+     * |        |          |00101 = Sample Module 5 conversion result EADC_DAT5 is selected to be compared.
+     * |        |          |00110 = Sample Module 6 conversion result EADC_DAT6 is selected to be compared.
+     * |        |          |00111 = Sample Module 7 conversion result EADC_DAT7 is selected to be compared.
+     * |        |          |01000 = Sample Module 8 conversion result EADC_DAT8 is selected to be compared.
+     * |        |          |01001 = Sample Module 9 conversion result EADC_DAT9 is selected to be compared.
+     * |        |          |01010 = Sample Module 10 conversion result EADC_DAT10 is selected to be compared.
+     * |        |          |01011 = Sample Module 11 conversion result EADC_DAT11 is selected to be compared.
+     * |        |          |01100 = Sample Module 12 conversion result EADC_DAT12 is selected to be compared.
+     * |        |          |01101 = Sample Module 13 conversion result EADC_DAT13 is selected to be compared.
+     * |        |          |01110 = Sample Module 14 conversion result EADC_DAT14 is selected to be compared.
+     * |        |          |01111 = Sample Module 15 conversion result EADC_DAT15 is selected to be compared.
+     * |        |          |10000 = Sample Module 16 conversion result EADC_DAT16 is selected to be compared.
+     * |        |          |10001 = Sample Module 17 conversion result EADC_DAT17 is selected to be compared.
+     * |        |          |10010 = Sample Module 18 conversion result EADC_DAT18 is selected to be compared.
+     * |[11:8]  |CMPMCNT   |Compare Match Count
+     * |        |          |When the specified A/D sample module analog conversion result matches the compare condition defined by CMPCOND (EADC_CMPn[2], n=0~3), the internal match counter will increase 1
+     * |        |          |If the compare result does not meet the compare condition, the internal compare match counter will reset to 0
+     * |        |          |When the internal counter reaches the value to (CMPMCNT +1), the ADCMPFn (EADC_STATUS2[7:4], n=0~3) will be set.
+     * |[15]    |CMPWEN    |Compare Window Mode Enable Bit
+     * |        |          |0 = ADCMPF0 (EADC_STATUS2[4]) will be set when EADC_CMP0 compared condition matched
+     * |        |          |ADCMPF2 (EADC_STATUS2[6]) will be set when EADC_CMP2 compared condition matched
+     * |        |          |1 = ADCMPF0 (EADC_STATUS2[4]) will be set when both EADC_CMP0 and EADC_CMP1 compared condition matched
+     * |        |          |ADCMPF2 (EADC_STATUS2[6]) will be set when both EADC_CMP2 and EADC_CMP3 compared condition matched.
+     * |        |          |Note: This bit is only present in EADC_CMP0 and EADC_CMP2 register.
+     * |[27:16] |CMPDAT    |Comparison Data
+     * |        |          |The 12 bits data is used to compare with conversion result of specified sample module
+     * |        |          |User can use it to monitor the external analog input pin voltage transition without imposing a load on software.
+     * @var EADC_T::STATUS0
+     * Offset: 0xF0  A/D Status Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |VALID     |EADC_DAT0~15 Data Valid Flag
+     * |        |          |It is a mirror of VALID bit in sample module A/D result data register EADC_DATn. (n=0~15).
+     * |[31:16] |OV        |EADC_DAT0~15 Overrun Flag
+     * |        |          |It is a mirror to OV bit in sample module A/D result data register EADC_DATn. (n=0~15).
+     * @var EADC_T::STATUS1
+     * Offset: 0xF4  A/D Status Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |VALID     |EADC_DAT16~18 Data Valid Flag
+     * |        |          |It is a mirror of VALID bit in sample module A/D result data register EADC_DATn. (n=16~18).
+     * |[18:16] |OV        |EADC_DAT16~18 Overrun Flag
+     * |        |          |It is a mirror to OV bit in sample module A/D result data register EADC_DATn. (n=16~18).
+     * @var EADC_T::STATUS2
+     * Offset: 0xF8  A/D Status Register 2
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ADIF0     |A/D ADINT0 Interrupt Flag
+     * |        |          |0 = No ADINT0 interrupt pulse received.
+     * |        |          |1 = ADINT0 interrupt pulse has been received.
+     * |        |          |Note1: This bit is cleared by writing 1 to it.
+     * |        |          |Note2:This bit indicates whether an A/D conversion of specific sample module has been completed
+     * |[1]     |ADIF1     |A/D ADINT1 Interrupt Flag
+     * |        |          |0 = No ADINT1 interrupt pulse received.
+     * |        |          |1 = ADINT1 interrupt pulse has been received.
+     * |        |          |Note1: This bit is cleared by writing 1 to it.
+     * |        |          |Note2:This bit indicates whether an A/D conversion of specific sample module has been completed
+     * |[2]     |ADIF2     |A/D ADINT2 Interrupt Flag
+     * |        |          |0 = No ADINT2 interrupt pulse received.
+     * |        |          |1 = ADINT2 interrupt pulse has been received.
+     * |        |          |Note1: This bit is cleared by writing 1 to it.
+     * |        |          |Note2:This bit indicates whether an A/D conversion of specific sample module has been completed
+     * |[3]     |ADIF3     |A/D ADINT3 Interrupt Flag
+     * |        |          |0 = No ADINT3 interrupt pulse received.
+     * |        |          |1 = ADINT3 interrupt pulse has been received.
+     * |        |          |Note1: This bit is cleared by writing 1 to it.
+     * |        |          |Note2:This bit indicates whether an A/D conversion of specific sample module has been completed
+     * |[4]     |ADCMPF0   |ADC Compare 0 Flag
+     * |        |          |When the specific sample module A/D conversion result meets setting condition in EADC_CMP0 then this bit is set to 1.
+     * |        |          |0 = Conversion result in EADC_DAT does not meet EADC_CMP0 register setting.
+     * |        |          |1 = Conversion result in EADC_DAT meets EADC_CMP0 register setting.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[5]     |ADCMPF1   |ADC Compare 1 Flag
+     * |        |          |When the specific sample module A/D conversion result meets setting condition in EADC_CMP1 then this bit is set to 1.
+     * |        |          |0 = Conversion result in EADC_DAT does not meet EADC_CMP1 register setting.
+     * |        |          |1 = Conversion result in EADC_DAT meets EADC_CMP1 register setting.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[6]     |ADCMPF2   |ADC Compare 2 Flag
+     * |        |          |When the specific sample module A/D conversion result meets setting condition in EADC_CMP2 then this bit is set to 1.
+     * |        |          |0 = Conversion result in EADC_DAT does not meet EADC_CMP2 register setting.
+     * |        |          |1 = Conversion result in EADC_DAT meets EADC_CMP2 register setting.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[7]     |ADCMPF3   |ADC Compare 3 Flag
+     * |        |          |When the specific sample module A/D conversion result meets setting condition in EADC_CMP3 then this bit is set to 1.
+     * |        |          |0 = Conversion result in EADC_DAT does not meet EADC_CMP3 register setting.
+     * |        |          |1 = Conversion result in EADC_DAT meets EADC_CMP3 register setting.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[8]     |ADOVIF0   |A/D ADINT0 Interrupt Flag Overrun
+     * |        |          |0 = ADINT0 interrupt flag is not overwritten to 1.
+     * |        |          |1 = ADINT0 interrupt flag is overwritten to 1.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[9]     |ADOVIF1   |A/D ADINT1 Interrupt Flag Overrun
+     * |        |          |0 = ADINT1 interrupt flag is not overwritten to 1.
+     * |        |          |1 = ADINT1 interrupt flag is overwritten to 1.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[10]    |ADOVIF2   |A/D ADINT2 Interrupt Flag Overrun
+     * |        |          |0 = ADINT2 interrupt flag is not overwritten to 1.
+     * |        |          |1 = ADINT2 interrupt flag is overwritten to 1.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[11]    |ADOVIF3   |A/D ADINT3 Interrupt Flag Overrun
+     * |        |          |0 = ADINT3 interrupt flag is not overwritten to 1.
+     * |        |          |1 = ADINT3 interrupt flag is overwritten to 1.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[12]    |ADCMPO0   |ADC Compare 0 Output Status
+     * |        |          |The 12 bits compare0 data CMPDAT0 (EADC_CMP0[27:16]) is used to compare with conversion result of specified sample module
+     * |        |          |User can use it to monitor the external analog input pin voltage status.
+     * |        |          |0 = Conversion result in EADC_DAT less than CMPDAT0 setting.
+     * |        |          |1 = Conversion result in EADC_DAT great than or equal CMPDAT0 setting.
+     * |[13]    |ADCMPO1   |ADC Compare 1 Output Status
+     * |        |          |The 12 bits compare1 data CMPDAT1 (EADC_CMP1[27:16]) is used to compare with conversion result of specified sample module
+     * |        |          |User can use it to monitor the external analog input pin voltage status.
+     * |        |          |0 = Conversion result in EADC_DAT less than CMPDAT1 setting.
+     * |        |          |1 = Conversion result in EADC_DAT great than or equal CMPDAT1 setting.
+     * |[14]    |ADCMPO2   |ADC Compare 2 Output Status
+     * |        |          |The 12 bits compare2 data CMPDAT2 (EADC_CMP2[27:16]) is used to compare with conversion result of specified sample module
+     * |        |          |User can use it to monitor the external analog input pin voltage status.
+     * |        |          |0 = Conversion result in EADC_DAT less than CMPDAT2 setting.
+     * |        |          |1 = Conversion result in EADC_DAT great than or equal CMPDAT2 setting.
+     * |[15]    |ADCMPO3   |ADC Compare 3 Output Status
+     * |        |          |The 12 bits compare3 data CMPDAT3 (EADC_CMP3[27:16]) is used to compare with conversion result of specified sample module
+     * |        |          |User can use it to monitor the external analog input pin voltage status.
+     * |        |          |0 = Conversion result in EADC_DAT less than CMPDAT3 setting.
+     * |        |          |1 = Conversion result in EADC_DAT great than or equal CMPDAT3 setting.
+     * |[20:16] |CHANNEL   |Current Conversion Channel
+     * |        |          |This filed reflects ADC current conversion channel when BUSY=1.
+     * |        |          |It is read only.
+     * |        |          |00H = EADC_CH0.
+     * |        |          |01H = EADC_CH1.
+     * |        |          |02H = EADC_CH2.
+     * |        |          |03H = EADC_CH3.
+     * |        |          |04H = EADC_CH4.
+     * |        |          |05H = EADC_CH5.
+     * |        |          |06H = EADC_CH6.
+     * |        |          |07H = EADC_CH7.
+     * |        |          |08H = EADC_CH8.
+     * |        |          |09H = EADC_CH9.
+     * |        |          |0AH = EADC_CH10.
+     * |        |          |0BH = EADC_CH11.
+     * |        |          |0CH = EADC_CH12.
+     * |        |          |0DH = EADC_CH13.
+     * |        |          |0EH = EADC_CH14.
+     * |        |          |0FH = EADC_CH15.
+     * |        |          |10H = VBG.
+     * |        |          |11H = VTEMP.
+     * |        |          |12H = VBAT/4.
+     * |        |          |Note: These bit are read only.
+     * |[23]    |BUSY      |A/D Conveter Busy/Idle Status
+     * |        |          |0 = EADC is in idle state.
+     * |        |          |1 = EADC is busy for sample or conversion.
+     * |        |          |Note: This bit is read only
+     * |        |          |Once trigger source is coming, it must wait 2 ADC_CLK synchronization then the BUSY status will be high
+     * |        |          |This status will be high to low when the current conversion done.
+     * |[24]    |ADOVIF    |All A/D Interrupt Flag Overrun Bits Check
+     * |        |          |n=0~3.
+     * |        |          |0 = None of ADINT interrupt flag ADOVIFn (EADC_STATUS2[11:8]) is overwritten to 1.
+     * |        |          |1 = Any one of ADINT interrupt flag ADOVIFn (EADC_STATUS2[11:8]) is overwritten to 1.
+     * |        |          |Note: This bit will keep 1 when any ADOVIFn Flag is equal to 1.
+     * |[25]    |STOVF     |for All A/D Sample Module Start of Conversion Overrun Flags Check
+     * |        |          |n=0~18.
+     * |        |          |0 = None of sample module event overrun flag SPOVFn (EADC_OVSTS[n]) is set to 1.
+     * |        |          |1 = Any one of sample module event overrun flag SPOVFn (EADC_OVSTS[n]) is set to 1.
+     * |        |          |Note: This bit will keep 1 when any SPOVFn Flag is equal to 1.
+     * |[26]    |AVALID    |for All Sample Module A/D Result Data Register EADC_DAT Data Valid Flag Check
+     * |        |          |n=0~18.
+     * |        |          |0 = None of sample module data register valid flag VALIDn (EADC_DATn[17]) is set to 1.
+     * |        |          |1 = Any one of sample module data register valid flag VALIDn (EADC_DATn[17]) is set to 1.
+     * |        |          |Note: This bit will keep 1 when any VALIDn Flag is equal to 1.
+     * |[27]    |AOV       |for All Sample Module A/D Result Data Register Overrun Flags Check
+     * |        |          |n=0~18.
+     * |        |          |0 = None of sample module data register overrun flag OVn (EADC_DATn[16]) is set to 1.
+     * |        |          |1 = Any one of sample module data register overrun flag OVn (EADC_DATn[16]) is set to 1.
+     * |        |          |Note: This bit will keep 1 when any OVn Flag is equal to 1.
+     * @var EADC_T::STATUS3
+     * Offset: 0xFC  A/D Status Register 3
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[4:0]   |CURSPL    |ADC Current Sample Module
+     * |        |          |This register show the current ADC is controlled by which sample module control logic modules.
+     * |        |          |If the ADC is Idle, this bit filed will set to 0x1F.
+     * |        |          |Note: This is a read only register.
+     * @var EADC_T::PWRCTL
+     * Offset: 0x110  ADC Power Management Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |READY     |ADC Start-up Completely and Ready for Conversion (Read Only)
+     * |        |          |0 = Power-on sequence is still in progress.
+     * |        |          |1 = ADC is ready for conversion.
+     * |[5]     |AUTOFF    |Auto Off Mode
+     * |        |          |0 = Function of auto off disabled.
+     * |        |          |1 = Function of auto off enabled
+     * |        |          |When AUTOFF is set to 1, ADC will be power off automatically to save power
+     * |[19:8]  |STUPT     |ADC Start-up Time
+     * |        |          |Set this bit fields to adjust start-up time. The minimum start-up time of ADC is 10us.
+     * |        |          |ADC start-up time = (1/ADC_CLK) x STUPT.
+     * |[23:20] |AUTOPDTHT |Auto Power Down Threshold Time
+     * |        |          |Auto Power Down Threshold Time = (1/ADC_CLK) x AUTOPDTHT.
+     * |        |          |0111 = 8 ADC clock for power down threshold time.
+     * |        |          |1000 = 16 ADC clock for power down threshold time.
+     * |        |          |1001 = 32 ADC clock for power down threshold time.
+     * |        |          |1010 = 64 ADC clock for power down threshold time.
+     * |        |          |1011 = 128 ADC clock for power down threshold time.
+     * |        |          |1100 = 256 ADC clock for power down threshold time.
+     * |        |          |Others = 256 ADC clock for power down threshold time.
+     * @var EADC_T::PDMACTL
+     * Offset: 0x130  ADC PDMA Control Rgister
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[18:0]  |PDMATEN   |PDMA Transfer Enable Bit
+     * |        |          |When ADC conversion is completed, the converted data is loaded into EADC_DATn (n: 0 ~ 18) register, user can enable this bit to generate a PDMA data transfer request.
+     * |        |          |0 = PDMA data transfer Disabled.
+     * |        |          |1 = PDMA data transfer Enabled.
+     * |        |          |Note: When set this bit field to 1, user must set ADCIENn (EADC_CTL[5:2], n=0~3) = 0 to disable interrupt.
+     * @var EADC_T::MCTL1[16]
+     * Offset: 0x140~0x17C  A/D Sample Module 0~15 Control Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ALIGN     |Alignment Selection
+     * |        |          |0 = The conversion result will be right aligned in data register.
+     * |        |          |1 = The conversion result will be left aligned in data register.
+     * |[1]     |AVG       |Average Mode Selection
+     * |        |          |0 = Conversion results will be stored in data register without averaging.
+     * |        |          |1 = Conversion results in data register will be averaged.
+     * |        |          |This bit needs to work with ACU (EADC_MnCTL1[7:4], n=0~15).
+     * |[7:4]   |ACU       |Number of Accumulated Conversion Results Selection
+     * |        |          |0H = 1 conversion result will be accumulated.
+     * |        |          |1H = 2 conversion result will be accumulated.
+     * |        |          |2H = 4 conversion result will be accumulated.
+     * |        |          |3H = 8 conversion result will be accumulated.
+     * |        |          |4H = 16 conversion result will be accumulated.
+     * |        |          |5H = 32 conversion result will be accumulated.
+     * |        |          |6H = 64 conversion result will be accumulated.
+     * |        |          |7H = 128 conversion result will be accumulated.
+     * |        |          |8H = 256 conversion result will be accumulated.
+     */
+    __I  uint32_t DAT[19];               /*!< [0x0000~0x0048] A/D Data Register n for Sample Module n,  n=0~18          */
+    __I  uint32_t CURDAT;                /*!< [0x004c] EADC PDMA Current Transfer Data Register                         */
+    __IO uint32_t CTL;                   /*!< [0x0050] A/D Control Register                                             */
+    __O  uint32_t SWTRG;                 /*!< [0x0054] A/D Sample Module Software Start Register                        */
+    __IO uint32_t PENDSTS;               /*!< [0x0058] A/D Start of Conversion Pending Flag Register                    */
+    __IO uint32_t OVSTS;                 /*!< [0x005c] A/D Sample Module Start of Conversion Overrun Flag Register      */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[8];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t SCTL[16];              /*!< [0x0080~0x00bc] A/D Sample Module n Control Register n=0~15               */
+    __IO uint32_t SCTL0[3];              /*!< [0x00c0~0x00c8] A/D Sample Module n Control Register n=16~18              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t INTSRC[4];             /*!< [0x00d0~0x00dc] ADC Interrupt n Source Enable Control Register. n=0~3     */
+    __IO uint32_t CMP[4];                /*!< [0x00e0~0x00ec] A/D Result Compare Register n, n=0~3                      */
+    __I  uint32_t STATUS0;               /*!< [0x00f0] A/D Status Register 0                                            */
+    __I  uint32_t STATUS1;               /*!< [0x00f4] A/D Status Register 1                                            */
+    __IO uint32_t STATUS2;               /*!< [0x00f8] A/D Status Register 2                                            */
+    __I  uint32_t STATUS3;               /*!< [0x00fc] A/D Status Register 3                                            */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[4];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PWRCTL;                /*!< [0x0110] ADC Power Management Control Register                            */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[7];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PDMACTL;               /*!< [0x0130] ADC PDMA Control Rgister                                         */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE4[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t MCTL1[16];             /*!< [0x0140~0x017c] A/D Sample Module n Control Register 1, n=0~15            */
+} EADC_T;
+
+/**
+    @addtogroup EADC_CONST EADC Bit Field Definition
+    Constant Definitions for EADC Controller
+@{ */
+
+#define EADC_DAT_RESULT_Pos              (0)                                               /*!< EADC_T::DATn: RESULT Position          */
+#define EADC_DAT_RESULT_Msk              (0xfffful << EADC_DAT_RESULT_Pos)                 /*!< EADC_T::DATn: RESULT Mask              */
+
+#define EADC_DAT_OV_Pos                  (16)                                              /*!< EADC_T::DATn: OV Position              */
+#define EADC_DAT_OV_Msk                  (0x1ul << EADC_DAT_OV_Pos)                        /*!< EADC_T::DATn: OV Mask                  */
+
+#define EADC_DAT_VALID_Pos               (17)                                              /*!< EADC_T::DATn: VALID Position           */
+#define EADC_DAT_VALID_Msk               (0x1ul << EADC_DAT_VALID_Pos)                     /*!< EADC_T::DATn: VALID Mask               */
+
+#define EADC_CURDAT_CURDAT_Pos           (0)                                               /*!< EADC_T::CURDAT: CURDAT Position        */
+#define EADC_CURDAT_CURDAT_Msk           (0x3fffful << EADC_CURDAT_CURDAT_Pos)             /*!< EADC_T::CURDAT: CURDAT Mask            */
+
+#define EADC_CTL_ADCEN_Pos               (0)                                               /*!< EADC_T::CTL: ADCEN Position            */
+#define EADC_CTL_ADCEN_Msk               (0x1ul << EADC_CTL_ADCEN_Pos)                     /*!< EADC_T::CTL: ADCEN Mask                */
+
+#define EADC_CTL_ADCRST_Pos              (1)                                               /*!< EADC_T::CTL: ADCRST Position           */
+#define EADC_CTL_ADCRST_Msk              (0x1ul << EADC_CTL_ADCRST_Pos)                    /*!< EADC_T::CTL: ADCRST Mask               */
+
+#define EADC_CTL_ADCIEN0_Pos             (2)                                               /*!< EADC_T::CTL: ADCIEN0 Position          */
+#define EADC_CTL_ADCIEN0_Msk             (0x1ul << EADC_CTL_ADCIEN0_Pos)                   /*!< EADC_T::CTL: ADCIEN0 Mask              */
+
+#define EADC_CTL_ADCIEN1_Pos             (3)                                               /*!< EADC_T::CTL: ADCIEN1 Position          */
+#define EADC_CTL_ADCIEN1_Msk             (0x1ul << EADC_CTL_ADCIEN1_Pos)                   /*!< EADC_T::CTL: ADCIEN1 Mask              */
+
+#define EADC_CTL_ADCIEN2_Pos             (4)                                               /*!< EADC_T::CTL: ADCIEN2 Position          */
+#define EADC_CTL_ADCIEN2_Msk             (0x1ul << EADC_CTL_ADCIEN2_Pos)                   /*!< EADC_T::CTL: ADCIEN2 Mask              */
+
+#define EADC_CTL_ADCIEN3_Pos             (5)                                               /*!< EADC_T::CTL: ADCIEN3 Position          */
+#define EADC_CTL_ADCIEN3_Msk             (0x1ul << EADC_CTL_ADCIEN3_Pos)                   /*!< EADC_T::CTL: ADCIEN3 Mask              */
+
+#define EADC_SWTRG_SWTRG_Pos             (0)                                               /*!< EADC_T::SWTRG: SWTRG Position          */
+#define EADC_SWTRG_SWTRG_Msk             (0x7fffful << EADC_SWTRG_SWTRG_Pos)               /*!< EADC_T::SWTRG: SWTRG Mask              */
+
+#define EADC_PENDSTS_STPF_Pos            (0)                                               /*!< EADC_T::PENDSTS: STPF Position         */
+#define EADC_PENDSTS_STPF_Msk            (0x7fffful << EADC_PENDSTS_STPF_Pos)              /*!< EADC_T::PENDSTS: STPF Mask             */
+
+#define EADC_OVSTS_SPOVF_Pos             (0)                                               /*!< EADC_T::OVSTS: SPOVF Position          */
+#define EADC_OVSTS_SPOVF_Msk             (0x7fffful << EADC_OVSTS_SPOVF_Pos)               /*!< EADC_T::OVSTS: SPOVF Mask              */
+
+#define EADC_SCTL_CHSEL_Pos              (0)                                               /*!< EADC_T::SCTLn: CHSEL Position          */
+#define EADC_SCTL_CHSEL_Msk              (0xful << EADC_SCTL_CHSEL_Pos)                    /*!< EADC_T::SCTLn: CHSEL Mask              */
+
+#define EADC_SCTL_EXTREN_Pos             (4)                                               /*!< EADC_T::SCTLn: EXTREN Position         */
+#define EADC_SCTL_EXTREN_Msk             (0x1ul << EADC_SCTL_EXTREN_Pos)                   /*!< EADC_T::SCTLn: EXTREN Mask             */
+
+#define EADC_SCTL_EXTFEN_Pos             (5)                                               /*!< EADC_T::SCTLn: EXTFEN Position         */
+#define EADC_SCTL_EXTFEN_Msk             (0x1ul << EADC_SCTL_EXTFEN_Pos)                   /*!< EADC_T::SCTLn: EXTFEN Mask             */
+
+#define EADC_SCTL_TRGDLYDIV_Pos          (6)                                               /*!< EADC_T::SCTLn: TRGDLYDIV Position      */
+#define EADC_SCTL_TRGDLYDIV_Msk          (0x3ul << EADC_SCTL_TRGDLYDIV_Pos)                /*!< EADC_T::SCTLn: TRGDLYDIV Mask          */
+
+#define EADC_SCTL_TRGDLYCNT_Pos          (8)                                               /*!< EADC_T::SCTLn: TRGDLYCNT Position      */
+#define EADC_SCTL_TRGDLYCNT_Msk          (0xfful << EADC_SCTL_TRGDLYCNT_Pos)               /*!< EADC_T::SCTLn: TRGDLYCNT Mask          */
+
+#define EADC_SCTL_TRGSEL_Pos             (16)                                              /*!< EADC_T::SCTLn: TRGSEL Position         */
+#define EADC_SCTL_TRGSEL_Msk             (0x1ful << EADC_SCTL_TRGSEL_Pos)                  /*!< EADC_T::SCTLn: TRGSEL Mask             */
+
+#define EADC_SCTL_INTPOS_Pos             (22)                                              /*!< EADC_T::SCTLn: INTPOS Position         */
+#define EADC_SCTL_INTPOS_Msk             (0x1ul << EADC_SCTL_INTPOS_Pos)                   /*!< EADC_T::SCTLn: INTPOS Mask             */
+
+#define EADC_SCTL_EXTSMPT_Pos            (24)                                              /*!< EADC_T::SCTLn: EXTSMPT Position        */
+#define EADC_SCTL_EXTSMPT_Msk            (0xfful << EADC_SCTL_EXTSMPT_Pos)                 /*!< EADC_T::SCTLn: EXTSMPT Mask            */
+
+#define EADC_SCTL0_EXTSMPT_Pos           (24)                                              /*!< EADC_T::SCTL0n: EXTSMPT Position       */
+#define EADC_SCTL0_EXTSMPT_Msk           (0xfful << EADC_SCTL0_EXTSMPT_Pos)                /*!< EADC_T::SCTL0n: EXTSMPT Mask           */
+
+#define EADC_INTSRC_SPLIE0_Pos           (0)                                               /*!< EADC_T::INTSRCn: SPLIE0 Position       */
+#define EADC_INTSRC_SPLIE0_Msk           (0x1ul << EADC_INTSRC_SPLIE0_Pos)                 /*!< EADC_T::INTSRCn: SPLIE0 Mask           */
+
+#define EADC_INTSRC_SPLIE1_Pos           (1)                                               /*!< EADC_T::INTSRCn: SPLIE1 Position       */
+#define EADC_INTSRC_SPLIE1_Msk           (0x1ul << EADC_INTSRC_SPLIE1_Pos)                 /*!< EADC_T::INTSRCn: SPLIE1 Mask           */
+
+#define EADC_INTSRC_SPLIE2_Pos           (2)                                               /*!< EADC_T::INTSRCn: SPLIE2 Position       */
+#define EADC_INTSRC_SPLIE2_Msk           (0x1ul << EADC_INTSRC_SPLIE2_Pos)                 /*!< EADC_T::INTSRCn: SPLIE2 Mask           */
+
+#define EADC_INTSRC_SPLIE3_Pos           (3)                                               /*!< EADC_T::INTSRCn: SPLIE3 Position       */
+#define EADC_INTSRC_SPLIE3_Msk           (0x1ul << EADC_INTSRC_SPLIE3_Pos)                 /*!< EADC_T::INTSRCn: SPLIE3 Mask           */
+
+#define EADC_INTSRC_SPLIE4_Pos           (4)                                               /*!< EADC_T::INTSRCn: SPLIE4 Position       */
+#define EADC_INTSRC_SPLIE4_Msk           (0x1ul << EADC_INTSRC_SPLIE4_Pos)                 /*!< EADC_T::INTSRCn: SPLIE4 Mask           */
+
+#define EADC_INTSRC_SPLIE5_Pos           (5)                                               /*!< EADC_T::INTSRCn: SPLIE5 Position       */
+#define EADC_INTSRC_SPLIE5_Msk           (0x1ul << EADC_INTSRC_SPLIE5_Pos)                 /*!< EADC_T::INTSRCn: SPLIE5 Mask           */
+
+#define EADC_INTSRC_SPLIE6_Pos           (6)                                               /*!< EADC_T::INTSRCn: SPLIE6 Position       */
+#define EADC_INTSRC_SPLIE6_Msk           (0x1ul << EADC_INTSRC_SPLIE6_Pos)                 /*!< EADC_T::INTSRCn: SPLIE6 Mask           */
+
+#define EADC_INTSRC_SPLIE7_Pos           (7)                                               /*!< EADC_T::INTSRCn: SPLIE7 Position       */
+#define EADC_INTSRC_SPLIE7_Msk           (0x1ul << EADC_INTSRC_SPLIE7_Pos)                 /*!< EADC_T::INTSRCn: SPLIE7 Mask           */
+
+#define EADC_INTSRC_SPLIE8_Pos           (8)                                               /*!< EADC_T::INTSRCn: SPLIE8 Position       */
+#define EADC_INTSRC_SPLIE8_Msk           (0x1ul << EADC_INTSRC_SPLIE8_Pos)                 /*!< EADC_T::INTSRCn: SPLIE8 Mask           */
+
+#define EADC_INTSRC_SPLIE9_Pos           (9)                                               /*!< EADC_T::INTSRCn: SPLIE9 Position       */
+#define EADC_INTSRC_SPLIE9_Msk           (0x1ul << EADC_INTSRC_SPLIE9_Pos)                 /*!< EADC_T::INTSRCn: SPLIE9 Mask           */
+
+#define EADC_INTSRC_SPLIE10_Pos          (10)                                              /*!< EADC_T::INTSRCn: SPLIE10 Position      */
+#define EADC_INTSRC_SPLIE10_Msk          (0x1ul << EADC_INTSRC_SPLIE10_Pos)                /*!< EADC_T::INTSRCn: SPLIE10 Mask          */
+
+#define EADC_INTSRC_SPLIE11_Pos          (11)                                              /*!< EADC_T::INTSRCn: SPLIE11 Position      */
+#define EADC_INTSRC_SPLIE11_Msk          (0x1ul << EADC_INTSRC_SPLIE11_Pos)                /*!< EADC_T::INTSRCn: SPLIE11 Mask          */
+
+#define EADC_INTSRC_SPLIE12_Pos          (12)                                              /*!< EADC_T::INTSRCn: SPLIE12 Position      */
+#define EADC_INTSRC_SPLIE12_Msk          (0x1ul << EADC_INTSRC_SPLIE12_Pos)                /*!< EADC_T::INTSRCn: SPLIE12 Mask          */
+
+#define EADC_INTSRC_SPLIE13_Pos          (13)                                              /*!< EADC_T::INTSRCn: SPLIE13 Position      */
+#define EADC_INTSRC_SPLIE13_Msk          (0x1ul << EADC_INTSRC_SPLIE13_Pos)                /*!< EADC_T::INTSRCn: SPLIE13 Mask          */
+
+#define EADC_INTSRC_SPLIE14_Pos          (14)                                              /*!< EADC_T::INTSRCn: SPLIE14 Position      */
+#define EADC_INTSRC_SPLIE14_Msk          (0x1ul << EADC_INTSRC_SPLIE14_Pos)                /*!< EADC_T::INTSRCn: SPLIE14 Mask          */
+
+#define EADC_INTSRC_SPLIE15_Pos          (15)                                              /*!< EADC_T::INTSRCn: SPLIE15 Position      */
+#define EADC_INTSRC_SPLIE15_Msk          (0x1ul << EADC_INTSRC_SPLIE15_Pos)                /*!< EADC_T::INTSRCn: SPLIE15 Mask          */
+
+#define EADC_INTSRC_SPLIE16_Pos          (16)                                              /*!< EADC_T::INTSRCn: SPLIE16 Position      */
+#define EADC_INTSRC_SPLIE16_Msk          (0x1ul << EADC_INTSRC_SPLIE16_Pos)                /*!< EADC_T::INTSRCn: SPLIE16 Mask          */
+
+#define EADC_INTSRC_SPLIE17_Pos          (17)                                              /*!< EADC_T::INTSRCn: SPLIE17 Position      */
+#define EADC_INTSRC_SPLIE17_Msk          (0x1ul << EADC_INTSRC_SPLIE17_Pos)                /*!< EADC_T::INTSRCn: SPLIE17 Mask          */
+
+#define EADC_INTSRC_SPLIE18_Pos          (18)                                              /*!< EADC_T::INTSRCn: SPLIE18 Position      */
+#define EADC_INTSRC_SPLIE18_Msk          (0x1ul << EADC_INTSRC_SPLIE18_Pos)                /*!< EADC_T::INTSRCn: SPLIE18 Mask          */
+
+#define EADC_CMP_ADCMPEN_Pos             (0)                                               /*!< EADC_T::CMPn: ADCMPEN Position         */
+#define EADC_CMP_ADCMPEN_Msk             (0x1ul << EADC_CMP_ADCMPEN_Pos)                   /*!< EADC_T::CMPn: ADCMPEN Mask             */
+
+#define EADC_CMP_ADCMPIE_Pos             (1)                                               /*!< EADC_T::CMPn: ADCMPIE Position         */
+#define EADC_CMP_ADCMPIE_Msk             (0x1ul << EADC_CMP_ADCMPIE_Pos)                   /*!< EADC_T::CMPn: ADCMPIE Mask             */
+
+#define EADC_CMP_CMPCOND_Pos             (2)                                               /*!< EADC_T::CMPn: CMPCOND Position         */
+#define EADC_CMP_CMPCOND_Msk             (0x1ul << EADC_CMP_CMPCOND_Pos)                   /*!< EADC_T::CMPn: CMPCOND Mask             */
+
+#define EADC_CMP_CMPSPL_Pos              (3)                                               /*!< EADC_T::CMPn: CMPSPL Position          */
+#define EADC_CMP_CMPSPL_Msk              (0x1ful << EADC_CMP_CMPSPL_Pos)                   /*!< EADC_T::CMPn: CMPSPL Mask              */
+
+#define EADC_CMP_CMPMCNT_Pos             (8)                                               /*!< EADC_T::CMPn: CMPMCNT Position         */
+#define EADC_CMP_CMPMCNT_Msk             (0xful << EADC_CMP_CMPMCNT_Pos)                   /*!< EADC_T::CMPn: CMPMCNT Mask             */
+
+#define EADC_CMP_CMPWEN_Pos              (15)                                              /*!< EADC_T::CMPn: CMPWEN Position          */
+#define EADC_CMP_CMPWEN_Msk              (0x1ul << EADC_CMP_CMPWEN_Pos)                    /*!< EADC_T::CMPn: CMPWEN Mask              */
+
+#define EADC_CMP_CMPDAT_Pos              (16)                                              /*!< EADC_T::CMPn: CMPDAT Position          */
+#define EADC_CMP_CMPDAT_Msk              (0xffful << EADC_CMP_CMPDAT_Pos)                  /*!< EADC_T::CMPn: CMPDAT Mask              */
+
+#define EADC_STATUS0_VALID_Pos           (0)                                               /*!< EADC_T::STATUS0: VALID Position        */
+#define EADC_STATUS0_VALID_Msk           (0xfffful << EADC_STATUS0_VALID_Pos)              /*!< EADC_T::STATUS0: VALID Mask            */
+
+#define EADC_STATUS0_OV_Pos              (16)                                              /*!< EADC_T::STATUS0: OV Position           */
+#define EADC_STATUS0_OV_Msk              (0xfffful << EADC_STATUS0_OV_Pos)                 /*!< EADC_T::STATUS0: OV Mask               */
+
+#define EADC_STATUS1_VALID_Pos           (0)                                               /*!< EADC_T::STATUS1: VALID Position        */
+#define EADC_STATUS1_VALID_Msk           (0x7ul << EADC_STATUS1_VALID_Pos)                 /*!< EADC_T::STATUS1: VALID Mask            */
+
+#define EADC_STATUS1_OV_Pos              (16)                                              /*!< EADC_T::STATUS1: OV Position           */
+#define EADC_STATUS1_OV_Msk              (0x7ul << EADC_STATUS1_OV_Pos)                    /*!< EADC_T::STATUS1: OV Mask               */
+
+#define EADC_STATUS2_ADIF0_Pos           (0)                                               /*!< EADC_T::STATUS2: ADIF0 Position        */
+#define EADC_STATUS2_ADIF0_Msk           (0x1ul << EADC_STATUS2_ADIF0_Pos)                 /*!< EADC_T::STATUS2: ADIF0 Mask            */
+
+#define EADC_STATUS2_ADIF1_Pos           (1)                                               /*!< EADC_T::STATUS2: ADIF1 Position        */
+#define EADC_STATUS2_ADIF1_Msk           (0x1ul << EADC_STATUS2_ADIF1_Pos)                 /*!< EADC_T::STATUS2: ADIF1 Mask            */
+
+#define EADC_STATUS2_ADIF2_Pos           (2)                                               /*!< EADC_T::STATUS2: ADIF2 Position        */
+#define EADC_STATUS2_ADIF2_Msk           (0x1ul << EADC_STATUS2_ADIF2_Pos)                 /*!< EADC_T::STATUS2: ADIF2 Mask            */
+
+#define EADC_STATUS2_ADIF3_Pos           (3)                                               /*!< EADC_T::STATUS2: ADIF3 Position        */
+#define EADC_STATUS2_ADIF3_Msk           (0x1ul << EADC_STATUS2_ADIF3_Pos)                 /*!< EADC_T::STATUS2: ADIF3 Mask            */
+
+#define EADC_STATUS2_ADCMPF0_Pos         (4)                                               /*!< EADC_T::STATUS2: ADCMPF0 Position      */
+#define EADC_STATUS2_ADCMPF0_Msk         (0x1ul << EADC_STATUS2_ADCMPF0_Pos)               /*!< EADC_T::STATUS2: ADCMPF0 Mask          */
+
+#define EADC_STATUS2_ADCMPF1_Pos         (5)                                               /*!< EADC_T::STATUS2: ADCMPF1 Position      */
+#define EADC_STATUS2_ADCMPF1_Msk         (0x1ul << EADC_STATUS2_ADCMPF1_Pos)               /*!< EADC_T::STATUS2: ADCMPF1 Mask          */
+
+#define EADC_STATUS2_ADCMPF2_Pos         (6)                                               /*!< EADC_T::STATUS2: ADCMPF2 Position      */
+#define EADC_STATUS2_ADCMPF2_Msk         (0x1ul << EADC_STATUS2_ADCMPF2_Pos)               /*!< EADC_T::STATUS2: ADCMPF2 Mask          */
+
+#define EADC_STATUS2_ADCMPF3_Pos         (7)                                               /*!< EADC_T::STATUS2: ADCMPF3 Position      */
+#define EADC_STATUS2_ADCMPF3_Msk         (0x1ul << EADC_STATUS2_ADCMPF3_Pos)               /*!< EADC_T::STATUS2: ADCMPF3 Mask          */
+
+#define EADC_STATUS2_ADOVIF0_Pos         (8)                                               /*!< EADC_T::STATUS2: ADOVIF0 Position      */
+#define EADC_STATUS2_ADOVIF0_Msk         (0x1ul << EADC_STATUS2_ADOVIF0_Pos)               /*!< EADC_T::STATUS2: ADOVIF0 Mask          */
+
+#define EADC_STATUS2_ADOVIF1_Pos         (9)                                               /*!< EADC_T::STATUS2: ADOVIF1 Position      */
+#define EADC_STATUS2_ADOVIF1_Msk         (0x1ul << EADC_STATUS2_ADOVIF1_Pos)               /*!< EADC_T::STATUS2: ADOVIF1 Mask          */
+
+#define EADC_STATUS2_ADOVIF2_Pos         (10)                                              /*!< EADC_T::STATUS2: ADOVIF2 Position      */
+#define EADC_STATUS2_ADOVIF2_Msk         (0x1ul << EADC_STATUS2_ADOVIF2_Pos)               /*!< EADC_T::STATUS2: ADOVIF2 Mask          */
+
+#define EADC_STATUS2_ADOVIF3_Pos         (11)                                              /*!< EADC_T::STATUS2: ADOVIF3 Position      */
+#define EADC_STATUS2_ADOVIF3_Msk         (0x1ul << EADC_STATUS2_ADOVIF3_Pos)               /*!< EADC_T::STATUS2: ADOVIF3 Mask          */
+
+#define EADC_STATUS2_ADCMPO0_Pos         (12)                                              /*!< EADC_T::STATUS2: ADCMPO0 Position      */
+#define EADC_STATUS2_ADCMPO0_Msk         (0x1ul << EADC_STATUS2_ADCMPO0_Pos)               /*!< EADC_T::STATUS2: ADCMPO0 Mask          */
+
+#define EADC_STATUS2_ADCMPO1_Pos         (13)                                              /*!< EADC_T::STATUS2: ADCMPO1 Position      */
+#define EADC_STATUS2_ADCMPO1_Msk         (0x1ul << EADC_STATUS2_ADCMPO1_Pos)               /*!< EADC_T::STATUS2: ADCMPO1 Mask          */
+
+#define EADC_STATUS2_ADCMPO2_Pos         (14)                                              /*!< EADC_T::STATUS2: ADCMPO2 Position      */
+#define EADC_STATUS2_ADCMPO2_Msk         (0x1ul << EADC_STATUS2_ADCMPO2_Pos)               /*!< EADC_T::STATUS2: ADCMPO2 Mask          */
+
+#define EADC_STATUS2_ADCMPO3_Pos         (15)                                              /*!< EADC_T::STATUS2: ADCMPO3 Position      */
+#define EADC_STATUS2_ADCMPO3_Msk         (0x1ul << EADC_STATUS2_ADCMPO3_Pos)               /*!< EADC_T::STATUS2: ADCMPO3 Mask          */
+
+#define EADC_STATUS2_CHANNEL_Pos         (16)                                              /*!< EADC_T::STATUS2: CHANNEL Position      */
+#define EADC_STATUS2_CHANNEL_Msk         (0x1ful << EADC_STATUS2_CHANNEL_Pos)              /*!< EADC_T::STATUS2: CHANNEL Mask          */
+
+#define EADC_STATUS2_BUSY_Pos            (23)                                              /*!< EADC_T::STATUS2: BUSY Position         */
+#define EADC_STATUS2_BUSY_Msk            (0x1ul << EADC_STATUS2_BUSY_Pos)                  /*!< EADC_T::STATUS2: BUSY Mask             */
+
+#define EADC_STATUS2_ADOVIF_Pos          (24)                                              /*!< EADC_T::STATUS2: ADOVIF Position       */
+#define EADC_STATUS2_ADOVIF_Msk          (0x1ul << EADC_STATUS2_ADOVIF_Pos)                /*!< EADC_T::STATUS2: ADOVIF Mask           */
+
+#define EADC_STATUS2_STOVF_Pos           (25)                                              /*!< EADC_T::STATUS2: STOVF Position        */
+#define EADC_STATUS2_STOVF_Msk           (0x1ul << EADC_STATUS2_STOVF_Pos)                 /*!< EADC_T::STATUS2: STOVF Mask            */
+
+#define EADC_STATUS2_AVALID_Pos          (26)                                              /*!< EADC_T::STATUS2: AVALID Position       */
+#define EADC_STATUS2_AVALID_Msk          (0x1ul << EADC_STATUS2_AVALID_Pos)                /*!< EADC_T::STATUS2: AVALID Mask           */
+
+#define EADC_STATUS2_AOV_Pos             (27)                                              /*!< EADC_T::STATUS2: AOV Position          */
+#define EADC_STATUS2_AOV_Msk             (0x1ul << EADC_STATUS2_AOV_Pos)                   /*!< EADC_T::STATUS2: AOV Mask              */
+
+#define EADC_STATUS3_CURSPL_Pos          (0)                                               /*!< EADC_T::STATUS3: CURSPL Position       */
+#define EADC_STATUS3_CURSPL_Msk          (0x1ful << EADC_STATUS3_CURSPL_Pos)               /*!< EADC_T::STATUS3: CURSPL Mask           */
+
+#define EADC_MCTL1_ALIGN_Pos             (0)                                               /*!< EADC_T::MnCTL1: ALIGN Position         */
+#define EADC_MCTL1_ALIGN_Msk             (0x1ul << EADC_MCTL1_ALIGN_Pos)                   /*!< EADC_T::MnCTL1: ALIGN Mask             */
+
+#define EADC_MCTL1_AVG_Pos               (1)                                               /*!< EADC_T::MnCTL1: AVG Position           */
+#define EADC_MCTL1_AVG_Msk               (0x1ul << EADC_MCTL1_AVG_Pos)                     /*!< EADC_T::MnCTL1: AVG Mask               */
+
+#define EADC_MCTL1_ACU_Pos               (4)                                               /*!< EADC_T::MnCTL1: ACU Position           */
+#define EADC_MCTL1_ACU_Msk               (0xful << EADC_MCTL1_ACU_Pos)                     /*!< EADC_T::MnCTL1: ACU Mask               */
+
+#define EADC_PWRCTL_READY_Pos            (0)                                               /*!< EADC_T::PWRCTL: READY Position         */
+#define EADC_PWRCTL_READY_Msk            (0x1ul << EADC_PWRCTL_READY_Pos)                  /*!< EADC_T::PWRCTL: READY Mask             */
+
+#define EADC_PWRCTL_AUTOFF_Pos           (5)                                               /*!< EADC_T::PWRCTL: AUTOFF Position        */
+#define EADC_PWRCTL_AUTOFF_Msk           (0x1ul << EADC_PWRCTL_AUTOFF_Pos)                 /*!< EADC_T::PWRCTL: AUTOFF Mask            */
+
+#define EADC_PWRCTL_STUPT_Pos            (8)                                               /*!< EADC_T::PWRCTL: STUPT Position         */
+#define EADC_PWRCTL_STUPT_Msk            (0xffful << EADC_PWRCTL_STUPT_Pos)                /*!< EADC_T::PWRCTL: STUPT Mask             */
+
+#define EADC_PWRCTL_AUTOPDTHT_Pos        (20)                                              /*!< EADC_T::PWRCTL: AUTOPDTHT Position     */
+#define EADC_PWRCTL_AUTOPDTHT_Msk        (0xful << EADC_PWRCTL_AUTOPDTHT_Pos)              /*!< EADC_T::PWRCTL: AUTOPDTHT Mask         */
+
+#define EADC_PDMACTL_PDMATEN_Pos         (0)                                               /*!< EADC_T::PDMACTL: PDMATEN Position      */
+#define EADC_PDMACTL_PDMATEN_Msk         (0x7fffful << EADC_PDMACTL_PDMATEN_Pos)           /*!< EADC_T::PDMACTL: PDMATEN Mask          */
+
+/** @} EADC_CONST */
+/** @} end of EADC register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __EADC_REG_H__ */

--- a/hal/m258ke/nuvoton/ebi_reg.h
+++ b/hal/m258ke/nuvoton/ebi_reg.h
@@ -1,0 +1,292 @@
+/**************************************************************************//**
+ * @file     ebi_reg.h
+ * @version  V1.00
+ * @brief    EBI register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __EBI_REG_H__
+#define __EBI_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup EBI External Bus Interface Controller (EBI)
+    Memory Mapped Structure for EBI Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var EBI_T::CTL0
+     * Offset: 0x00  External Bus Interface Bank0 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |EN        |EBI Enable Bit
+     * |        |          |This bit is the functional enable bit for EBI.
+     * |        |          |0 = EBI function Disabled.
+     * |        |          |1 = EBI function Enabled.
+     * |[1]     |DW16      |EBI Data Width 16-bit Select
+     * |        |          |This bit defines if the EBI data width is 8-bit or 16-bit.
+     * |        |          |0 = EBI data width is 8-bit.
+     * |        |          |1 = EBI data width is 16-bit.
+     * |[2]     |CSPOLINV  |Chip Select Pin Polar Inverse
+     * |        |          |This bit defines the active level of EBI chip select pin (EBI_nCS).
+     * |        |          |0 = Chip select pin (EBI_nCS) is active low.
+     * |        |          |1 = Chip select pin (EBI_nCS) is active high.
+     * |[4]     |CACCESS   |Continuous Data Access Mode
+     * |        |          |When con tenuous access mode enabled, the tASU, tALE and tLHD cycles are bypass for continuous data transfer request.
+     * |        |          |0 = Continuous data access mode Disabled.
+     * |        |          |1 = Continuous data access mode Enabled.
+     * |[10:8]  |MCLKDIV   |External Output Clock Divider
+     * |        |          |The frequency of EBI output clock (MCLK) is controlled by MCLKDIV as follow:
+     * |        |          |000 = HCLK/1.
+     * |        |          |001 = HCLK/2.
+     * |        |          |010 = HCLK/4.
+     * |        |          |011 = HCLK/8.
+     * |        |          |100 = HCLK/16.
+     * |        |          |101 = HCLK/32.
+     * |        |          |110 = HCLK/64.
+     * |        |          |111 = HCLK/128.
+     * |[18:16] |TALE      |Extend Time of ALE
+     * |        |          |The EBI_ALE high pulse period (tALE) to latch the address can be controlled by TALE.
+     * |        |          |tALE = (TALE+1)*EBI_MCLK.
+     * |        |          |Note: This field only available in EBI_CTL0 register
+     * |[24]    |WBUFEN    |EBI Write Buffer Enable Bit
+     * |        |          |0 = EBI write buffer Disabled.
+     * |        |          |1 = EBI write buffer Enabled.
+     * |        |          |Note: This bit only available in EBI_CTL0 register
+     * @var EBI_T::TCTL0
+     * Offset: 0x04  External Bus Interface Bank0 Timing Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:3]   |TACC      |EBI Data Access Time
+     * |        |          |TACC defines data access time (tACC).
+     * |        |          |tACC = (TACC +1) * EBI_MCLK.
+     * |[10:8]  |TAHD      |EBI Data Access Hold Time
+     * |        |          |TAHD defines data access hold time (tAHD).
+     * |        |          |tAHD = (TAHD +1) * EBI_MCLK.
+     * |[15:12] |W2X       |Idle Cycle After Write
+     * |        |          |This field defines the number of W2X idle cycle.
+     * |        |          |W2X idle cycle = (W2X * EBI_MCLK).
+     * |        |          |When write action is finished, W2X idle cycle is inserted and EBI_nCS return to idle state.
+     * |[22]    |RAHDOFF   |Access Hold Time Disable Control When Read
+     * |        |          |0 = Data Access Hold Time (tAHD) during EBI reading Enabled.
+     * |        |          |1 = Data Access Hold Time (tAHD) during EBI reading Disabled.
+     * |[23]    |WAHDOFF   |Access Hold Time Disable Control When Write
+     * |        |          |0 = Data Access Hold Time (tAHD) during EBI writing Enabled.
+     * |        |          |1 = Data Access Hold Time (tAHD) during EBI writing Disabled.
+     * |[27:24] |R2R       |Idle Cycle Between Read-to-read
+     * |        |          |This field defines the number of R2R idle cycle.
+     * |        |          |R2R idle cycle = (R2R * EBI_MCLK).
+     * |        |          |When read action is finished and the next action is going to read, R2R idle cycle is inserted and EBI_nCS return to idle state.
+     * @var EBI_T::CTL1
+     * Offset: 0x10  External Bus Interface Bank1 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |EN        |EBI Enable Bit
+     * |        |          |This bit is the functional enable bit for EBI.
+     * |        |          |0 = EBI function Disabled.
+     * |        |          |1 = EBI function Enabled.
+     * |[1]     |DW16      |EBI Data Width 16-bit Select
+     * |        |          |This bit defines if the EBI data width is 8-bit or 16-bit.
+     * |        |          |0 = EBI data width is 8-bit.
+     * |        |          |1 = EBI data width is 16-bit.
+     * |[2]     |CSPOLINV  |Chip Select Pin Polar Inverse
+     * |        |          |This bit defines the active level of EBI chip select pin (EBI_nCS).
+     * |        |          |0 = Chip select pin (EBI_nCS) is active low.
+     * |        |          |1 = Chip select pin (EBI_nCS) is active high.
+     * |[4]     |CACCESS   |Continuous Data Access Mode
+     * |        |          |When con tenuous access mode enabled, the tASU, tALE and tLHD cycles are bypass for continuous data transfer request.
+     * |        |          |0 = Continuous data access mode Disabled.
+     * |        |          |1 = Continuous data access mode Enabled.
+     * |[10:8]  |MCLKDIV   |External Output Clock Divider
+     * |        |          |The frequency of EBI output clock (MCLK) is controlled by MCLKDIV as follow:
+     * |        |          |000 = HCLK/1.
+     * |        |          |001 = HCLK/2.
+     * |        |          |010 = HCLK/4.
+     * |        |          |011 = HCLK/8.
+     * |        |          |100 = HCLK/16.
+     * |        |          |101 = HCLK/32.
+     * |        |          |110 = HCLK/64.
+     * |        |          |111 = HCLK/128.
+     * |[18:16] |TALE      |Extend Time of ALE
+     * |        |          |The EBI_ALE high pulse period (tALE) to latch the address can be controlled by TALE.
+     * |        |          |tALE = (TALE+1)*EBI_MCLK.
+     * |        |          |Note: This field only available in EBI_CTL0 register
+     * |[24]    |WBUFEN    |EBI Write Buffer Enable Bit
+     * |        |          |0 = EBI write buffer Disabled.
+     * |        |          |1 = EBI write buffer Enabled.
+     * |        |          |Note: This bit only available in EBI_CTL0 register
+     * @var EBI_T::TCTL1
+     * Offset: 0x14  External Bus Interface Bank1 Timing Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:3]   |TACC      |EBI Data Access Time
+     * |        |          |TACC defines data access time (tACC).
+     * |        |          |tACC = (TACC +1) * EBI_MCLK.
+     * |[10:8]  |TAHD      |EBI Data Access Hold Time
+     * |        |          |TAHD defines data access hold time (tAHD).
+     * |        |          |tAHD = (TAHD +1) * EBI_MCLK.
+     * |[15:12] |W2X       |Idle Cycle After Write
+     * |        |          |This field defines the number of W2X idle cycle.
+     * |        |          |W2X idle cycle = (W2X * EBI_MCLK).
+     * |        |          |When write action is finished, W2X idle cycle is inserted and EBI_nCS return to idle state.
+     * |[22]    |RAHDOFF   |Access Hold Time Disable Control When Read
+     * |        |          |0 = Data Access Hold Time (tAHD) during EBI reading Enabled.
+     * |        |          |1 = Data Access Hold Time (tAHD) during EBI reading Disabled.
+     * |[23]    |WAHDOFF   |Access Hold Time Disable Control When Write
+     * |        |          |0 = Data Access Hold Time (tAHD) during EBI writing Enabled.
+     * |        |          |1 = Data Access Hold Time (tAHD) during EBI writing Disabled.
+     * |[27:24] |R2R       |Idle Cycle Between Read-to-read
+     * |        |          |This field defines the number of R2R idle cycle.
+     * |        |          |R2R idle cycle = (R2R * EBI_MCLK).
+     * |        |          |When read action is finished and the next action is going to read, R2R idle cycle is inserted and EBI_nCS return to idle state.
+     * @var EBI_T::CTL2
+     * Offset: 0x20  External Bus Interface Bank2 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |EN        |EBI Enable Bit
+     * |        |          |This bit is the functional enable bit for EBI.
+     * |        |          |0 = EBI function Disabled.
+     * |        |          |1 = EBI function Enabled.
+     * |[1]     |DW16      |EBI Data Width 16-bit Select
+     * |        |          |This bit defines if the EBI data width is 8-bit or 16-bit.
+     * |        |          |0 = EBI data width is 8-bit.
+     * |        |          |1 = EBI data width is 16-bit.
+     * |[2]     |CSPOLINV  |Chip Select Pin Polar Inverse
+     * |        |          |This bit defines the active level of EBI chip select pin (EBI_nCS).
+     * |        |          |0 = Chip select pin (EBI_nCS) is active low.
+     * |        |          |1 = Chip select pin (EBI_nCS) is active high.
+     * |[4]     |CACCESS   |Continuous Data Access Mode
+     * |        |          |When con tenuous access mode enabled, the tASU, tALE and tLHD cycles are bypass for continuous data transfer request.
+     * |        |          |0 = Continuous data access mode Disabled.
+     * |        |          |1 = Continuous data access mode Enabled.
+     * |[10:8]  |MCLKDIV   |External Output Clock Divider
+     * |        |          |The frequency of EBI output clock (MCLK) is controlled by MCLKDIV as follow:
+     * |        |          |000 = HCLK/1.
+     * |        |          |001 = HCLK/2.
+     * |        |          |010 = HCLK/4.
+     * |        |          |011 = HCLK/8.
+     * |        |          |100 = HCLK/16.
+     * |        |          |101 = HCLK/32.
+     * |        |          |110 = HCLK/64.
+     * |        |          |111 = HCLK/128.
+     * |[18:16] |TALE      |Extend Time of ALE
+     * |        |          |The EBI_ALE high pulse period (tALE) to latch the address can be controlled by TALE.
+     * |        |          |tALE = (TALE+1)*EBI_MCLK.
+     * |        |          |Note: This field only available in EBI_CTL0 register
+     * |[24]    |WBUFEN    |EBI Write Buffer Enable Bit
+     * |        |          |0 = EBI write buffer Disabled.
+     * |        |          |1 = EBI write buffer Enabled.
+     * |        |          |Note: This bit only available in EBI_CTL0 register
+     * @var EBI_T::TCTL2
+     * Offset: 0x24  External Bus Interface Bank2 Timing Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:3]   |TACC      |EBI Data Access Time
+     * |        |          |TACC defines data access time (tACC).
+     * |        |          |tACC = (TACC +1) * EBI_MCLK.
+     * |[10:8]  |TAHD      |EBI Data Access Hold Time
+     * |        |          |TAHD defines data access hold time (tAHD).
+     * |        |          |tAHD = (TAHD +1) * EBI_MCLK.
+     * |[15:12] |W2X       |Idle Cycle After Write
+     * |        |          |This field defines the number of W2X idle cycle.
+     * |        |          |W2X idle cycle = (W2X * EBI_MCLK).
+     * |        |          |When write action is finished, W2X idle cycle is inserted and EBI_nCS return to idle state.
+     * |[22]    |RAHDOFF   |Access Hold Time Disable Control When Read
+     * |        |          |0 = Data Access Hold Time (tAHD) during EBI reading Enabled.
+     * |        |          |1 = Data Access Hold Time (tAHD) during EBI reading Disabled.
+     * |[23]    |WAHDOFF   |Access Hold Time Disable Control When Write
+     * |        |          |0 = Data Access Hold Time (tAHD) during EBI writing Enabled.
+     * |        |          |1 = Data Access Hold Time (tAHD) during EBI writing Disabled.
+     * |[27:24] |R2R       |Idle Cycle Between Read-to-read
+     * |        |          |This field defines the number of R2R idle cycle.
+     * |        |          |R2R idle cycle = (R2R * EBI_MCLK).
+     * |        |          |When read action is finished and the next action is going to read, R2R idle cycle is inserted and EBI_nCS return to idle state.
+     */
+    __IO uint32_t CTL0;                  /*!< [0x0000] External Bus Interface Bank0 Control Register                    */
+    __IO uint32_t TCTL0;                 /*!< [0x0004] External Bus Interface Bank0 Timing Control Register             */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CTL1;                  /*!< [0x0010] External Bus Interface Bank1 Control Register                    */
+    __IO uint32_t TCTL1;                 /*!< [0x0014] External Bus Interface Bank1 Timing Control Register             */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CTL2;                  /*!< [0x0020] External Bus Interface Bank2 Control Register                    */
+    __IO uint32_t TCTL2;                 /*!< [0x0024] External Bus Interface Bank2 Timing Control Register             */
+} EBI_T;
+
+/**
+    @addtogroup EBI_CONST EBI Bit Field Definition
+    Constant Definitions for EBI Controller
+@{ */
+
+#define EBI_CTL_EN_Pos                   (0)                                               /*!< EBI_T::CTL: EN Position                */
+#define EBI_CTL_EN_Msk                   (0x1ul << EBI_CTL_EN_Pos)                         /*!< EBI_T::CTL: EN Mask                    */
+
+#define EBI_CTL_DW16_Pos                 (1)                                               /*!< EBI_T::CTL: DW16 Position              */
+#define EBI_CTL_DW16_Msk                 (0x1ul << EBI_CTL_DW16_Pos)                       /*!< EBI_T::CTL: DW16 Mask                  */
+
+#define EBI_CTL_CSPOLINV_Pos             (2)                                               /*!< EBI_T::CTL: CSPOLINV Position          */
+#define EBI_CTL_CSPOLINV_Msk             (0x1ul << EBI_CTL_CSPOLINV_Pos)                   /*!< EBI_T::CTL: CSPOLINV Mask              */
+
+#define EBI_CTL_CACCESS_Pos              (4)                                               /*!< EBI_T::CTL: CACCESS Position           */
+#define EBI_CTL_CACCESS_Msk              (0x1ul << EBI_CTL_CACCESS_Pos)                    /*!< EBI_T::CTL: CACCESS Mask               */
+
+#define EBI_CTL_MCLKDIV_Pos              (8)                                               /*!< EBI_T::CTL: MCLKDIV Position           */
+#define EBI_CTL_MCLKDIV_Msk              (0x7ul << EBI_CTL_MCLKDIV_Pos)                    /*!< EBI_T::CTL: MCLKDIV Mask               */
+
+#define EBI_CTL_TALE_Pos                 (16)                                              /*!< EBI_T::CTL: TALE Position              */
+#define EBI_CTL_TALE_Msk                 (0x7ul << EBI_CTL_TALE_Pos)                       /*!< EBI_T::CTL: TALE Mask                  */
+
+#define EBI_CTL_WBUFEN_Pos               (24)                                              /*!< EBI_T::CTL: WBUFEN Position            */
+#define EBI_CTL_WBUFEN_Msk               (0x1ul << EBI_CTL_WBUFEN_Pos)                     /*!< EBI_T::CTL: WBUFEN Mask                */
+
+#define EBI_TCTL_TACC_Pos                (3)                                               /*!< EBI_T::TCTL: TACC Position             */
+#define EBI_TCTL_TACC_Msk                (0x1ful << EBI_TCTL_TACC_Pos)                     /*!< EBI_T::TCTL: TACC Mask                 */
+
+#define EBI_TCTL_TAHD_Pos                (8)                                               /*!< EBI_T::TCTL: TAHD Position             */
+#define EBI_TCTL_TAHD_Msk                (0x7ul << EBI_TCTL_TAHD_Pos)                      /*!< EBI_T::TCTL: TAHD Mask                 */
+
+#define EBI_TCTL_W2X_Pos                 (12)                                              /*!< EBI_T::TCTL: W2X Position              */
+#define EBI_TCTL_W2X_Msk                 (0xful << EBI_TCTL_W2X_Pos)                       /*!< EBI_T::TCTL: W2X Mask                  */
+
+#define EBI_TCTL_RAHDOFF_Pos             (22)                                              /*!< EBI_T::TCTL: RAHDOFF Position          */
+#define EBI_TCTL_RAHDOFF_Msk             (0x1ul << EBI_TCTL_RAHDOFF_Pos)                   /*!< EBI_T::TCTL: RAHDOFF Mask              */
+
+#define EBI_TCTL_WAHDOFF_Pos             (23)                                              /*!< EBI_T::TCTL: WAHDOFF Position          */
+#define EBI_TCTL_WAHDOFF_Msk             (0x1ul << EBI_TCTL_WAHDOFF_Pos)                   /*!< EBI_T::TCTL: WAHDOFF Mask              */
+
+#define EBI_TCTL_R2R_Pos                 (24)                                              /*!< EBI_T::TCTL: R2R Position              */
+#define EBI_TCTL_R2R_Msk                 (0xful << EBI_TCTL_R2R_Pos)                       /*!< EBI_T::TCTL: R2R Mask                  */
+
+/** @} EBI_CONST */
+/** @} end of EBI register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __EBI_REG_H__ */

--- a/hal/m258ke/nuvoton/fmc_reg.h
+++ b/hal/m258ke/nuvoton/fmc_reg.h
@@ -1,0 +1,447 @@
+/**************************************************************************//**
+ * @file     fmc_reg.h
+ * @version  V1.00
+ * @brief    FMC register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __FMC_REG_H__
+#define __FMC_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup FMC Flash Memory Controller (FMC)
+    Memory Mapped Structure for FMC Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var FMC_T::ISPCTL
+     * Offset: 0x00  ISP Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ISPEN     |ISP Enable Bit (Write Protect)
+     * |        |          |ISP function enable bit. Set this bit to enable ISP function.
+     * |        |          |0 = ISP function Disabled.
+     * |        |          |1 = ISP function Enabled.
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * |[1]     |BS        |Boot Select (Write Protect)
+     * |        |          |Set/clear this bit to select next booting from LDROM/APROM, respectively
+     * |        |          |This bit also functions as chip booting status flag, which can be used to check where chip booted from
+     * |        |          |This bit is initiated with the inversed value of CBS[1] (CONFIG0[7]) after any reset is happened except CPU reset (CPU is 1) or system reset (SYS) is happened
+     * |        |          |0 = Booting from APROM.
+     * |        |          |1 = Booting from LDROM.
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * |[3]     |APUEN     |APROM Update Enable Bit (Write Protect)
+     * |        |          |0 = APROM cannot be updated when the chip runs in APROM.
+     * |        |          |1 = APROM can be updated when the chip runs in APROM.
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * |[4]     |CFGUEN    |CONFIG Update Enable Bit (Write Protect)
+     * |        |          |0 = CONFIG cannot be updated.
+     * |        |          |1 = CONFIG can be updated.
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * |[5]     |LDUEN     |LDROM Update Enable Bit (Write Protect)
+     * |        |          |LDROM update enable bit.
+     * |        |          |0 = LDROM cannot be updated.
+     * |        |          |1 = LDROM can be updated.
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * |[6]     |ISPFF     |ISP Fail Flag (Write Protect)
+     * |        |          |This bit is set by hardware when a triggered ISP meets any of the following conditions:
+     * |        |          |This bit needs to be cleared by writing 1 to it.
+     * |        |          |(1) APROM writes to itself if APUEN is set to 0.
+     * |        |          |(2) LDROM writes to itself if LDUEN is set to 0.
+     * |        |          |(3) CONFIG is erased/programmed if CFGUEN is set to 0.
+     * |        |          |(4) Page Erase command at LOCK mode with ICE connection
+     * |        |          |(5) Erase or Program command at brown-out detected
+     * |        |          |(6) Destination address is illegal, such as over an available range.
+     * |        |          |(7) Invalid ISP commands
+     * |        |          |(8) ISP CMD in XOM region, except mass erase, page erase and chksum command
+     * |        |          |(9) The wrong setting of page erase ISP CMD in XOM
+     * |        |          |(10) Violate XOM setting one time protection
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * @var FMC_T::ISPADDR
+     * Offset: 0x04  ISP Address Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |ISPADDR   |ISP Address
+     * |        |          |For Checksum Calculation command, this field is the Flash starting address for checksum calculation, 512 bytes alignment is necessary for checksum calculation.
+     * @var FMC_T::ISPDAT
+     * Offset: 0x08  ISP Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |ISPDAT    |ISP Data
+     * |        |          |Write data to this register before ISP program operation.
+     * |        |          |Read data from this register after ISP read operation.
+     * |        |          |For Run Checksum Calculation command, ISPDAT is the memory size (byte) and 512 bytes alignment
+     * |        |          |For ISP Read Checksum command, ISPDAT is the checksum result
+     * |        |          |If ISPDAT = 0x0000_0000, it means that (1) the checksum calculation is in progress, (2) the memory range for checksum calculation is incorrect.
+     * @var FMC_T::ISPCMD
+     * Offset: 0x0C  ISP CMD Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[6:0]   |CMD       |ISP CMD
+     * |        |          |ISP command table is shown below:
+     * |        |          |0x00= FLASH Read.
+     * |        |          |0x04= Read Unique ID.
+     * |        |          |0x0B= Read Company ID.
+     * |        |          |0x0C= Read Device ID.
+     * |        |          |0x0D= Read Checksum.
+     * |        |          |0x21= FLASH 32-bit Program.
+     * |        |          |0x22= FLASH Page Erase.
+     * |        |          |0x27= FLASH Multi-Word Program.
+     * |        |          |0x28= Run Flash All-One Verification.
+     * |        |          |0x2D= Run Checksum Calculation.
+     * |        |          |0x2E= Vector Remap.
+     * |        |          |The other commands are invalid.
+     * @var FMC_T::ISPTRG
+     * Offset: 0x10  ISP Trigger Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ISPGO     |ISP Start Trigger (Write Protect)
+     * |        |          |Write 1 to start ISP operation and this bit will be cleared to 0 by hardware automatically when ISP operation is finished.
+     * |        |          |0 = ISP operation is finished.
+     * |        |          |1 = ISP is progressed.
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * @var FMC_T::FTCTL
+     * Offset: 0x18  Flash Access Time Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9]     |CACHEINV  |Flash Cache Invalidation (Write Protect)
+     * |        |          |Write 1 to start cache invalidation. The value will be change to 0 once the process finishes.
+     * |        |          |0 = Flash Cache Invalidation.(default)
+     * |        |          |1 = Flash Cache Invalidation.
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * @var FMC_T::ISPSTS
+     * Offset: 0x40  ISP Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ISPBUSY   |ISP Busy Flag (Read Only)
+     * |        |          |Write 1 to start ISP operation and this bit will be cleared to 0 by hardware automatically when ISP operation is finished.
+     * |        |          |This bit is the mirror of ISPGO(FMC_ISPTRG[0]).
+     * |        |          |0 = ISP operation is finished.
+     * |        |          |1 = ISP is progressed.
+     * |[2:1]   |CBS       |Boot Selection of CONFIG (Read Only)
+     * |        |          |This bit is initiated with the CBS (CONFIG0[7:6]) after any reset is happened except CPU reset (CPU is 1) or system reset (SYS) is happened.
+     * |        |          |00 = LDROM with IAP mode.
+     * |        |          |01 = LDROM without IAP mode.
+     * |        |          |10 = APROM with IAP mode.
+     * |        |          |11 = APROM without IAP mode.
+     * |[5]     |PGFF      |Flash Program with Fast Verification Flag (Read Only)
+     * |        |          |This bit is set if data is mismatched at ISP programming verification
+     * |        |          |This bit is clear by performing ISP Flash erase or ISP read CID operation
+     * |        |          |0 = Flash Program is success.
+     * |        |          |1 = Flash Program is fail. Program data is different with data in the Flash memory
+     * |[6]     |ISPFF     |ISP Fail Flag (Write Protect)
+     * |        |          |This bit is the mirror of ISPFF (FMC_ISPCTL[6]), it needs to be cleared by writing 1 to FMC_ISPCTL[6] or FMC_ISPSTS[6]
+     * |        |          |This bit is set by hardware when a triggered ISP meets any of the following conditions:
+     * |        |          |(1) APROM writes to itself if APUEN is set to 0.
+     * |        |          |(2) LDROM writes to itself if LDUEN is set to 0.
+     * |        |          |(3) CONFIG is erased/programmed if CFGUEN is set to 0.
+     * |        |          |(4) Page Erase command at LOCK mode with ICE connection
+     * |        |          |(5) Erase or Program command at brown-out detected
+     * |        |          |(6) Destination address is illegal, such as over an available range.
+     * |        |          |(7) Invalid ISP commands
+     * |        |          |(8) ISP CMD in XOM region, except mass erase, page erase and chksum command
+     * |        |          |(9) The wrong setting of page erase ISP CMD in XOM
+     * |        |          |(10) Violate XOM setting one time protection
+     * |        |          |Note: This bit is write-protected. Refer to the SYS_REGLCTL register.
+     * |[7]     |ALLONE    |Flash All-one Verification Flag
+     * |        |          |This bit is set by hardware if all of Flash bits are 1, and clear if Flash bits are not all 1 after "Run Flash All-One Verification" complete; this bit also can be clear by writing 1
+     * |        |          |0 = Flash bits are not all 1 after "Run Flash All-One Verification" complete.
+     * |        |          |1 = All of Flash bits are 1 after "Run Flash All-One Verification" complete.
+     * |[29:9]  |VECMAP    |Vector Page Mapping Address (Read Only)
+     * |        |          |All access to 0x0000_0000~0x0000_01FF is remapped to the Flash memory or SRAM address {VECMAP[20:0], 9'h000} ~ {VECMAP[20:0], 9'h1FF}.
+     * |        |          |VECMAP [20:19] = 00 system vector address is mapped to Flash memory.
+     * |        |          |VECMAP [20:19] = 10 system vector address is mapped to SRAM memory.
+     * |        |          |VECMAP [18:12] should be 0.
+     * @var FMC_T::CYCCTL
+     * Offset: 0x4C  Flash Access Cycle Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |CYCLE     |Flash Access Cycle Control (Write Protect)
+     * |        |          |0001 = CPU access with zero wait cycle ; Flash access cycle is 1;.
+     * |        |          |The HCLK working frequency range is <19MHz; Cache is disabled by hardware.
+     * |        |          |0010 = CPU access with one wait cycles if cache miss; Flash access cycle is 2;.
+     * |        |          | The optimized HCLK working frequency range is 18~33 MHz
+     * |        |          |0011 = CPU access with two wait cycles if cahce miss; Flash access cycle is 3;.
+     * |        |          | The optimized HCLK working frequency range is 33~50 MHz
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var FMC_T::MPDAT0
+     * Offset: 0x80  ISP Data0 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |ISPDAT0   |ISP Data 0
+     * |        |          |This register is the first 32-bit data for 32-bit/64-bit/multi-word programming, and it is also the mirror of FMC_ISPDAT, both registers keep the same data
+     * @var FMC_T::MPDAT1
+     * Offset: 0x84  ISP Data1 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |ISPDAT1   |ISP Data 1
+     * |        |          |This register is the second 32-bit data for 64-bit/multi-word programming.
+     * @var FMC_T::MPDAT2
+     * Offset: 0x88  ISP Data2 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |ISPDAT2   |ISP Data 2
+     * |        |          |This register is the third 32-bit data for multi-word programming.
+     * @var FMC_T::MPDAT3
+     * Offset: 0x8C  ISP Data3 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |ISPDAT3   |ISP Data 3
+     * |        |          |This register is the fourth 32-bit data for multi-word programming.
+     * @var FMC_T::MPSTS
+     * Offset: 0xC0  ISP Multi-program Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MPBUSY    |ISP Multi-word Program Busy Flag (Read Only)
+     * |        |          |Write 1 to start ISP Multi-Word program operation and this bit will be cleared to 0 by hardware automatically when ISP Multi-Word program operation is finished.
+     * |        |          |This bit is the mirror of ISPGO(FMC_ISPTRG[0]).
+     * |        |          |0 = ISP Multi-Word program operation is finished.
+     * |        |          |1 = ISP Multi-Word program operation is progressed.
+     * |[1]     |PPGO      |ISP Multi-program Status (Read Only)
+     * |        |          |0 = ISP multi-word program operation is not active.
+     * |        |          |1 = ISP multi-word program operation is in progress.
+     * |[2]     |ISPFF     |ISP Fail Flag (Read Only)
+     * |        |          |This bit is the mirror of ISPFF (FMC_ISPCTL[6]), it needs to be cleared by writing 1 to FMC_ISPCTL[6] or FMC_ISPSTS[6]
+     * |        |          |This bit is set by hardware when a triggered ISP meets any of the following conditions:
+     * |        |          |(1) APROM writes to itself if APUEN is set to 0.
+     * |        |          |(2) LDROM writes to itself if LDUEN is set to 0.
+     * |        |          |(3) CONFIG is erased/programmed if CFGUEN is set to 0.
+     * |        |          |(4) Page Erase command at LOCK mode with ICE connection
+     * |        |          |(5) Erase or Program command at brown-out detected
+     * |        |          |(6) Destination address is illegal, such as over an available range.
+     * |        |          |(7) Invalid ISP commands
+     * |[4]     |D0        |ISP DATA 0 Flag (Read Only)
+     * |        |          |This bit is set when FMC_MPDAT0 is written and auto-clear to 0 when the FMC_MPDAT0 data is programmed to Flash complete.
+     * |        |          |0 = FMC_MPDAT0 register is empty, or program to Flash complete.
+     * |        |          |1 = FMC_MPDAT0 register has been written, and not program to Flash complete.
+     * |[5]     |D1        |ISP DATA 1 Flag (Read Only)
+     * |        |          |This bit is set when FMC_MPDAT1 is written and auto-clear to 0 when the FMC_MPDAT1 data is programmed to Flash complete.
+     * |        |          |0 = FMC_MPDAT1 register is empty, or program to Flash complete.
+     * |        |          |1 = FMC_MPDAT1 register has been written, and not program to Flash complete.
+     * |[6]     |D2        |ISP DATA 2 Flag (Read Only)
+     * |        |          |This bit is set when FMC_MPDAT2 is written and auto-clear to 0 when the FMC_MPDAT2 data is programmed to Flash complete.
+     * |        |          |0 = FMC_MPDAT2 register is empty, or program to Flash complete.
+     * |        |          |1 = FMC_MPDAT2 register has been written, and not program to Flash complete.
+     * |[7]     |D3        |ISP DATA 3 Flag (Read Only)
+     * |        |          |This bit is set when FMC_MPDAT3 is written and auto-clear to 0 when the FMC_MPDAT3 data is programmed to Flash complete.
+     * |        |          |0 = FMC_MPDAT3 register is empty, or program to Flash complete.
+     * |        |          |1 = FMC_MPDAT3 register has been written, and not program to Flash complete.
+     * @var FMC_T::MPADDR
+     * Offset: 0xC4  ISP Multi-program Address Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |MPADDR    |ISP Multi-word Program Address
+     * |        |          |MPADDR is the address of ISP multi-word program operation when ISPGO flag is 1.
+     * |        |          |MPADDR will keep the final ISP address when ISP multi-word program is complete.
+     * @var FMC_T::XOMR0STS0
+     * Offset: 0xD0  XOM Region 0 Status Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[23:0]  |BASE      |XOM Region 0 Base Address (Page-aligned)
+     * |        |          |BASE is the base address of XOM Region 0.
+     * @var FMC_T::XOMR0STS1
+     * Offset: 0xD4  XOM Region 0 Status Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |SIZE      |XOM Region 0 Size (Page-aligned)
+     * |        |          |SIZE is the page number of XOM Region 0.
+     * @var FMC_T::XOMSTS
+     * Offset: 0xE0  XOM Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |XOMR0ON   |XOM Region 0 On
+     * |        |          |XOM Region 0 active status.
+     * |        |          |0 = No active.
+     * |        |          |1 = XOM region 0 is active.
+     * |[4]     |XOMPEF    |XOM Page Erase Function Fail
+     * |        |          |XOM page erase function status. If XOMPEF is set to 1, user needs to erase XOM region again.
+     * |        |          |0 = Sucess.
+     * |        |          |1 = Fail.
+     */
+    __IO uint32_t ISPCTL;                /*!< [0x0000] ISP Control Register                                             */
+    __IO uint32_t ISPADDR;               /*!< [0x0004] ISP Address Register                                             */
+    __IO uint32_t ISPDAT;                /*!< [0x0008] ISP Data Register                                                */
+    __IO uint32_t ISPCMD;                /*!< [0x000c] ISP CMD Register                                                 */
+    __IO uint32_t ISPTRG;                /*!< [0x0010] ISP Trigger Control Register                                     */
+    __I  uint32_t RESERVE0;
+    __IO uint32_t FTCTL;                 /*!< [0x0018] Flash Access Time Control Register                               */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[9];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t ISPSTS;                /*!< [0x0040] ISP Status Register                                              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CYCCTL;                /*!< [0x004c] Flash Access Cycle Control Register                              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[12];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t MPDAT0;                /*!< [0x0080] ISP Data0 Register                                               */
+    __IO uint32_t MPDAT1;                /*!< [0x0084] ISP Data1 Register                                               */
+    __IO uint32_t MPDAT2;                /*!< [0x0088] ISP Data2 Register                                               */
+    __IO uint32_t MPDAT3;                /*!< [0x008c] ISP Data3 Register                                               */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE4[12];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t MPSTS;                 /*!< [0x00c0] ISP Multi-program Status Register                                */
+    __I  uint32_t MPADDR;                /*!< [0x00c4] ISP Multi-program Address Register                               */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE5[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t XOMR0STS0;             /*!< [0x00d0] XOM Region 0 Status Register 0                                   */
+    __I  uint32_t XOMR0STS1;             /*!< [0x00d4] XOM Region 0 Status Register 1                                   */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE6[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t XOMSTS;                /*!< [0x00e0] XOM Status Register                                              */
+} FMC_T;
+
+/**
+    @addtogroup FMC_CONST FMC Bit Field Definition
+    Constant Definitions for FMC Controller
+@{ */
+
+#define FMC_ISPCTL_ISPEN_Pos             (0)                                               /*!< FMC_T::ISPCTL: ISPEN Position          */
+#define FMC_ISPCTL_ISPEN_Msk             (0x1ul << FMC_ISPCTL_ISPEN_Pos)                   /*!< FMC_T::ISPCTL: ISPEN Mask              */
+
+#define FMC_ISPCTL_BS_Pos                (1)                                               /*!< FMC_T::ISPCTL: BS Position             */
+#define FMC_ISPCTL_BS_Msk                (0x1ul << FMC_ISPCTL_BS_Pos)                      /*!< FMC_T::ISPCTL: BS Mask                 */
+
+#define FMC_ISPCTL_APUEN_Pos             (3)                                               /*!< FMC_T::ISPCTL: APUEN Position          */
+#define FMC_ISPCTL_APUEN_Msk             (0x1ul << FMC_ISPCTL_APUEN_Pos)                   /*!< FMC_T::ISPCTL: APUEN Mask              */
+
+#define FMC_ISPCTL_CFGUEN_Pos            (4)                                               /*!< FMC_T::ISPCTL: CFGUEN Position         */
+#define FMC_ISPCTL_CFGUEN_Msk            (0x1ul << FMC_ISPCTL_CFGUEN_Pos)                  /*!< FMC_T::ISPCTL: CFGUEN Mask             */
+
+#define FMC_ISPCTL_LDUEN_Pos             (5)                                               /*!< FMC_T::ISPCTL: LDUEN Position          */
+#define FMC_ISPCTL_LDUEN_Msk             (0x1ul << FMC_ISPCTL_LDUEN_Pos)                   /*!< FMC_T::ISPCTL: LDUEN Mask              */
+
+#define FMC_ISPCTL_ISPFF_Pos             (6)                                               /*!< FMC_T::ISPCTL: ISPFF Position          */
+#define FMC_ISPCTL_ISPFF_Msk             (0x1ul << FMC_ISPCTL_ISPFF_Pos)                   /*!< FMC_T::ISPCTL: ISPFF Mask              */
+
+#define FMC_ISPADDR_ISPADDR_Pos          (0)                                               /*!< FMC_T::ISPADDR: ISPADDR Position       */
+#define FMC_ISPADDR_ISPADDR_Msk          (0xfffffffful << FMC_ISPADDR_ISPADDR_Pos)         /*!< FMC_T::ISPADDR: ISPADDR Mask           */
+
+#define FMC_ISPDAT_ISPDAT_Pos            (0)                                               /*!< FMC_T::ISPDAT: ISPDAT Position         */
+#define FMC_ISPDAT_ISPDAT_Msk            (0xfffffffful << FMC_ISPDAT_ISPDAT_Pos)           /*!< FMC_T::ISPDAT: ISPDAT Mask             */
+
+#define FMC_ISPCMD_CMD_Pos               (0)                                               /*!< FMC_T::ISPCMD: CMD Position            */
+#define FMC_ISPCMD_CMD_Msk               (0x7ful << FMC_ISPCMD_CMD_Pos)                    /*!< FMC_T::ISPCMD: CMD Mask                */
+
+#define FMC_ISPTRG_ISPGO_Pos             (0)                                               /*!< FMC_T::ISPTRG: ISPGO Position          */
+#define FMC_ISPTRG_ISPGO_Msk             (0x1ul << FMC_ISPTRG_ISPGO_Pos)                   /*!< FMC_T::ISPTRG: ISPGO Mask              */
+
+#define FMC_FTCTL_CACHEINV_Pos           (9)                                               /*!< FMC_T::FTCTL: CACHEINV Position        */
+#define FMC_FTCTL_CACHEINV_Msk           (0x1ul << FMC_FTCTL_CACHEINV_Pos)                 /*!< FMC_T::FTCTL: CACHEINV Mask            */
+
+#define FMC_ISPSTS_ISPBUSY_Pos           (0)                                               /*!< FMC_T::ISPSTS: ISPBUSY Position        */
+#define FMC_ISPSTS_ISPBUSY_Msk           (0x1ul << FMC_ISPSTS_ISPBUSY_Pos)                 /*!< FMC_T::ISPSTS: ISPBUSY Mask            */
+
+#define FMC_ISPSTS_CBS_Pos               (1)                                               /*!< FMC_T::ISPSTS: CBS Position            */
+#define FMC_ISPSTS_CBS_Msk               (0x3ul << FMC_ISPSTS_CBS_Pos)                     /*!< FMC_T::ISPSTS: CBS Mask                */
+
+#define FMC_ISPSTS_PGFF_Pos              (5)                                               /*!< FMC_T::ISPSTS: PGFF Position           */
+#define FMC_ISPSTS_PGFF_Msk              (0x1ul << FMC_ISPSTS_PGFF_Pos)                    /*!< FMC_T::ISPSTS: PGFF Mask               */
+
+#define FMC_ISPSTS_ISPFF_Pos             (6)                                               /*!< FMC_T::ISPSTS: ISPFF Position          */
+#define FMC_ISPSTS_ISPFF_Msk             (0x1ul << FMC_ISPSTS_ISPFF_Pos)                   /*!< FMC_T::ISPSTS: ISPFF Mask              */
+
+#define FMC_ISPSTS_ALLONE_Pos            (7)                                               /*!< FMC_T::ISPSTS: ALLONE Position         */
+#define FMC_ISPSTS_ALLONE_Msk            (0x1ul << FMC_ISPSTS_ALLONE_Pos)                  /*!< FMC_T::ISPSTS: ALLONE Mask             */
+
+#define FMC_ISPSTS_VECMAP_Pos            (9)                                               /*!< FMC_T::ISPSTS: VECMAP Position         */
+#define FMC_ISPSTS_VECMAP_Msk            (0x1ffffful << FMC_ISPSTS_VECMAP_Pos)             /*!< FMC_T::ISPSTS: VECMAP Mask             */
+
+#define FMC_CYCCTL_CYCLE_Pos             (0)                                               /*!< FMC_T::CYCCTL: CYCLE Position          */
+#define FMC_CYCCTL_CYCLE_Msk             (0xful << FMC_CYCCTL_CYCLE_Pos)                   /*!< FMC_T::CYCCTL: CYCLE Mask              */
+
+#define FMC_MPDAT0_ISPDAT0_Pos           (0)                                               /*!< FMC_T::MPDAT0: ISPDAT0 Position        */
+#define FMC_MPDAT0_ISPDAT0_Msk           (0xfffffffful << FMC_MPDAT0_ISPDAT0_Pos)          /*!< FMC_T::MPDAT0: ISPDAT0 Mask            */
+
+#define FMC_MPDAT1_ISPDAT1_Pos           (0)                                               /*!< FMC_T::MPDAT1: ISPDAT1 Position        */
+#define FMC_MPDAT1_ISPDAT1_Msk           (0xfffffffful << FMC_MPDAT1_ISPDAT1_Pos)          /*!< FMC_T::MPDAT1: ISPDAT1 Mask            */
+
+#define FMC_MPDAT2_ISPDAT2_Pos           (0)                                               /*!< FMC_T::MPDAT2: ISPDAT2 Position        */
+#define FMC_MPDAT2_ISPDAT2_Msk           (0xfffffffful << FMC_MPDAT2_ISPDAT2_Pos)          /*!< FMC_T::MPDAT2: ISPDAT2 Mask            */
+
+#define FMC_MPDAT3_ISPDAT3_Pos           (0)                                               /*!< FMC_T::MPDAT3: ISPDAT3 Position        */
+#define FMC_MPDAT3_ISPDAT3_Msk           (0xfffffffful << FMC_MPDAT3_ISPDAT3_Pos)          /*!< FMC_T::MPDAT3: ISPDAT3 Mask            */
+
+#define FMC_MPSTS_MPBUSY_Pos             (0)                                               /*!< FMC_T::MPSTS: MPBUSY Position          */
+#define FMC_MPSTS_MPBUSY_Msk             (0x1ul << FMC_MPSTS_MPBUSY_Pos)                   /*!< FMC_T::MPSTS: MPBUSY Mask              */
+
+#define FMC_MPSTS_PPGO_Pos               (1)                                               /*!< FMC_T::MPSTS: PPGO Position            */
+#define FMC_MPSTS_PPGO_Msk               (0x1ul << FMC_MPSTS_PPGO_Pos)                     /*!< FMC_T::MPSTS: PPGO Mask                */
+
+#define FMC_MPSTS_ISPFF_Pos              (2)                                               /*!< FMC_T::MPSTS: ISPFF Position           */
+#define FMC_MPSTS_ISPFF_Msk              (0x1ul << FMC_MPSTS_ISPFF_Pos)                    /*!< FMC_T::MPSTS: ISPFF Mask               */
+
+#define FMC_MPSTS_D0_Pos                 (4)                                               /*!< FMC_T::MPSTS: D0 Position              */
+#define FMC_MPSTS_D0_Msk                 (0x1ul << FMC_MPSTS_D0_Pos)                       /*!< FMC_T::MPSTS: D0 Mask                  */
+
+#define FMC_MPSTS_D1_Pos                 (5)                                               /*!< FMC_T::MPSTS: D1 Position              */
+#define FMC_MPSTS_D1_Msk                 (0x1ul << FMC_MPSTS_D1_Pos)                       /*!< FMC_T::MPSTS: D1 Mask                  */
+
+#define FMC_MPSTS_D2_Pos                 (6)                                               /*!< FMC_T::MPSTS: D2 Position              */
+#define FMC_MPSTS_D2_Msk                 (0x1ul << FMC_MPSTS_D2_Pos)                       /*!< FMC_T::MPSTS: D2 Mask                  */
+
+#define FMC_MPSTS_D3_Pos                 (7)                                               /*!< FMC_T::MPSTS: D3 Position              */
+#define FMC_MPSTS_D3_Msk                 (0x1ul << FMC_MPSTS_D3_Pos)                       /*!< FMC_T::MPSTS: D3 Mask                  */
+
+#define FMC_MPADDR_MPADDR_Pos            (0)                                               /*!< FMC_T::MPADDR: MPADDR Position         */
+#define FMC_MPADDR_MPADDR_Msk            (0xfffffffful << FMC_MPADDR_MPADDR_Pos)           /*!< FMC_T::MPADDR: MPADDR Mask             */
+
+#define FMC_XOMR0STS0_BASE_Pos           (0)                                               /*!< FMC_T::XOMR0STS0: BASE Position        */
+#define FMC_XOMR0STS0_BASE_Msk           (0xfffffful << FMC_XOMR0STS0_BASE_Pos)            /*!< FMC_T::XOMR0STS0: BASE Mask            */
+
+#define FMC_XOMR0STS1_SIZE_Pos           (0)                                               /*!< FMC_T::XOMR0STS1: SIZE Position        */
+#define FMC_XOMR0STS1_SIZE_Msk           (0x1fful << FMC_XOMR0STS1_SIZE_Pos)               /*!< FMC_T::XOMR0STS1: SIZE Mask            */
+
+#define FMC_XOMSTS_XOMR0ON_Pos           (0)                                               /*!< FMC_T::XOMSTS: XOMR0ON Position        */
+#define FMC_XOMSTS_XOMR0ON_Msk           (0x1ul << FMC_XOMSTS_XOMR0ON_Pos)                 /*!< FMC_T::XOMSTS: XOMR0ON Mask            */
+
+#define FMC_XOMSTS_XOMPEF_Pos            (4)                                               /*!< FMC_T::XOMSTS: XOMPEF Position         */
+#define FMC_XOMSTS_XOMPEF_Msk            (0x1ul << FMC_XOMSTS_XOMPEF_Pos)                  /*!< FMC_T::XOMSTS: XOMPEF Mask             */
+
+/** @} FMC_CONST */
+/** @} end of FMC register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __FMC_REG_H__ */

--- a/hal/m258ke/nuvoton/gcc_arm.ld
+++ b/hal/m258ke/nuvoton/gcc_arm.ld
@@ -1,0 +1,195 @@
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x8000    /* 32k */
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 0x2000    /* 8k  */
+}
+
+/* Library configurations */
+GROUP(libgcc.a libc.a libm.a libnosys.a)
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __copy_table_start__
+ *   __copy_table_end__
+ *   __zero_table_start__
+ *   __zero_table_end__
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ *   __Vectors_End
+ *   __Vectors_Size
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.vectors))
+		__Vectors_End = .;
+		__Vectors_Size = __Vectors_End - __Vectors;
+		__end__ = .;
+
+		*(.text*)
+
+		KEEP(*(.init))
+		KEEP(*(.fini))
+
+		/* .ctors */
+		*crtbegin.o(.ctors)
+		*crtbegin?.o(.ctors)
+		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+		*(SORT(.ctors.*))
+		*(.ctors)
+
+		/* .dtors */
+ 		*crtbegin.o(.dtors)
+ 		*crtbegin?.o(.dtors)
+ 		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+ 		*(SORT(.dtors.*))
+ 		*(.dtors)
+        
+		*(.rodata*)
+
+		KEEP(*(.eh_frame*))
+	} > FLASH
+
+	.ARM.extab :
+	{
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+	} > FLASH
+
+	__exidx_start = .;
+	.ARM.exidx :
+	{
+		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
+	} > FLASH
+	__exidx_end = .;
+
+	/* To copy multiple ROM to RAM sections,
+	 * uncomment .copy.table section and,
+	 * define __STARTUP_COPY_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.copy.table :
+	{
+		. = ALIGN(4);
+		__copy_table_start__ = .;
+		LONG (__etext)
+		LONG (__data_start__)
+		LONG (__data_end__ - __data_start__)
+		LONG (__etext2)
+		LONG (__data2_start__)
+		LONG (__data2_end__ - __data2_start__)
+		__copy_table_end__ = .;
+	} > FLASH
+	*/
+
+	/* To clear multiple BSS sections,
+	 * uncomment .zero.table section and,
+	 * define __STARTUP_CLEAR_BSS_MULTIPLE in startup_ARMCMx.S */
+	/*
+	.zero.table :
+	{
+		. = ALIGN(4);
+		__zero_table_start__ = .;
+		LONG (__bss_start__)
+		LONG (__bss_end__ - __bss_start__)
+		LONG (__bss2_start__)
+		LONG (__bss2_end__ - __bss2_start__)
+		__zero_table_end__ = .;
+	} > FLASH
+	*/
+
+	__etext = .;
+
+	.data : AT (__etext)
+	{
+		__data_start__ = .;
+		*(vtable)
+		*(.data*)
+
+		. = ALIGN(4);
+		/* preinit data */
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP(*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+
+		. = ALIGN(4);
+		/* init data */
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP(*(SORT(.init_array.*)))
+		KEEP(*(.init_array))
+		PROVIDE_HIDDEN (__init_array_end = .);
+
+
+		. = ALIGN(4);
+		/* finit data */
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP(*(SORT(.fini_array.*)))
+		KEEP(*(.fini_array))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+
+		KEEP(*(.jcr*))
+		. = ALIGN(4);
+		/* All data end */
+		__data_end__ = .;
+
+	} > RAM
+
+	.bss :
+	{
+		. = ALIGN(4);
+		__bss_start__ = .;
+		*(.bss*)
+		*(COMMON)
+		. = ALIGN(4);
+		__bss_end__ = .;
+	} > RAM
+
+	.heap (COPY):
+	{
+		__HeapBase = .;
+		__end__ = .;
+		end = __end__;
+		KEEP(*(.heap*))
+		__HeapLimit = .;
+	} > RAM
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	 * used for linker to calculate size of stack sections, and assign
+	 * values to stack symbols later */
+	.stack_dummy (COPY):
+	{
+		KEEP(*(.stack*))
+	} > RAM
+
+	/* Set stack top to end of RAM, and stack limit move down by
+	 * size of stack_dummy section */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
+	PROVIDE(__stack = __StackTop);
+
+	/* Check if data + heap + stack exceeds RAM limit */
+	ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/hal/m258ke/nuvoton/gcc_arm.ld
+++ b/hal/m258ke/nuvoton/gcc_arm.ld
@@ -1,8 +1,8 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x8000    /* 32k */
-  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 0x2000    /* 8k  */
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 128*1024
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 16*1024
 }
 
 /* Library configurations */

--- a/hal/m258ke/nuvoton/gcc_arm.ld
+++ b/hal/m258ke/nuvoton/gcc_arm.ld
@@ -123,7 +123,7 @@ SECTIONS
 
 	__etext = .;
 
-	.data : AT (__etext)
+	.data : ALIGN(4)
 	{
 		__data_start__ = .;
 		*(vtable)
@@ -155,7 +155,7 @@ SECTIONS
 		/* All data end */
 		__data_end__ = .;
 
-	} > RAM
+	} > RAM AT > FLASH
 
 	.bss :
 	{

--- a/hal/m258ke/nuvoton/gcc_arm.ld
+++ b/hal/m258ke/nuvoton/gcc_arm.ld
@@ -185,8 +185,8 @@ SECTIONS
 	} > RAM
 
 	/* Set stack top to end of RAM, and stack limit move down by
-	 * size of stack_dummy section */
-	__StackTop = ORIGIN(RAM) + LENGTH(RAM);
+	 * size of stack_dummy section. Reserve 4 bytes at end of RAM for magic number. */
+	__StackTop = ORIGIN(RAM) + LENGTH(RAM) - 4;
 	__StackLimit = __StackTop - SIZEOF(.stack_dummy);
 	PROVIDE(__stack = __StackTop);
 

--- a/hal/m258ke/nuvoton/gpio_reg.h
+++ b/hal/m258ke/nuvoton/gpio_reg.h
@@ -1,0 +1,930 @@
+/**************************************************************************//**
+ * @file     gpio_reg.h
+ * @version  V1.00
+ * @brief    GPIO register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __GPIO_REG_H__
+#define __GPIO_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup GPIO General Purpose Input/Output Controller (GPIO)
+    Memory Mapped Structure for GPIO Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var GPIO_T::MODE
+     * Offset: 0x00/0x40/0x80/0xC0/0x100/0x140  Port A-F I/O Mode Control
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2n+1:2n]|MODEn    |Port A-F I/O Pin[n] Mode Control
+     * |        |          |Determine each I/O mode of Px.n pins.
+     * |        |          |00 = Px.n is in Input mode.
+     * |        |          |01 = Px.n is in Push-pull Output mode.
+     * |        |          |10 = Px.n is in Open-drain Output mode.
+     * |        |          |11 = Px.n is in Quasi-bidirectional mode.
+     * |        |          |Note1: The initial value of this field is defined by CIOINI (CONFIG0 [10])
+     * |        |          |If CIOINI is set to 0, the default value is 0xFFFF_FFFF and all pins will be quasi-bidirectional mode after chip powered on
+     * |        |          |If CIOINI is set to 1, the default value is 0x0000_0000 and all pins will be  input mode after chip powered on.
+     * |        |          |Note2: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::DINOFF
+     * Offset: 0x04/0x44/0x84/0xC4/0x104/0x144  Port A-F Digital Input Path Disable Control
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n+16]  |DINOFFn   |Port A-F Pin[n] Digital Input Path Disable Bit
+     * |        |          |Each of these bits is used to control if the digital input path of corresponding Px.n pin is disabled
+     * |        |          |If input is analog signal, users can disable Px.n digital input path to avoid input current leakage.
+     * |        |          |0 = Px.n digital input path Enabled.
+     * |        |          |1 = Px.n digital input path Disabled (digital input tied to low).
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::DOUT
+     * Offset: 0x08/0x48/0x88/0xC8/0x108/0x148  Port A-F Data Output Value
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n]     |DOUTn     |Port A-F Pin[n] Output Value
+     * |        |          |Each of these bits controls the status of a Px.n pin when the Px.n is configured as Push-pull output, Open-drain output or Quasi-bidirectional mode.
+     * |        |          |0 = Px.n will drive Low if the Px.n pin is configured as Push-pull output, Open-drain output or Quasi-bidirectional mode.
+     * |        |          |1 = Px.n will drive High if the Px.n pin is configured as Push-pull output or Quasi-bidirectional mode.
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::DATMSK
+     * Offset: 0x0C/0x4C/0x8C/0xCC/0x10C/0x14C  Port A-F Data Output Write Mask
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n]     |DATMSKn   |Port A-F Pin[n] Data Output Write Mask
+     * |        |          |These bits are used to protect the corresponding DOUT (Px_DOUT[n]) bit
+     * |        |          |When the DATMSK (Px_DATMSK[n]) bit is set to 1, the corresponding DOUT (Px_DOUT[n]) bit is protected
+     * |        |          |If the write signal is masked, writing data to the protect bit is ignored.
+     * |        |          |0 = Corresponding DOUT (Px_DOUT[n]) bit can be updated.
+     * |        |          |1 = Corresponding DOUT (Px_DOUT[n]) bit protected.
+     * |        |          |Note1: This function only protects the corresponding DOUT (Px_DOUT[n]) bit, and will not protect the corresponding PDIO (Pxn_PDIO[0]) bit.
+     * |        |          |Note2: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::PIN
+     * Offset: 0x10/0x50/0x90/0xD0/0x110/0x150  Port A-H Pin Value
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n]     |PINn      |Port A-F Pin[n] Pin Value
+     * |        |          |Each bit of the register reflects the actual status of the respective Px.n pin
+     * |        |          |If the bit is 1, it indicates the corresponding pin status is high; else the pin status is low.
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::DBEN
+     * Offset: 0x14/0x54/0x94/0xD4/0x114/0x154  Port A-F De-Bounce Enable Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n]     |DBENn     |Port A-F Pin[n] Input Signal De-bounce Enable Bit
+     * |        |          |The DBEN[n] bit is used to enable the de-bounce function for each corresponding bit
+     * |        |          |If the input signal pulse width cannot be sampled by continuous two de-bounce sample cycle, the input signal transition is seen as the signal bounce and will not trigger the interrupt
+     * |        |          |The de-bounce clock source is controlled by DBCLKSRC (GPIO_DBCTL [4]), one de-bounce sample cycle period is controlled by DBCLKSEL (GPIO_DBCTL [3:0]).
+     * |        |          |0 = Px.n de-bounce function Disabled.
+     * |        |          |1 = Px.n de-bounce function Enabled.
+     * |        |          |The de-bounce function is valid only for edge triggered interrupt
+     * |        |          |If the interrupt mode is level triggered, the de-bounce enable bit is ignored.
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::INTTYPE
+     * Offset: 0x18/0x58/0x98/0xD8/0x118/0x158   Port A-F Interrupt Trigger Type Control
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n]     |TYPEn     |Port A-F Pin[n] Edge or Level Detection Interrupt Trigger Type Control
+     * |        |          |TYPE (Px_INTTYPE[n]) bit is used to control the triggered interrupt is by level trigger or by edge trigger
+     * |        |          |If the interrupt is by edge trigger, the trigger source can be controlled by de-bounce
+     * |        |          |If the interrupt is by level trigger, the input source is sampled by one HCLK clock and generates the interrupt.
+     * |        |          |0 = Edge trigger interrupt.
+     * |        |          |1 = Level trigger interrupt.
+     * |        |          |If the pin is set as the level trigger interrupt, only one level can be set on the registers RHIEN (Px_INTEN[n+16])/FLIEN (Px_INTEN[n])
+     * |        |          |If both levels to trigger interrupt are set, the setting is ignored and no interrupt will occur.
+     * |        |          |The de-bounce function is valid only for edge triggered interrupt
+     * |        |          |If the interrupt mode is level triggered, the de-bounce enable bit is ignored.
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::INTEN
+     * Offset: 0x1C/0x5C/0x9C/0xDC/0x11C/0x15C  Port A-F Interrupt Enable Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n]     |FLIENn    |Port A-F Pin[n] Falling Edge or Low Level Interrupt Trigger Type Enable Bit
+     * |        |          |The FLIEN (Px_INTEN[n]) bit is used to enable the interrupt for each of the corresponding input Px.n pin
+     * |        |          |Set bit to 1 also enable the pin wake-up function.
+     * |        |          |When setting the FLIEN (Px_INTEN[n]) bit to 1 :
+     * |        |          |If the interrupt is level trigger (TYPE (Px_INTTYPE[n]) bit is set to 1), the input Px.n pin will generate the interrupt while this pin state is at low level.
+     * |        |          |If the interrupt is edge trigger(TYPE (Px_INTTYPE[n]) bit is set to 0), the input Px.n pin will generate the interrupt while this pin state changed from high to low.
+     * |        |          |0 = Px.n level low or high to low interrupt Disabled.
+     * |        |          |1 = Px.n level low or high to low interrupt Enabled.
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * |[n+16]  |RHIENn    |Port A-F Pin[n] Rising Edge or High Level Interrupt Trigger Type Enable Bit
+     * |        |          |The RHIEN (Px_INTEN[n+16]) bit is used to enable the interrupt for each of the corresponding input Px.n pin
+     * |        |          |Set bit to 1 also enable the pin wake-up function.
+     * |        |          |When setting the RHIEN (Px_INTEN[n+16]) bit to 1 :
+     * |        |          |If the interrupt is level trigger (TYPE (Px_INTTYPE[n]) bit is set to 1), the input Px.n pin will generate the interrupt while this pin state is at high level.
+     * |        |          |If the interrupt is edge trigger (TYPE (Px_INTTYPE[n]) bit is set to 0), the input Px.n pin will generate the interrupt while this pin state changed from low to high.
+     * |        |          |0 = Px.n level high or low to high interrupt Disabled.
+     * |        |          |1 = Px.n level high or low to high interrupt Enabled.
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::INTSRC
+     * Offset: 0x20/0x60/0xA0/0xE0/0x120/0x160  Port A-F Interrupt Source Flag
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n]     |INTSRCn   |Port A-F Pin[n] Interrupt Source Flag
+     * |        |          |Write Operation :
+     * |        |          |0 = No action.
+     * |        |          |1 = Clear the corresponding pending interrupt.
+     * |        |          |Read Operation :
+     * |        |          |0 = No interrupt at Px.n.
+     * |        |          |1 = Px.n generates an interrupt.
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::SMTEN
+     * Offset: 0x24/0x64/0xA4/0xE4/0x124/0x164  Port A-F Input Schmitt Trigger Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[n]     |SMTENn    |Port A-F Pin[n] Input Schmitt Trigger Enable Bit
+     * |        |          |0 = Px.n input schmitt trigger function Disabled.
+     * |        |          |1 = Px.n input schmitt trigger function Enabled.
+     * |        |          |Note: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     * @var GPIO_T::SLEWCTL
+     * Offset: 0x28/0x68/0xA8/0xE8/0x128/0x168  Port A-F High Slew Rate Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2n+1:2n]|HSRENn   |Port A-F Pin[n] High Slew Rate Control
+     * |        |          |00 = Px.n output with normal slew rate mode.
+     * |        |          |01 = Px.n output with high slew rate mode.
+     * |        |          |10 = Reserved.
+     * |        |          |11 = Reserved.
+     * |        |          |Note1: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |Note2: Please refer to the M25 Datasheet for detailed pin operation voltage
+     * |        |          |       information about VDD, VDDIO and VBAT electrical characteristics.
+     * @var GPIO_T::PUSEL
+     * Offset: 0x30/0x70/0xB0/0xF0/0x130/0x170  Port A-F Pull-up and Pull-down Selection Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2n+1:2n]|PUSELn   |Port A-F Pin[n] Pull-up and Pull-down Enable Register
+     * |        |          |Determine each I/O Pull-up/pull-down of Px.n pins.
+     * |        |          |00 = Px.n pull-up and pull-down disable.
+     * |        |          |01 = Px.n pull-up enable.
+     * |        |          |10 = Px.n pull-down enable.
+     * |        |          |11 = Px.n pull-up and pull-down disable.
+     * |        |          |Note1:
+     * |        |          |Basically, the pull-up control and pull-down control has following behavior limitation
+     * |        |          |The independent pull-up control register only valid when MODEn set as tri-state and open-drain mode
+     * |        |          |The independent pull-down control register only valid when MODEn set as tri-state mode
+     * |        |          |When both pull-up pull-down is set as 1 at tri-state mode, keep I/O in tri-state mode
+     * |        |          |Note2: The PC.13/PC.15/PD.14/PF.8~15 pin is ignored.
+     * |        |          |
+     */
+    __IO uint32_t MODE;               /*!< [0x00/0x40/0x80/0xc0/0x100/0x140] PA~PF I/O Mode Control                     */
+    __IO uint32_t DINOFF;             /*!< [0x04/0x44/0x84/0xc4/0x104/0x144] PA~PF Digital Input Path Disable Control   */
+    __IO uint32_t DOUT;               /*!< [0x08/0x48/0x88/0xc8/0x108/0x148] PA~PF Data Output Value                    */
+    __IO uint32_t DATMSK;             /*!< [0x0c/0x4c/0x8c/0xcc/0x10c/0x14c] PA~PF Data Output Write Mask               */
+    __I  uint32_t PIN;                /*!< [0x10/0x50/0x90/0xd0/0x110/0x150] PA~PF Pin Value                            */
+    __IO uint32_t DBEN;               /*!< [0x14/0x54/0x94/0xd4/0x114/0x154] PA~PF De-bounce Enable Control Register    */
+    __IO uint32_t INTTYPE;            /*!< [0x18/0x58/0x98/0xd8/0x118/0x158] PA~PF Interrupt Trigger Type Control       */
+    __IO uint32_t INTEN;              /*!< [0x1c/0x5c/0x9c/0xdc/0x11c/0x15c] PA~PF Interrupt Enable Control Register    */
+    __IO uint32_t INTSRC;             /*!< [0x20/0x60/0xa0/0xe0/0x120/0x160] PA~PF Interrupt Source Flag                */
+    __IO uint32_t SMTEN;              /*!< [0x24/0x64/0xa4/0xe4/0x124/0x164] PA~PF Input Schmitt Trigger Enable Register*/
+    __IO uint32_t SLEWCTL;            /*!< [0x28/0x68/0xa8/0xe8/0x128/0x168] PA~PF High Slew Rate Control Register      */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PUSEL;              /*!< [0x30/0x70/0xB0/0xF0/0x130/0x170] PA~PF Pull-up and Pull-down Selection Register*/
+} GPIO_T;
+
+
+typedef struct
+{
+
+
+
+    /**
+     * @var GPIO_DBCTL_T::DBCTL
+     * Offset: 0x440  Interrupt De-bounce Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |DBCLKSEL  |De-bounce Sampling Cycle Selection
+     * |        |          |0000 = Sample interrupt input once per 1 clocks.
+     * |        |          |0001 = Sample interrupt input once per 2 clocks.
+     * |        |          |0010 = Sample interrupt input once per 4 clocks.
+     * |        |          |0011 = Sample interrupt input once per 8 clocks.
+     * |        |          |0100 = Sample interrupt input once per 16 clocks.
+     * |        |          |0101 = Sample interrupt input once per 32 clocks.
+     * |        |          |0110 = Sample interrupt input once per 64 clocks.
+     * |        |          |0111 = Sample interrupt input once per 128 clocks.
+     * |        |          |1000 = Sample interrupt input once per 256 clocks.
+     * |        |          |1001 = Sample interrupt input once per 2*256 clocks.
+     * |        |          |1010 = Sample interrupt input once per 4*256 clocks.
+     * |        |          |1011 = Sample interrupt input once per 8*256 clocks.
+     * |        |          |1100 = Sample interrupt input once per 16*256 clocks.
+     * |        |          |1101 = Sample interrupt input once per 32*256 clocks.
+     * |        |          |1110 = Sample interrupt input once per 64*256 clocks.
+     * |        |          |1111 = Sample interrupt input once per 128*256 clocks.
+     * |[4]     |DBCLKSRC  |De-bounce Counter Clock Source Selection
+     * |        |          |0 = De-bounce counter clock source is the HCLK.
+     * |        |          |1 = De-bounce counter clock source is the 38.4 kHz internal low speed RC oscillator (LIRC).
+     * |[21:16] |ICLKONx   |Interrupt Clock on Mode
+     * |        |          |0 = Edge detection circuit is active only if I/O pin corresponding RHIEN (Px_INTEN[n+16])/FLIEN (Px_INTEN[n]) bit is set to 1.
+     * |        |          |1 = All I/O pins edge detection circuit is always active after reset.
+     * |        |          |Note: It is recommended to disable this bit to save system power if no special application concern.
+     */
+
+    __IO uint32_t DBCTL;   /*!< [0x0440] Interrupt De-bounce Control Register                             */
+
+} GPIO_DBCTL_T;
+
+/**
+    @addtogroup GPIO_CONST GPIO Bit Field Definition
+    Constant Definitions for GPIO Controller
+@{ */
+
+#define GPIO_MODE_MODE0_Pos              (0)                                               /*!< GPIO_T::MODE: MODE0 Position           */
+#define GPIO_MODE_MODE0_Msk              (0x3ul << GPIO_MODE_MODE0_Pos)                    /*!< GPIO_T::MODE: MODE0 Mask               */
+
+#define GPIO_MODE_MODE1_Pos              (2)                                               /*!< GPIO_T::MODE: MODE1 Position           */
+#define GPIO_MODE_MODE1_Msk              (0x3ul << GPIO_MODE_MODE1_Pos)                    /*!< GPIO_T::MODE: MODE1 Mask               */
+
+#define GPIO_MODE_MODE2_Pos              (4)                                               /*!< GPIO_T::MODE: MODE2 Position           */
+#define GPIO_MODE_MODE2_Msk              (0x3ul << GPIO_MODE_MODE2_Pos)                    /*!< GPIO_T::MODE: MODE2 Mask               */
+
+#define GPIO_MODE_MODE3_Pos              (6)                                               /*!< GPIO_T::MODE: MODE3 Position           */
+#define GPIO_MODE_MODE3_Msk              (0x3ul << GPIO_MODE_MODE3_Pos)                    /*!< GPIO_T::MODE: MODE3 Mask               */
+
+#define GPIO_MODE_MODE4_Pos              (8)                                               /*!< GPIO_T::MODE: MODE4 Position           */
+#define GPIO_MODE_MODE4_Msk              (0x3ul << GPIO_MODE_MODE4_Pos)                    /*!< GPIO_T::MODE: MODE4 Mask               */
+
+#define GPIO_MODE_MODE5_Pos              (10)                                              /*!< GPIO_T::MODE: MODE5 Position           */
+#define GPIO_MODE_MODE5_Msk              (0x3ul << GPIO_MODE_MODE5_Pos)                    /*!< GPIO_T::MODE: MODE5 Mask               */
+
+#define GPIO_MODE_MODE6_Pos              (12)                                              /*!< GPIO_T::MODE: MODE6 Position           */
+#define GPIO_MODE_MODE6_Msk              (0x3ul << GPIO_MODE_MODE6_Pos)                    /*!< GPIO_T::MODE: MODE6 Mask               */
+
+#define GPIO_MODE_MODE7_Pos              (14)                                              /*!< GPIO_T::MODE: MODE7 Position           */
+#define GPIO_MODE_MODE7_Msk              (0x3ul << GPIO_MODE_MODE7_Pos)                    /*!< GPIO_T::MODE: MODE7 Mask               */
+
+#define GPIO_MODE_MODE8_Pos              (16)                                              /*!< GPIO_T::MODE: MODE8 Position           */
+#define GPIO_MODE_MODE8_Msk              (0x3ul << GPIO_MODE_MODE8_Pos)                    /*!< GPIO_T::MODE: MODE8 Mask               */
+
+#define GPIO_MODE_MODE9_Pos              (18)                                              /*!< GPIO_T::MODE: MODE9 Position           */
+#define GPIO_MODE_MODE9_Msk              (0x3ul << GPIO_MODE_MODE9_Pos)                    /*!< GPIO_T::MODE: MODE9 Mask               */
+
+#define GPIO_MODE_MODE10_Pos             (20)                                              /*!< GPIO_T::MODE: MODE10 Position          */
+#define GPIO_MODE_MODE10_Msk             (0x3ul << GPIO_MODE_MODE10_Pos)                   /*!< GPIO_T::MODE: MODE10 Mask              */
+
+#define GPIO_MODE_MODE11_Pos             (22)                                              /*!< GPIO_T::MODE: MODE11 Position          */
+#define GPIO_MODE_MODE11_Msk             (0x3ul << GPIO_MODE_MODE11_Pos)                   /*!< GPIO_T::MODE: MODE11 Mask              */
+
+#define GPIO_MODE_MODE12_Pos             (24)                                              /*!< GPIO_T::MODE: MODE12 Position          */
+#define GPIO_MODE_MODE12_Msk             (0x3ul << GPIO_MODE_MODE12_Pos)                   /*!< GPIO_T::MODE: MODE12 Mask              */
+
+#define GPIO_MODE_MODE13_Pos             (26)                                              /*!< GPIO_T::MODE: MODE13 Position          */
+#define GPIO_MODE_MODE13_Msk             (0x3ul << GPIO_MODE_MODE13_Pos)                   /*!< GPIO_T::MODE: MODE13 Mask              */
+
+#define GPIO_MODE_MODE14_Pos             (28)                                              /*!< GPIO_T::MODE: MODE14 Position          */
+#define GPIO_MODE_MODE14_Msk             (0x3ul << GPIO_MODE_MODE14_Pos)                   /*!< GPIO_T::MODE: MODE14 Mask              */
+
+#define GPIO_MODE_MODE15_Pos             (30)                                              /*!< GPIO_T::MODE: MODE15 Position          */
+#define GPIO_MODE_MODE15_Msk             (0x3ul << GPIO_MODE_MODE15_Pos)                   /*!< GPIO_T::MODE: MODE15 Mask              */
+
+#define GPIO_DINOFF_DINOFF0_Pos          (16)                                              /*!< GPIO_T::DINOFF: DINOFF0 Position       */
+#define GPIO_DINOFF_DINOFF0_Msk          (0x1ul << GPIO_DINOFF_DINOFF0_Pos)                /*!< GPIO_T::DINOFF: DINOFF0 Mask           */
+
+#define GPIO_DINOFF_DINOFF1_Pos          (17)                                              /*!< GPIO_T::DINOFF: DINOFF1 Position       */
+#define GPIO_DINOFF_DINOFF1_Msk          (0x1ul << GPIO_DINOFF_DINOFF1_Pos)                /*!< GPIO_T::DINOFF: DINOFF1 Mask           */
+
+#define GPIO_DINOFF_DINOFF2_Pos          (18)                                              /*!< GPIO_T::DINOFF: DINOFF2 Position       */
+#define GPIO_DINOFF_DINOFF2_Msk          (0x1ul << GPIO_DINOFF_DINOFF2_Pos)                /*!< GPIO_T::DINOFF: DINOFF2 Mask           */
+
+#define GPIO_DINOFF_DINOFF3_Pos          (19)                                              /*!< GPIO_T::DINOFF: DINOFF3 Position       */
+#define GPIO_DINOFF_DINOFF3_Msk          (0x1ul << GPIO_DINOFF_DINOFF3_Pos)                /*!< GPIO_T::DINOFF: DINOFF3 Mask           */
+
+#define GPIO_DINOFF_DINOFF4_Pos          (20)                                              /*!< GPIO_T::DINOFF: DINOFF4 Position       */
+#define GPIO_DINOFF_DINOFF4_Msk          (0x1ul << GPIO_DINOFF_DINOFF4_Pos)                /*!< GPIO_T::DINOFF: DINOFF4 Mask           */
+
+#define GPIO_DINOFF_DINOFF5_Pos          (21)                                              /*!< GPIO_T::DINOFF: DINOFF5 Position       */
+#define GPIO_DINOFF_DINOFF5_Msk          (0x1ul << GPIO_DINOFF_DINOFF5_Pos)                /*!< GPIO_T::DINOFF: DINOFF5 Mask           */
+
+#define GPIO_DINOFF_DINOFF6_Pos          (22)                                              /*!< GPIO_T::DINOFF: DINOFF6 Position       */
+#define GPIO_DINOFF_DINOFF6_Msk          (0x1ul << GPIO_DINOFF_DINOFF6_Pos)                /*!< GPIO_T::DINOFF: DINOFF6 Mask           */
+
+#define GPIO_DINOFF_DINOFF7_Pos          (23)                                              /*!< GPIO_T::DINOFF: DINOFF7 Position       */
+#define GPIO_DINOFF_DINOFF7_Msk          (0x1ul << GPIO_DINOFF_DINOFF7_Pos)                /*!< GPIO_T::DINOFF: DINOFF7 Mask           */
+
+#define GPIO_DINOFF_DINOFF8_Pos          (24)                                              /*!< GPIO_T::DINOFF: DINOFF8 Position       */
+#define GPIO_DINOFF_DINOFF8_Msk          (0x1ul << GPIO_DINOFF_DINOFF8_Pos)                /*!< GPIO_T::DINOFF: DINOFF8 Mask           */
+
+#define GPIO_DINOFF_DINOFF9_Pos          (25)                                              /*!< GPIO_T::DINOFF: DINOFF9 Position       */
+#define GPIO_DINOFF_DINOFF9_Msk          (0x1ul << GPIO_DINOFF_DINOFF9_Pos)                /*!< GPIO_T::DINOFF: DINOFF9 Mask           */
+
+#define GPIO_DINOFF_DINOFF10_Pos         (26)                                              /*!< GPIO_T::DINOFF: DINOFF10 Position      */
+#define GPIO_DINOFF_DINOFF10_Msk         (0x1ul << GPIO_DINOFF_DINOFF10_Pos)               /*!< GPIO_T::DINOFF: DINOFF10 Mask          */
+
+#define GPIO_DINOFF_DINOFF11_Pos         (27)                                              /*!< GPIO_T::DINOFF: DINOFF11 Position      */
+#define GPIO_DINOFF_DINOFF11_Msk         (0x1ul << GPIO_DINOFF_DINOFF11_Pos)               /*!< GPIO_T::DINOFF: DINOFF11 Mask          */
+
+#define GPIO_DINOFF_DINOFF12_Pos         (28)                                              /*!< GPIO_T::DINOFF: DINOFF12 Position      */
+#define GPIO_DINOFF_DINOFF12_Msk         (0x1ul << GPIO_DINOFF_DINOFF12_Pos)               /*!< GPIO_T::DINOFF: DINOFF12 Mask          */
+
+#define GPIO_DINOFF_DINOFF13_Pos         (29)                                              /*!< GPIO_T::DINOFF: DINOFF13 Position      */
+#define GPIO_DINOFF_DINOFF13_Msk         (0x1ul << GPIO_DINOFF_DINOFF13_Pos)               /*!< GPIO_T::DINOFF: DINOFF13 Mask          */
+
+#define GPIO_DINOFF_DINOFF14_Pos         (30)                                              /*!< GPIO_T::DINOFF: DINOFF14 Position      */
+#define GPIO_DINOFF_DINOFF14_Msk         (0x1ul << GPIO_DINOFF_DINOFF14_Pos)               /*!< GPIO_T::DINOFF: DINOFF14 Mask          */
+
+#define GPIO_DINOFF_DINOFF15_Pos         (31)                                              /*!< GPIO_T::DINOFF: DINOFF15 Position      */
+#define GPIO_DINOFF_DINOFF15_Msk         (0x1ul << GPIO_DINOFF_DINOFF15_Pos)               /*!< GPIO_T::DINOFF: DINOFF15 Mask          */
+
+#define GPIO_DOUT_DOUT0_Pos              (0)                                               /*!< GPIO_T::DOUT: DOUT0 Position           */
+#define GPIO_DOUT_DOUT0_Msk              (0x1ul << GPIO_DOUT_DOUT0_Pos)                    /*!< GPIO_T::DOUT: DOUT0 Mask               */
+
+#define GPIO_DOUT_DOUT1_Pos              (1)                                               /*!< GPIO_T::DOUT: DOUT1 Position           */
+#define GPIO_DOUT_DOUT1_Msk              (0x1ul << GPIO_DOUT_DOUT1_Pos)                    /*!< GPIO_T::DOUT: DOUT1 Mask               */
+
+#define GPIO_DOUT_DOUT2_Pos              (2)                                               /*!< GPIO_T::DOUT: DOUT2 Position           */
+#define GPIO_DOUT_DOUT2_Msk              (0x1ul << GPIO_DOUT_DOUT2_Pos)                    /*!< GPIO_T::DOUT: DOUT2 Mask               */
+
+#define GPIO_DOUT_DOUT3_Pos              (3)                                               /*!< GPIO_T::DOUT: DOUT3 Position           */
+#define GPIO_DOUT_DOUT3_Msk              (0x1ul << GPIO_DOUT_DOUT3_Pos)                    /*!< GPIO_T::DOUT: DOUT3 Mask               */
+
+#define GPIO_DOUT_DOUT4_Pos              (4)                                               /*!< GPIO_T::DOUT: DOUT4 Position           */
+#define GPIO_DOUT_DOUT4_Msk              (0x1ul << GPIO_DOUT_DOUT4_Pos)                    /*!< GPIO_T::DOUT: DOUT4 Mask               */
+
+#define GPIO_DOUT_DOUT5_Pos              (5)                                               /*!< GPIO_T::DOUT: DOUT5 Position           */
+#define GPIO_DOUT_DOUT5_Msk              (0x1ul << GPIO_DOUT_DOUT5_Pos)                    /*!< GPIO_T::DOUT: DOUT5 Mask               */
+
+#define GPIO_DOUT_DOUT6_Pos              (6)                                               /*!< GPIO_T::DOUT: DOUT6 Position           */
+#define GPIO_DOUT_DOUT6_Msk              (0x1ul << GPIO_DOUT_DOUT6_Pos)                    /*!< GPIO_T::DOUT: DOUT6 Mask               */
+
+#define GPIO_DOUT_DOUT7_Pos              (7)                                               /*!< GPIO_T::DOUT: DOUT7 Position           */
+#define GPIO_DOUT_DOUT7_Msk              (0x1ul << GPIO_DOUT_DOUT7_Pos)                    /*!< GPIO_T::DOUT: DOUT7 Mask               */
+
+#define GPIO_DOUT_DOUT8_Pos              (8)                                               /*!< GPIO_T::DOUT: DOUT8 Position           */
+#define GPIO_DOUT_DOUT8_Msk              (0x1ul << GPIO_DOUT_DOUT8_Pos)                    /*!< GPIO_T::DOUT: DOUT8 Mask               */
+
+#define GPIO_DOUT_DOUT9_Pos              (9)                                               /*!< GPIO_T::DOUT: DOUT9 Position           */
+#define GPIO_DOUT_DOUT9_Msk              (0x1ul << GPIO_DOUT_DOUT9_Pos)                    /*!< GPIO_T::DOUT: DOUT9 Mask               */
+
+#define GPIO_DOUT_DOUT10_Pos             (10)                                              /*!< GPIO_T::DOUT: DOUT10 Position          */
+#define GPIO_DOUT_DOUT10_Msk             (0x1ul << GPIO_DOUT_DOUT10_Pos)                   /*!< GPIO_T::DOUT: DOUT10 Mask              */
+
+#define GPIO_DOUT_DOUT11_Pos             (11)                                              /*!< GPIO_T::DOUT: DOUT11 Position          */
+#define GPIO_DOUT_DOUT11_Msk             (0x1ul << GPIO_DOUT_DOUT11_Pos)                   /*!< GPIO_T::DOUT: DOUT11 Mask              */
+
+#define GPIO_DOUT_DOUT12_Pos             (12)                                              /*!< GPIO_T::DOUT: DOUT12 Position          */
+#define GPIO_DOUT_DOUT12_Msk             (0x1ul << GPIO_DOUT_DOUT12_Pos)                   /*!< GPIO_T::DOUT: DOUT12 Mask              */
+
+#define GPIO_DOUT_DOUT13_Pos             (13)                                              /*!< GPIO_T::DOUT: DOUT13 Position          */
+#define GPIO_DOUT_DOUT13_Msk             (0x1ul << GPIO_DOUT_DOUT13_Pos)                   /*!< GPIO_T::DOUT: DOUT13 Mask              */
+
+#define GPIO_DOUT_DOUT14_Pos             (14)                                              /*!< GPIO_T::DOUT: DOUT14 Position          */
+#define GPIO_DOUT_DOUT14_Msk             (0x1ul << GPIO_DOUT_DOUT14_Pos)                   /*!< GPIO_T::DOUT: DOUT14 Mask              */
+
+#define GPIO_DOUT_DOUT15_Pos             (15)                                              /*!< GPIO_T::DOUT: DOUT15 Position          */
+#define GPIO_DOUT_DOUT15_Msk             (0x1ul << GPIO_DOUT_DOUT15_Pos)                   /*!< GPIO_T::DOUT: DOUT15 Mask              */
+
+#define GPIO_DATMSK_DATMSK0_Pos          (0)                                               /*!< GPIO_T::DATMSK: DATMSK0 Position       */
+#define GPIO_DATMSK_DATMSK0_Msk          (0x1ul << GPIO_DATMSK_DATMSK0_Pos)                /*!< GPIO_T::DATMSK: DATMSK0 Mask           */
+
+#define GPIO_DATMSK_DATMSK1_Pos          (1)                                               /*!< GPIO_T::DATMSK: DATMSK1 Position       */
+#define GPIO_DATMSK_DATMSK1_Msk          (0x1ul << GPIO_DATMSK_DATMSK1_Pos)                /*!< GPIO_T::DATMSK: DATMSK1 Mask           */
+
+#define GPIO_DATMSK_DATMSK2_Pos          (2)                                               /*!< GPIO_T::DATMSK: DATMSK2 Position       */
+#define GPIO_DATMSK_DATMSK2_Msk          (0x1ul << GPIO_DATMSK_DATMSK2_Pos)                /*!< GPIO_T::DATMSK: DATMSK2 Mask           */
+
+#define GPIO_DATMSK_DATMSK3_Pos          (3)                                               /*!< GPIO_T::DATMSK: DATMSK3 Position       */
+#define GPIO_DATMSK_DATMSK3_Msk          (0x1ul << GPIO_DATMSK_DATMSK3_Pos)                /*!< GPIO_T::DATMSK: DATMSK3 Mask           */
+
+#define GPIO_DATMSK_DATMSK4_Pos          (4)                                               /*!< GPIO_T::DATMSK: DATMSK4 Position       */
+#define GPIO_DATMSK_DATMSK4_Msk          (0x1ul << GPIO_DATMSK_DATMSK4_Pos)                /*!< GPIO_T::DATMSK: DATMSK4 Mask           */
+
+#define GPIO_DATMSK_DATMSK5_Pos          (5)                                               /*!< GPIO_T::DATMSK: DATMSK5 Position       */
+#define GPIO_DATMSK_DATMSK5_Msk          (0x1ul << GPIO_DATMSK_DATMSK5_Pos)                /*!< GPIO_T::DATMSK: DATMSK5 Mask           */
+
+#define GPIO_DATMSK_DATMSK6_Pos          (6)                                               /*!< GPIO_T::DATMSK: DATMSK6 Position       */
+#define GPIO_DATMSK_DATMSK6_Msk          (0x1ul << GPIO_DATMSK_DATMSK6_Pos)                /*!< GPIO_T::DATMSK: DATMSK6 Mask           */
+
+#define GPIO_DATMSK_DATMSK7_Pos          (7)                                               /*!< GPIO_T::DATMSK: DATMSK7 Position       */
+#define GPIO_DATMSK_DATMSK7_Msk          (0x1ul << GPIO_DATMSK_DATMSK7_Pos)                /*!< GPIO_T::DATMSK: DATMSK7 Mask           */
+
+#define GPIO_DATMSK_DATMSK8_Pos          (8)                                               /*!< GPIO_T::DATMSK: DATMSK8 Position       */
+#define GPIO_DATMSK_DATMSK8_Msk          (0x1ul << GPIO_DATMSK_DATMSK8_Pos)                /*!< GPIO_T::DATMSK: DATMSK8 Mask           */
+
+#define GPIO_DATMSK_DATMSK9_Pos          (9)                                               /*!< GPIO_T::DATMSK: DATMSK9 Position       */
+#define GPIO_DATMSK_DATMSK9_Msk          (0x1ul << GPIO_DATMSK_DATMSK9_Pos)                /*!< GPIO_T::DATMSK: DATMSK9 Mask           */
+
+#define GPIO_DATMSK_DATMSK10_Pos         (10)                                              /*!< GPIO_T::DATMSK: DATMSK10 Position      */
+#define GPIO_DATMSK_DATMSK10_Msk         (0x1ul << GPIO_DATMSK_DATMSK10_Pos)               /*!< GPIO_T::DATMSK: DATMSK10 Mask          */
+
+#define GPIO_DATMSK_DATMSK11_Pos         (11)                                              /*!< GPIO_T::DATMSK: DATMSK11 Position      */
+#define GPIO_DATMSK_DATMSK11_Msk         (0x1ul << GPIO_DATMSK_DATMSK11_Pos)               /*!< GPIO_T::DATMSK: DATMSK11 Mask          */
+
+#define GPIO_DATMSK_DATMSK12_Pos         (12)                                              /*!< GPIO_T::DATMSK: DATMSK12 Position      */
+#define GPIO_DATMSK_DATMSK12_Msk         (0x1ul << GPIO_DATMSK_DATMSK12_Pos)               /*!< GPIO_T::DATMSK: DATMSK12 Mask          */
+
+#define GPIO_DATMSK_DATMSK13_Pos         (13)                                              /*!< GPIO_T::DATMSK: DATMSK13 Position      */
+#define GPIO_DATMSK_DATMSK13_Msk         (0x1ul << GPIO_DATMSK_DATMSK13_Pos)               /*!< GPIO_T::DATMSK: DATMSK13 Mask          */
+
+#define GPIO_DATMSK_DATMSK14_Pos         (14)                                              /*!< GPIO_T::DATMSK: DATMSK14 Position      */
+#define GPIO_DATMSK_DATMSK14_Msk         (0x1ul << GPIO_DATMSK_DATMSK14_Pos)               /*!< GPIO_T::DATMSK: DATMSK14 Mask          */
+
+#define GPIO_DATMSK_DATMSK15_Pos         (15)                                              /*!< GPIO_T::DATMSK: DATMSK15 Position      */
+#define GPIO_DATMSK_DATMSK15_Msk         (0x1ul << GPIO_DATMSK_DATMSK15_Pos)               /*!< GPIO_T::DATMSK: DATMSK15 Mask          */
+
+#define GPIO_PIN_PIN0_Pos                (0)                                               /*!< GPIO_T::PIN: PIN0 Position             */
+#define GPIO_PIN_PIN0_Msk                (0x1ul << GPIO_PIN_PIN0_Pos)                      /*!< GPIO_T::PIN: PIN0 Mask                 */
+
+#define GPIO_PIN_PIN1_Pos                (1)                                               /*!< GPIO_T::PIN: PIN1 Position             */
+#define GPIO_PIN_PIN1_Msk                (0x1ul << GPIO_PIN_PIN1_Pos)                      /*!< GPIO_T::PIN: PIN1 Mask                 */
+
+#define GPIO_PIN_PIN2_Pos                (2)                                               /*!< GPIO_T::PIN: PIN2 Position             */
+#define GPIO_PIN_PIN2_Msk                (0x1ul << GPIO_PIN_PIN2_Pos)                      /*!< GPIO_T::PIN: PIN2 Mask                 */
+
+#define GPIO_PIN_PIN3_Pos                (3)                                               /*!< GPIO_T::PIN: PIN3 Position             */
+#define GPIO_PIN_PIN3_Msk                (0x1ul << GPIO_PIN_PIN3_Pos)                      /*!< GPIO_T::PIN: PIN3 Mask                 */
+
+#define GPIO_PIN_PIN4_Pos                (4)                                               /*!< GPIO_T::PIN: PIN4 Position             */
+#define GPIO_PIN_PIN4_Msk                (0x1ul << GPIO_PIN_PIN4_Pos)                      /*!< GPIO_T::PIN: PIN4 Mask                 */
+
+#define GPIO_PIN_PIN5_Pos                (5)                                               /*!< GPIO_T::PIN: PIN5 Position             */
+#define GPIO_PIN_PIN5_Msk                (0x1ul << GPIO_PIN_PIN5_Pos)                      /*!< GPIO_T::PIN: PIN5 Mask                 */
+
+#define GPIO_PIN_PIN6_Pos                (6)                                               /*!< GPIO_T::PIN: PIN6 Position             */
+#define GPIO_PIN_PIN6_Msk                (0x1ul << GPIO_PIN_PIN6_Pos)                      /*!< GPIO_T::PIN: PIN6 Mask                 */
+
+#define GPIO_PIN_PIN7_Pos                (7)                                               /*!< GPIO_T::PIN: PIN7 Position             */
+#define GPIO_PIN_PIN7_Msk                (0x1ul << GPIO_PIN_PIN7_Pos)                      /*!< GPIO_T::PIN: PIN7 Mask                 */
+
+#define GPIO_PIN_PIN8_Pos                (8)                                               /*!< GPIO_T::PIN: PIN8 Position             */
+#define GPIO_PIN_PIN8_Msk                (0x1ul << GPIO_PIN_PIN8_Pos)                      /*!< GPIO_T::PIN: PIN8 Mask                 */
+
+#define GPIO_PIN_PIN9_Pos                (9)                                               /*!< GPIO_T::PIN: PIN9 Position             */
+#define GPIO_PIN_PIN9_Msk                (0x1ul << GPIO_PIN_PIN9_Pos)                      /*!< GPIO_T::PIN: PIN9 Mask                 */
+
+#define GPIO_PIN_PIN10_Pos               (10)                                              /*!< GPIO_T::PIN: PIN10 Position            */
+#define GPIO_PIN_PIN10_Msk               (0x1ul << GPIO_PIN_PIN10_Pos)                     /*!< GPIO_T::PIN: PIN10 Mask                */
+
+#define GPIO_PIN_PIN11_Pos               (11)                                              /*!< GPIO_T::PIN: PIN11 Position            */
+#define GPIO_PIN_PIN11_Msk               (0x1ul << GPIO_PIN_PIN11_Pos)                     /*!< GPIO_T::PIN: PIN11 Mask                */
+
+#define GPIO_PIN_PIN12_Pos               (12)                                              /*!< GPIO_T::PIN: PIN12 Position            */
+#define GPIO_PIN_PIN12_Msk               (0x1ul << GPIO_PIN_PIN12_Pos)                     /*!< GPIO_T::PIN: PIN12 Mask                */
+
+#define GPIO_PIN_PIN13_Pos               (13)                                              /*!< GPIO_T::PIN: PIN13 Position            */
+#define GPIO_PIN_PIN13_Msk               (0x1ul << GPIO_PIN_PIN13_Pos)                     /*!< GPIO_T::PIN: PIN13 Mask                */
+
+#define GPIO_PIN_PIN14_Pos               (14)                                              /*!< GPIO_T::PIN: PIN14 Position            */
+#define GPIO_PIN_PIN14_Msk               (0x1ul << GPIO_PIN_PIN14_Pos)                     /*!< GPIO_T::PIN: PIN14 Mask                */
+
+#define GPIO_PIN_PIN15_Pos               (15)                                              /*!< GPIO_T::PIN: PIN15 Position            */
+#define GPIO_PIN_PIN15_Msk               (0x1ul << GPIO_PIN_PIN15_Pos)                     /*!< GPIO_T::PIN: PIN15 Mask                */
+
+#define GPIO_DBEN_DBEN0_Pos              (0)                                               /*!< GPIO_T::DBEN: DBEN0 Position           */
+#define GPIO_DBEN_DBEN0_Msk              (0x1ul << GPIO_DBEN_DBEN0_Pos)                    /*!< GPIO_T::DBEN: DBEN0 Mask               */
+
+#define GPIO_DBEN_DBEN1_Pos              (1)                                               /*!< GPIO_T::DBEN: DBEN1 Position           */
+#define GPIO_DBEN_DBEN1_Msk              (0x1ul << GPIO_DBEN_DBEN1_Pos)                    /*!< GPIO_T::DBEN: DBEN1 Mask               */
+
+#define GPIO_DBEN_DBEN2_Pos              (2)                                               /*!< GPIO_T::DBEN: DBEN2 Position           */
+#define GPIO_DBEN_DBEN2_Msk              (0x1ul << GPIO_DBEN_DBEN2_Pos)                    /*!< GPIO_T::DBEN: DBEN2 Mask               */
+
+#define GPIO_DBEN_DBEN3_Pos              (3)                                               /*!< GPIO_T::DBEN: DBEN3 Position           */
+#define GPIO_DBEN_DBEN3_Msk              (0x1ul << GPIO_DBEN_DBEN3_Pos)                    /*!< GPIO_T::DBEN: DBEN3 Mask               */
+
+#define GPIO_DBEN_DBEN4_Pos              (4)                                               /*!< GPIO_T::DBEN: DBEN4 Position           */
+#define GPIO_DBEN_DBEN4_Msk              (0x1ul << GPIO_DBEN_DBEN4_Pos)                    /*!< GPIO_T::DBEN: DBEN4 Mask               */
+
+#define GPIO_DBEN_DBEN5_Pos              (5)                                               /*!< GPIO_T::DBEN: DBEN5 Position           */
+#define GPIO_DBEN_DBEN5_Msk              (0x1ul << GPIO_DBEN_DBEN5_Pos)                    /*!< GPIO_T::DBEN: DBEN5 Mask               */
+
+#define GPIO_DBEN_DBEN6_Pos              (6)                                               /*!< GPIO_T::DBEN: DBEN6 Position           */
+#define GPIO_DBEN_DBEN6_Msk              (0x1ul << GPIO_DBEN_DBEN6_Pos)                    /*!< GPIO_T::DBEN: DBEN6 Mask               */
+
+#define GPIO_DBEN_DBEN7_Pos              (7)                                               /*!< GPIO_T::DBEN: DBEN7 Position           */
+#define GPIO_DBEN_DBEN7_Msk              (0x1ul << GPIO_DBEN_DBEN7_Pos)                    /*!< GPIO_T::DBEN: DBEN7 Mask               */
+
+#define GPIO_DBEN_DBEN8_Pos              (8)                                               /*!< GPIO_T::DBEN: DBEN8 Position           */
+#define GPIO_DBEN_DBEN8_Msk              (0x1ul << GPIO_DBEN_DBEN8_Pos)                    /*!< GPIO_T::DBEN: DBEN8 Mask               */
+
+#define GPIO_DBEN_DBEN9_Pos              (9)                                               /*!< GPIO_T::DBEN: DBEN9 Position           */
+#define GPIO_DBEN_DBEN9_Msk              (0x1ul << GPIO_DBEN_DBEN9_Pos)                    /*!< GPIO_T::DBEN: DBEN9 Mask               */
+
+#define GPIO_DBEN_DBEN10_Pos             (10)                                              /*!< GPIO_T::DBEN: DBEN10 Position          */
+#define GPIO_DBEN_DBEN10_Msk             (0x1ul << GPIO_DBEN_DBEN10_Pos)                   /*!< GPIO_T::DBEN: DBEN10 Mask              */
+
+#define GPIO_DBEN_DBEN11_Pos             (11)                                              /*!< GPIO_T::DBEN: DBEN11 Position          */
+#define GPIO_DBEN_DBEN11_Msk             (0x1ul << GPIO_DBEN_DBEN11_Pos)                   /*!< GPIO_T::DBEN: DBEN11 Mask              */
+
+#define GPIO_DBEN_DBEN12_Pos             (12)                                              /*!< GPIO_T::DBEN: DBEN12 Position          */
+#define GPIO_DBEN_DBEN12_Msk             (0x1ul << GPIO_DBEN_DBEN12_Pos)                   /*!< GPIO_T::DBEN: DBEN12 Mask              */
+
+#define GPIO_DBEN_DBEN13_Pos             (13)                                              /*!< GPIO_T::DBEN: DBEN13 Position          */
+#define GPIO_DBEN_DBEN13_Msk             (0x1ul << GPIO_DBEN_DBEN13_Pos)                   /*!< GPIO_T::DBEN: DBEN13 Mask              */
+
+#define GPIO_DBEN_DBEN14_Pos             (14)                                              /*!< GPIO_T::DBEN: DBEN14 Position          */
+#define GPIO_DBEN_DBEN14_Msk             (0x1ul << GPIO_DBEN_DBEN14_Pos)                   /*!< GPIO_T::DBEN: DBEN14 Mask              */
+
+#define GPIO_DBEN_DBEN15_Pos             (15)                                              /*!< GPIO_T::DBEN: DBEN15 Position          */
+#define GPIO_DBEN_DBEN15_Msk             (0x1ul << GPIO_DBEN_DBEN15_Pos)                   /*!< GPIO_T::DBEN: DBEN15 Mask              */
+
+#define GPIO_INTTYPE_TYPE0_Pos           (0)                                               /*!< GPIO_T::INTTYPE: TYPE0 Position        */
+#define GPIO_INTTYPE_TYPE0_Msk           (0x1ul << GPIO_INTTYPE_TYPE0_Pos)                 /*!< GPIO_T::INTTYPE: TYPE0 Mask            */
+
+#define GPIO_INTTYPE_TYPE1_Pos           (1)                                               /*!< GPIO_T::INTTYPE: TYPE1 Position        */
+#define GPIO_INTTYPE_TYPE1_Msk           (0x1ul << GPIO_INTTYPE_TYPE1_Pos)                 /*!< GPIO_T::INTTYPE: TYPE1 Mask            */
+
+#define GPIO_INTTYPE_TYPE2_Pos           (2)                                               /*!< GPIO_T::INTTYPE: TYPE2 Position        */
+#define GPIO_INTTYPE_TYPE2_Msk           (0x1ul << GPIO_INTTYPE_TYPE2_Pos)                 /*!< GPIO_T::INTTYPE: TYPE2 Mask            */
+
+#define GPIO_INTTYPE_TYPE3_Pos           (3)                                               /*!< GPIO_T::INTTYPE: TYPE3 Position        */
+#define GPIO_INTTYPE_TYPE3_Msk           (0x1ul << GPIO_INTTYPE_TYPE3_Pos)                 /*!< GPIO_T::INTTYPE: TYPE3 Mask            */
+
+#define GPIO_INTTYPE_TYPE4_Pos           (4)                                               /*!< GPIO_T::INTTYPE: TYPE4 Position        */
+#define GPIO_INTTYPE_TYPE4_Msk           (0x1ul << GPIO_INTTYPE_TYPE4_Pos)                 /*!< GPIO_T::INTTYPE: TYPE4 Mask            */
+
+#define GPIO_INTTYPE_TYPE5_Pos           (5)                                               /*!< GPIO_T::INTTYPE: TYPE5 Position        */
+#define GPIO_INTTYPE_TYPE5_Msk           (0x1ul << GPIO_INTTYPE_TYPE5_Pos)                 /*!< GPIO_T::INTTYPE: TYPE5 Mask            */
+
+#define GPIO_INTTYPE_TYPE6_Pos           (6)                                               /*!< GPIO_T::INTTYPE: TYPE6 Position        */
+#define GPIO_INTTYPE_TYPE6_Msk           (0x1ul << GPIO_INTTYPE_TYPE6_Pos)                 /*!< GPIO_T::INTTYPE: TYPE6 Mask            */
+
+#define GPIO_INTTYPE_TYPE7_Pos           (7)                                               /*!< GPIO_T::INTTYPE: TYPE7 Position        */
+#define GPIO_INTTYPE_TYPE7_Msk           (0x1ul << GPIO_INTTYPE_TYPE7_Pos)                 /*!< GPIO_T::INTTYPE: TYPE7 Mask            */
+
+#define GPIO_INTTYPE_TYPE8_Pos           (8)                                               /*!< GPIO_T::INTTYPE: TYPE8 Position        */
+#define GPIO_INTTYPE_TYPE8_Msk           (0x1ul << GPIO_INTTYPE_TYPE8_Pos)                 /*!< GPIO_T::INTTYPE: TYPE8 Mask            */
+
+#define GPIO_INTTYPE_TYPE9_Pos           (9)                                               /*!< GPIO_T::INTTYPE: TYPE9 Position        */
+#define GPIO_INTTYPE_TYPE9_Msk           (0x1ul << GPIO_INTTYPE_TYPE9_Pos)                 /*!< GPIO_T::INTTYPE: TYPE9 Mask            */
+
+#define GPIO_INTTYPE_TYPE10_Pos          (10)                                              /*!< GPIO_T::INTTYPE: TYPE10 Position       */
+#define GPIO_INTTYPE_TYPE10_Msk          (0x1ul << GPIO_INTTYPE_TYPE10_Pos)                /*!< GPIO_T::INTTYPE: TYPE10 Mask           */
+
+#define GPIO_INTTYPE_TYPE11_Pos          (11)                                              /*!< GPIO_T::INTTYPE: TYPE11 Position       */
+#define GPIO_INTTYPE_TYPE11_Msk          (0x1ul << GPIO_INTTYPE_TYPE11_Pos)                /*!< GPIO_T::INTTYPE: TYPE11 Mask           */
+
+#define GPIO_INTTYPE_TYPE12_Pos          (12)                                              /*!< GPIO_T::INTTYPE: TYPE12 Position       */
+#define GPIO_INTTYPE_TYPE12_Msk          (0x1ul << GPIO_INTTYPE_TYPE12_Pos)                /*!< GPIO_T::INTTYPE: TYPE12 Mask           */
+
+#define GPIO_INTTYPE_TYPE13_Pos          (13)                                              /*!< GPIO_T::INTTYPE: TYPE13 Position       */
+#define GPIO_INTTYPE_TYPE13_Msk          (0x1ul << GPIO_INTTYPE_TYPE13_Pos)                /*!< GPIO_T::INTTYPE: TYPE13 Mask           */
+
+#define GPIO_INTTYPE_TYPE14_Pos          (14)                                              /*!< GPIO_T::INTTYPE: TYPE14 Position       */
+#define GPIO_INTTYPE_TYPE14_Msk          (0x1ul << GPIO_INTTYPE_TYPE14_Pos)                /*!< GPIO_T::INTTYPE: TYPE14 Mask           */
+
+#define GPIO_INTTYPE_TYPE15_Pos          (15)                                              /*!< GPIO_T::INTTYPE: TYPE15 Position       */
+#define GPIO_INTTYPE_TYPE15_Msk          (0x1ul << GPIO_INTTYPE_TYPE15_Pos)                /*!< GPIO_T::INTTYPE: TYPE15 Mask           */
+
+#define GPIO_INTEN_FLIEN0_Pos            (0)                                               /*!< GPIO_T::INTEN: FLIEN0 Position         */
+#define GPIO_INTEN_FLIEN0_Msk            (0x1ul << GPIO_INTEN_FLIEN0_Pos)                  /*!< GPIO_T::INTEN: FLIEN0 Mask             */
+
+#define GPIO_INTEN_FLIEN1_Pos            (1)                                               /*!< GPIO_T::INTEN: FLIEN1 Position         */
+#define GPIO_INTEN_FLIEN1_Msk            (0x1ul << GPIO_INTEN_FLIEN1_Pos)                  /*!< GPIO_T::INTEN: FLIEN1 Mask             */
+
+#define GPIO_INTEN_FLIEN2_Pos            (2)                                               /*!< GPIO_T::INTEN: FLIEN2 Position         */
+#define GPIO_INTEN_FLIEN2_Msk            (0x1ul << GPIO_INTEN_FLIEN2_Pos)                  /*!< GPIO_T::INTEN: FLIEN2 Mask             */
+
+#define GPIO_INTEN_FLIEN3_Pos            (3)                                               /*!< GPIO_T::INTEN: FLIEN3 Position         */
+#define GPIO_INTEN_FLIEN3_Msk            (0x1ul << GPIO_INTEN_FLIEN3_Pos)                  /*!< GPIO_T::INTEN: FLIEN3 Mask             */
+
+#define GPIO_INTEN_FLIEN4_Pos            (4)                                               /*!< GPIO_T::INTEN: FLIEN4 Position         */
+#define GPIO_INTEN_FLIEN4_Msk            (0x1ul << GPIO_INTEN_FLIEN4_Pos)                  /*!< GPIO_T::INTEN: FLIEN4 Mask             */
+
+#define GPIO_INTEN_FLIEN5_Pos            (5)                                               /*!< GPIO_T::INTEN: FLIEN5 Position         */
+#define GPIO_INTEN_FLIEN5_Msk            (0x1ul << GPIO_INTEN_FLIEN5_Pos)                  /*!< GPIO_T::INTEN: FLIEN5 Mask             */
+
+#define GPIO_INTEN_FLIEN6_Pos            (6)                                               /*!< GPIO_T::INTEN: FLIEN6 Position         */
+#define GPIO_INTEN_FLIEN6_Msk            (0x1ul << GPIO_INTEN_FLIEN6_Pos)                  /*!< GPIO_T::INTEN: FLIEN6 Mask             */
+
+#define GPIO_INTEN_FLIEN7_Pos            (7)                                               /*!< GPIO_T::INTEN: FLIEN7 Position         */
+#define GPIO_INTEN_FLIEN7_Msk            (0x1ul << GPIO_INTEN_FLIEN7_Pos)                  /*!< GPIO_T::INTEN: FLIEN7 Mask             */
+
+#define GPIO_INTEN_FLIEN8_Pos            (8)                                               /*!< GPIO_T::INTEN: FLIEN8 Position         */
+#define GPIO_INTEN_FLIEN8_Msk            (0x1ul << GPIO_INTEN_FLIEN8_Pos)                  /*!< GPIO_T::INTEN: FLIEN8 Mask             */
+
+#define GPIO_INTEN_FLIEN9_Pos            (9)                                               /*!< GPIO_T::INTEN: FLIEN9 Position         */
+#define GPIO_INTEN_FLIEN9_Msk            (0x1ul << GPIO_INTEN_FLIEN9_Pos)                  /*!< GPIO_T::INTEN: FLIEN9 Mask             */
+
+#define GPIO_INTEN_FLIEN10_Pos           (10)                                              /*!< GPIO_T::INTEN: FLIEN10 Position        */
+#define GPIO_INTEN_FLIEN10_Msk           (0x1ul << GPIO_INTEN_FLIEN10_Pos)                 /*!< GPIO_T::INTEN: FLIEN10 Mask            */
+
+#define GPIO_INTEN_FLIEN11_Pos           (11)                                              /*!< GPIO_T::INTEN: FLIEN11 Position        */
+#define GPIO_INTEN_FLIEN11_Msk           (0x1ul << GPIO_INTEN_FLIEN11_Pos)                 /*!< GPIO_T::INTEN: FLIEN11 Mask            */
+
+#define GPIO_INTEN_FLIEN12_Pos           (12)                                              /*!< GPIO_T::INTEN: FLIEN12 Position        */
+#define GPIO_INTEN_FLIEN12_Msk           (0x1ul << GPIO_INTEN_FLIEN12_Pos)                 /*!< GPIO_T::INTEN: FLIEN12 Mask            */
+
+#define GPIO_INTEN_FLIEN13_Pos           (13)                                              /*!< GPIO_T::INTEN: FLIEN13 Position        */
+#define GPIO_INTEN_FLIEN13_Msk           (0x1ul << GPIO_INTEN_FLIEN13_Pos)                 /*!< GPIO_T::INTEN: FLIEN13 Mask            */
+
+#define GPIO_INTEN_FLIEN14_Pos           (14)                                              /*!< GPIO_T::INTEN: FLIEN14 Position        */
+#define GPIO_INTEN_FLIEN14_Msk           (0x1ul << GPIO_INTEN_FLIEN14_Pos)                 /*!< GPIO_T::INTEN: FLIEN14 Mask            */
+
+#define GPIO_INTEN_FLIEN15_Pos           (15)                                              /*!< GPIO_T::INTEN: FLIEN15 Position        */
+#define GPIO_INTEN_FLIEN15_Msk           (0x1ul << GPIO_INTEN_FLIEN15_Pos)                 /*!< GPIO_T::INTEN: FLIEN15 Mask            */
+
+#define GPIO_INTEN_RHIEN0_Pos            (16)                                              /*!< GPIO_T::INTEN: RHIEN0 Position         */
+#define GPIO_INTEN_RHIEN0_Msk            (0x1ul << GPIO_INTEN_RHIEN0_Pos)                  /*!< GPIO_T::INTEN: RHIEN0 Mask             */
+
+#define GPIO_INTEN_RHIEN1_Pos            (17)                                              /*!< GPIO_T::INTEN: RHIEN1 Position         */
+#define GPIO_INTEN_RHIEN1_Msk            (0x1ul << GPIO_INTEN_RHIEN1_Pos)                  /*!< GPIO_T::INTEN: RHIEN1 Mask             */
+
+#define GPIO_INTEN_RHIEN2_Pos            (18)                                              /*!< GPIO_T::INTEN: RHIEN2 Position         */
+#define GPIO_INTEN_RHIEN2_Msk            (0x1ul << GPIO_INTEN_RHIEN2_Pos)                  /*!< GPIO_T::INTEN: RHIEN2 Mask             */
+
+#define GPIO_INTEN_RHIEN3_Pos            (19)                                              /*!< GPIO_T::INTEN: RHIEN3 Position         */
+#define GPIO_INTEN_RHIEN3_Msk            (0x1ul << GPIO_INTEN_RHIEN3_Pos)                  /*!< GPIO_T::INTEN: RHIEN3 Mask             */
+
+#define GPIO_INTEN_RHIEN4_Pos            (20)                                              /*!< GPIO_T::INTEN: RHIEN4 Position         */
+#define GPIO_INTEN_RHIEN4_Msk            (0x1ul << GPIO_INTEN_RHIEN4_Pos)                  /*!< GPIO_T::INTEN: RHIEN4 Mask             */
+
+#define GPIO_INTEN_RHIEN5_Pos            (21)                                              /*!< GPIO_T::INTEN: RHIEN5 Position         */
+#define GPIO_INTEN_RHIEN5_Msk            (0x1ul << GPIO_INTEN_RHIEN5_Pos)                  /*!< GPIO_T::INTEN: RHIEN5 Mask             */
+
+#define GPIO_INTEN_RHIEN6_Pos            (22)                                              /*!< GPIO_T::INTEN: RHIEN6 Position         */
+#define GPIO_INTEN_RHIEN6_Msk            (0x1ul << GPIO_INTEN_RHIEN6_Pos)                  /*!< GPIO_T::INTEN: RHIEN6 Mask             */
+
+#define GPIO_INTEN_RHIEN7_Pos            (23)                                              /*!< GPIO_T::INTEN: RHIEN7 Position         */
+#define GPIO_INTEN_RHIEN7_Msk            (0x1ul << GPIO_INTEN_RHIEN7_Pos)                  /*!< GPIO_T::INTEN: RHIEN7 Mask             */
+
+#define GPIO_INTEN_RHIEN8_Pos            (24)                                              /*!< GPIO_T::INTEN: RHIEN8 Position         */
+#define GPIO_INTEN_RHIEN8_Msk            (0x1ul << GPIO_INTEN_RHIEN8_Pos)                  /*!< GPIO_T::INTEN: RHIEN8 Mask             */
+
+#define GPIO_INTEN_RHIEN9_Pos            (25)                                              /*!< GPIO_T::INTEN: RHIEN9 Position         */
+#define GPIO_INTEN_RHIEN9_Msk            (0x1ul << GPIO_INTEN_RHIEN9_Pos)                  /*!< GPIO_T::INTEN: RHIEN9 Mask             */
+
+#define GPIO_INTEN_RHIEN10_Pos           (26)                                              /*!< GPIO_T::INTEN: RHIEN10 Position        */
+#define GPIO_INTEN_RHIEN10_Msk           (0x1ul << GPIO_INTEN_RHIEN10_Pos)                 /*!< GPIO_T::INTEN: RHIEN10 Mask            */
+
+#define GPIO_INTEN_RHIEN11_Pos           (27)                                              /*!< GPIO_T::INTEN: RHIEN11 Position        */
+#define GPIO_INTEN_RHIEN11_Msk           (0x1ul << GPIO_INTEN_RHIEN11_Pos)                 /*!< GPIO_T::INTEN: RHIEN11 Mask            */
+
+#define GPIO_INTEN_RHIEN12_Pos           (28)                                              /*!< GPIO_T::INTEN: RHIEN12 Position        */
+#define GPIO_INTEN_RHIEN12_Msk           (0x1ul << GPIO_INTEN_RHIEN12_Pos)                 /*!< GPIO_T::INTEN: RHIEN12 Mask            */
+
+#define GPIO_INTEN_RHIEN13_Pos           (29)                                              /*!< GPIO_T::INTEN: RHIEN13 Position        */
+#define GPIO_INTEN_RHIEN13_Msk           (0x1ul << GPIO_INTEN_RHIEN13_Pos)                 /*!< GPIO_T::INTEN: RHIEN13 Mask            */
+
+#define GPIO_INTEN_RHIEN14_Pos           (30)                                              /*!< GPIO_T::INTEN: RHIEN14 Position        */
+#define GPIO_INTEN_RHIEN14_Msk           (0x1ul << GPIO_INTEN_RHIEN14_Pos)                 /*!< GPIO_T::INTEN: RHIEN14 Mask            */
+
+#define GPIO_INTEN_RHIEN15_Pos           (31)                                              /*!< GPIO_T::INTEN: RHIEN15 Position        */
+#define GPIO_INTEN_RHIEN15_Msk           (0x1ul << GPIO_INTEN_RHIEN15_Pos)                 /*!< GPIO_T::INTEN: RHIEN15 Mask            */
+
+#define GPIO_INTSRC_INTSRC0_Pos          (0)                                               /*!< GPIO_T::INTSRC: INTSRC0 Position       */
+#define GPIO_INTSRC_INTSRC0_Msk          (0x1ul << GPIO_INTSRC_INTSRC0_Pos)                /*!< GPIO_T::INTSRC: INTSRC0 Mask           */
+
+#define GPIO_INTSRC_INTSRC1_Pos          (1)                                               /*!< GPIO_T::INTSRC: INTSRC1 Position       */
+#define GPIO_INTSRC_INTSRC1_Msk          (0x1ul << GPIO_INTSRC_INTSRC1_Pos)                /*!< GPIO_T::INTSRC: INTSRC1 Mask           */
+
+#define GPIO_INTSRC_INTSRC2_Pos          (2)                                               /*!< GPIO_T::INTSRC: INTSRC2 Position       */
+#define GPIO_INTSRC_INTSRC2_Msk          (0x1ul << GPIO_INTSRC_INTSRC2_Pos)                /*!< GPIO_T::INTSRC: INTSRC2 Mask           */
+
+#define GPIO_INTSRC_INTSRC3_Pos          (3)                                               /*!< GPIO_T::INTSRC: INTSRC3 Position       */
+#define GPIO_INTSRC_INTSRC3_Msk          (0x1ul << GPIO_INTSRC_INTSRC3_Pos)                /*!< GPIO_T::INTSRC: INTSRC3 Mask           */
+
+#define GPIO_INTSRC_INTSRC4_Pos          (4)                                               /*!< GPIO_T::INTSRC: INTSRC4 Position       */
+#define GPIO_INTSRC_INTSRC4_Msk          (0x1ul << GPIO_INTSRC_INTSRC4_Pos)                /*!< GPIO_T::INTSRC: INTSRC4 Mask           */
+
+#define GPIO_INTSRC_INTSRC5_Pos          (5)                                               /*!< GPIO_T::INTSRC: INTSRC5 Position       */
+#define GPIO_INTSRC_INTSRC5_Msk          (0x1ul << GPIO_INTSRC_INTSRC5_Pos)                /*!< GPIO_T::INTSRC: INTSRC5 Mask           */
+
+#define GPIO_INTSRC_INTSRC6_Pos          (6)                                               /*!< GPIO_T::INTSRC: INTSRC6 Position       */
+#define GPIO_INTSRC_INTSRC6_Msk          (0x1ul << GPIO_INTSRC_INTSRC6_Pos)                /*!< GPIO_T::INTSRC: INTSRC6 Mask           */
+
+#define GPIO_INTSRC_INTSRC7_Pos          (7)                                               /*!< GPIO_T::INTSRC: INTSRC7 Position       */
+#define GPIO_INTSRC_INTSRC7_Msk          (0x1ul << GPIO_INTSRC_INTSRC7_Pos)                /*!< GPIO_T::INTSRC: INTSRC7 Mask           */
+
+#define GPIO_INTSRC_INTSRC8_Pos          (8)                                               /*!< GPIO_T::INTSRC: INTSRC8 Position       */
+#define GPIO_INTSRC_INTSRC8_Msk          (0x1ul << GPIO_INTSRC_INTSRC8_Pos)                /*!< GPIO_T::INTSRC: INTSRC8 Mask           */
+
+#define GPIO_INTSRC_INTSRC9_Pos          (9)                                               /*!< GPIO_T::INTSRC: INTSRC9 Position       */
+#define GPIO_INTSRC_INTSRC9_Msk          (0x1ul << GPIO_INTSRC_INTSRC9_Pos)                /*!< GPIO_T::INTSRC: INTSRC9 Mask           */
+
+#define GPIO_INTSRC_INTSRC10_Pos         (10)                                              /*!< GPIO_T::INTSRC: INTSRC10 Position      */
+#define GPIO_INTSRC_INTSRC10_Msk         (0x1ul << GPIO_INTSRC_INTSRC10_Pos)               /*!< GPIO_T::INTSRC: INTSRC10 Mask          */
+
+#define GPIO_INTSRC_INTSRC11_Pos         (11)                                              /*!< GPIO_T::INTSRC: INTSRC11 Position      */
+#define GPIO_INTSRC_INTSRC11_Msk         (0x1ul << GPIO_INTSRC_INTSRC11_Pos)               /*!< GPIO_T::INTSRC: INTSRC11 Mask          */
+
+#define GPIO_INTSRC_INTSRC12_Pos         (12)                                              /*!< GPIO_T::INTSRC: INTSRC12 Position      */
+#define GPIO_INTSRC_INTSRC12_Msk         (0x1ul << GPIO_INTSRC_INTSRC12_Pos)               /*!< GPIO_T::INTSRC: INTSRC12 Mask          */
+
+#define GPIO_INTSRC_INTSRC13_Pos         (13)                                              /*!< GPIO_T::INTSRC: INTSRC13 Position      */
+#define GPIO_INTSRC_INTSRC13_Msk         (0x1ul << GPIO_INTSRC_INTSRC13_Pos)               /*!< GPIO_T::INTSRC: INTSRC13 Mask          */
+
+#define GPIO_INTSRC_INTSRC14_Pos         (14)                                              /*!< GPIO_T::INTSRC: INTSRC14 Position      */
+#define GPIO_INTSRC_INTSRC14_Msk         (0x1ul << GPIO_INTSRC_INTSRC14_Pos)               /*!< GPIO_T::INTSRC: INTSRC14 Mask          */
+
+#define GPIO_INTSRC_INTSRC15_Pos         (15)                                              /*!< GPIO_T::INTSRC: INTSRC15 Position      */
+#define GPIO_INTSRC_INTSRC15_Msk         (0x1ul << GPIO_INTSRC_INTSRC15_Pos)               /*!< GPIO_T::INTSRC: INTSRC15 Mask          */
+
+#define GPIO_SMTEN_SMTEN0_Pos            (0)                                               /*!< GPIO_T::SMTEN: SMTEN0 Position         */
+#define GPIO_SMTEN_SMTEN0_Msk            (0x1ul << GPIO_SMTEN_SMTEN0_Pos)                  /*!< GPIO_T::SMTEN: SMTEN0 Mask             */
+
+#define GPIO_SMTEN_SMTEN1_Pos            (1)                                               /*!< GPIO_T::SMTEN: SMTEN1 Position         */
+#define GPIO_SMTEN_SMTEN1_Msk            (0x1ul << GPIO_SMTEN_SMTEN1_Pos)                  /*!< GPIO_T::SMTEN: SMTEN1 Mask             */
+
+#define GPIO_SMTEN_SMTEN2_Pos            (2)                                               /*!< GPIO_T::SMTEN: SMTEN2 Position         */
+#define GPIO_SMTEN_SMTEN2_Msk            (0x1ul << GPIO_SMTEN_SMTEN2_Pos)                  /*!< GPIO_T::SMTEN: SMTEN2 Mask             */
+
+#define GPIO_SMTEN_SMTEN3_Pos            (3)                                               /*!< GPIO_T::SMTEN: SMTEN3 Position         */
+#define GPIO_SMTEN_SMTEN3_Msk            (0x1ul << GPIO_SMTEN_SMTEN3_Pos)                  /*!< GPIO_T::SMTEN: SMTEN3 Mask             */
+
+#define GPIO_SMTEN_SMTEN4_Pos            (4)                                               /*!< GPIO_T::SMTEN: SMTEN4 Position         */
+#define GPIO_SMTEN_SMTEN4_Msk            (0x1ul << GPIO_SMTEN_SMTEN4_Pos)                  /*!< GPIO_T::SMTEN: SMTEN4 Mask             */
+
+#define GPIO_SMTEN_SMTEN5_Pos            (5)                                               /*!< GPIO_T::SMTEN: SMTEN5 Position         */
+#define GPIO_SMTEN_SMTEN5_Msk            (0x1ul << GPIO_SMTEN_SMTEN5_Pos)                  /*!< GPIO_T::SMTEN: SMTEN5 Mask             */
+
+#define GPIO_SMTEN_SMTEN6_Pos            (6)                                               /*!< GPIO_T::SMTEN: SMTEN6 Position         */
+#define GPIO_SMTEN_SMTEN6_Msk            (0x1ul << GPIO_SMTEN_SMTEN6_Pos)                  /*!< GPIO_T::SMTEN: SMTEN6 Mask             */
+
+#define GPIO_SMTEN_SMTEN7_Pos            (7)                                               /*!< GPIO_T::SMTEN: SMTEN7 Position         */
+#define GPIO_SMTEN_SMTEN7_Msk            (0x1ul << GPIO_SMTEN_SMTEN7_Pos)                  /*!< GPIO_T::SMTEN: SMTEN7 Mask             */
+
+#define GPIO_SMTEN_SMTEN8_Pos            (8)                                               /*!< GPIO_T::SMTEN: SMTEN8 Position         */
+#define GPIO_SMTEN_SMTEN8_Msk            (0x1ul << GPIO_SMTEN_SMTEN8_Pos)                  /*!< GPIO_T::SMTEN: SMTEN8 Mask             */
+
+#define GPIO_SMTEN_SMTEN9_Pos            (9)                                               /*!< GPIO_T::SMTEN: SMTEN9 Position         */
+#define GPIO_SMTEN_SMTEN9_Msk            (0x1ul << GPIO_SMTEN_SMTEN9_Pos)                  /*!< GPIO_T::SMTEN: SMTEN9 Mask             */
+
+#define GPIO_SMTEN_SMTEN10_Pos           (10)                                              /*!< GPIO_T::SMTEN: SMTEN10 Position        */
+#define GPIO_SMTEN_SMTEN10_Msk           (0x1ul << GPIO_SMTEN_SMTEN10_Pos)                 /*!< GPIO_T::SMTEN: SMTEN10 Mask            */
+
+#define GPIO_SMTEN_SMTEN11_Pos           (11)                                              /*!< GPIO_T::SMTEN: SMTEN11 Position        */
+#define GPIO_SMTEN_SMTEN11_Msk           (0x1ul << GPIO_SMTEN_SMTEN11_Pos)                 /*!< GPIO_T::SMTEN: SMTEN11 Mask            */
+
+#define GPIO_SMTEN_SMTEN12_Pos           (12)                                              /*!< GPIO_T::SMTEN: SMTEN12 Position        */
+#define GPIO_SMTEN_SMTEN12_Msk           (0x1ul << GPIO_SMTEN_SMTEN12_Pos)                 /*!< GPIO_T::SMTEN: SMTEN12 Mask            */
+
+#define GPIO_SMTEN_SMTEN13_Pos           (13)                                              /*!< GPIO_T::SMTEN: SMTEN13 Position        */
+#define GPIO_SMTEN_SMTEN13_Msk           (0x1ul << GPIO_SMTEN_SMTEN13_Pos)                 /*!< GPIO_T::SMTEN: SMTEN13 Mask            */
+
+#define GPIO_SMTEN_SMTEN14_Pos           (14)                                              /*!< GPIO_T::SMTEN: SMTEN14 Position        */
+#define GPIO_SMTEN_SMTEN14_Msk           (0x1ul << GPIO_SMTEN_SMTEN14_Pos)                 /*!< GPIO_T::SMTEN: SMTEN14 Mask            */
+
+#define GPIO_SMTEN_SMTEN15_Pos           (15)                                              /*!< GPIO_T::SMTEN: SMTEN15 Position        */
+#define GPIO_SMTEN_SMTEN15_Msk           (0x1ul << GPIO_SMTEN_SMTEN15_Pos)                 /*!< GPIO_T::SMTEN: SMTEN15 Mask            */
+
+#define GPIO_SLEWCTL_HSREN0_Pos          (0)                                               /*!< GPIO_T::SLEWCTL: HSREN0 Position       */
+#define GPIO_SLEWCTL_HSREN0_Msk          (0x3ul << GPIO_SLEWCTL_HSREN0_Pos)                /*!< GPIO_T::SLEWCTL: HSREN0 Mask           */
+
+#define GPIO_SLEWCTL_HSREN1_Pos          (2)                                               /*!< GPIO_T::SLEWCTL: HSREN1 Position       */
+#define GPIO_SLEWCTL_HSREN1_Msk          (0x3ul << GPIO_SLEWCTL_HSREN1_Pos)                /*!< GPIO_T::SLEWCTL: HSREN1 Mask           */
+
+#define GPIO_SLEWCTL_HSREN2_Pos          (4)                                               /*!< GPIO_T::SLEWCTL: HSREN2 Position       */
+#define GPIO_SLEWCTL_HSREN2_Msk          (0x3ul << GPIO_SLEWCTL_HSREN2_Pos)                /*!< GPIO_T::SLEWCTL: HSREN2 Mask           */
+
+#define GPIO_SLEWCTL_HSREN3_Pos          (6)                                               /*!< GPIO_T::SLEWCTL: HSREN3 Position       */
+#define GPIO_SLEWCTL_HSREN3_Msk          (0x3ul << GPIO_SLEWCTL_HSREN3_Pos)                /*!< GPIO_T::SLEWCTL: HSREN3 Mask           */
+
+#define GPIO_SLEWCTL_HSREN4_Pos          (8)                                               /*!< GPIO_T::SLEWCTL: HSREN4 Position       */
+#define GPIO_SLEWCTL_HSREN4_Msk          (0x3ul << GPIO_SLEWCTL_HSREN4_Pos)                /*!< GPIO_T::SLEWCTL: HSREN4 Mask           */
+
+#define GPIO_SLEWCTL_HSREN5_Pos          (10)                                              /*!< GPIO_T::SLEWCTL: HSREN5 Position       */
+#define GPIO_SLEWCTL_HSREN5_Msk          (0x3ul << GPIO_SLEWCTL_HSREN5_Pos)                /*!< GPIO_T::SLEWCTL: HSREN5 Mask           */
+
+#define GPIO_SLEWCTL_HSREN6_Pos          (12)                                              /*!< GPIO_T::SLEWCTL: HSREN6 Position       */
+#define GPIO_SLEWCTL_HSREN6_Msk          (0x3ul << GPIO_SLEWCTL_HSREN6_Pos)                /*!< GPIO_T::SLEWCTL: HSREN6 Mask           */
+
+#define GPIO_SLEWCTL_HSREN7_Pos          (14)                                              /*!< GPIO_T::SLEWCTL: HSREN7 Position       */
+#define GPIO_SLEWCTL_HSREN7_Msk          (0x3ul << GPIO_SLEWCTL_HSREN7_Pos)                /*!< GPIO_T::SLEWCTL: HSREN7 Mask           */
+
+#define GPIO_SLEWCTL_HSREN8_Pos          (16)                                              /*!< GPIO_T::SLEWCTL: HSREN8 Position       */
+#define GPIO_SLEWCTL_HSREN8_Msk          (0x3ul << GPIO_SLEWCTL_HSREN8_Pos)                /*!< GPIO_T::SLEWCTL: HSREN8 Mask           */
+
+#define GPIO_SLEWCTL_HSREN9_Pos          (18)                                              /*!< GPIO_T::SLEWCTL: HSREN9 Position       */
+#define GPIO_SLEWCTL_HSREN9_Msk          (0x3ul << GPIO_SLEWCTL_HSREN9_Pos)                /*!< GPIO_T::SLEWCTL: HSREN9 Mask           */
+
+#define GPIO_SLEWCTL_HSREN10_Pos         (20)                                              /*!< GPIO_T::SLEWCTL: HSREN10 Position      */
+#define GPIO_SLEWCTL_HSREN10_Msk         (0x3ul << GPIO_SLEWCTL_HSREN10_Pos)               /*!< GPIO_T::SLEWCTL: HSREN10 Mask          */
+
+#define GPIO_SLEWCTL_HSREN11_Pos         (22)                                              /*!< GPIO_T::SLEWCTL: HSREN11 Position      */
+#define GPIO_SLEWCTL_HSREN11_Msk         (0x3ul << GPIO_SLEWCTL_HSREN11_Pos)               /*!< GPIO_T::SLEWCTL: HSREN11 Mask          */
+
+#define GPIO_SLEWCTL_HSREN12_Pos         (24)                                              /*!< GPIO_T::SLEWCTL: HSREN12 Position      */
+#define GPIO_SLEWCTL_HSREN12_Msk         (0x3ul << GPIO_SLEWCTL_HSREN12_Pos)               /*!< GPIO_T::SLEWCTL: HSREN12 Mask          */
+
+#define GPIO_SLEWCTL_HSREN13_Pos         (26)                                              /*!< GPIO_T::SLEWCTL: HSREN13 Position      */
+#define GPIO_SLEWCTL_HSREN13_Msk         (0x3ul << GPIO_SLEWCTL_HSREN13_Pos)               /*!< GPIO_T::SLEWCTL: HSREN13 Mask          */
+
+#define GPIO_SLEWCTL_HSREN14_Pos         (28)                                              /*!< GPIO_T::SLEWCTL: HSREN14 Position      */
+#define GPIO_SLEWCTL_HSREN14_Msk         (0x3ul << GPIO_SLEWCTL_HSREN14_Pos)               /*!< GPIO_T::SLEWCTL: HSREN14 Mask          */
+
+#define GPIO_SLEWCTL_HSREN15_Pos         (30)                                              /*!< GPIO_T::SLEWCTL: HSREN15 Position      */
+#define GPIO_SLEWCTL_HSREN15_Msk         (0x3ul << GPIO_SLEWCTL_HSREN15_Pos)               /*!< GPIO_T::SLEWCTL: HSREN15 Mask          */
+
+#define GPIO_PUSEL_PUSEL0_Pos            (0)                                               /*!< GPIO_T::PUSEL: PUSEL0 Position         */
+#define GPIO_PUSEL_PUSEL0_Msk            (0x3ul << GPIO_PUSEL_PUSEL0_Pos)                  /*!< GPIO_T::PUSEL: PUSEL0 Mask             */
+
+#define GPIO_PUSEL_PUSEL1_Pos            (2)                                               /*!< GPIO_T::PUSEL: PUSEL1 Position         */
+#define GPIO_PUSEL_PUSEL1_Msk            (0x3ul << GPIO_PUSEL_PUSEL1_Pos)                  /*!< GPIO_T::PUSEL: PUSEL1 Mask             */
+
+#define GPIO_PUSEL_PUSEL2_Pos            (4)                                               /*!< GPIO_T::PUSEL: PUSEL2 Position         */
+#define GPIO_PUSEL_PUSEL2_Msk            (0x3ul << GPIO_PUSEL_PUSEL2_Pos)                  /*!< GPIO_T::PUSEL: PUSEL2 Mask             */
+
+#define GPIO_PUSEL_PUSEL3_Pos            (6)                                               /*!< GPIO_T::PUSEL: PUSEL3 Position         */
+#define GPIO_PUSEL_PUSEL3_Msk            (0x3ul << GPIO_PUSEL_PUSEL3_Pos)                  /*!< GPIO_T::PUSEL: PUSEL3 Mask             */
+
+#define GPIO_PUSEL_PUSEL4_Pos            (8)                                               /*!< GPIO_T::PUSEL: PUSEL4 Position         */
+#define GPIO_PUSEL_PUSEL4_Msk            (0x3ul << GPIO_PUSEL_PUSEL4_Pos)                  /*!< GPIO_T::PUSEL: PUSEL4 Mask             */
+
+#define GPIO_PUSEL_PUSEL5_Pos            (10)                                              /*!< GPIO_T::PUSEL: PUSEL5 Position         */
+#define GPIO_PUSEL_PUSEL5_Msk            (0x3ul << GPIO_PUSEL_PUSEL5_Pos)                  /*!< GPIO_T::PUSEL: PUSEL5 Mask             */
+
+#define GPIO_PUSEL_PUSEL6_Pos            (12)                                              /*!< GPIO_T::PUSEL: PUSEL6 Position         */
+#define GPIO_PUSEL_PUSEL6_Msk            (0x3ul << GPIO_PUSEL_PUSEL6_Pos)                  /*!< GPIO_T::PUSEL: PUSEL6 Mask             */
+
+#define GPIO_PUSEL_PUSEL7_Pos            (14)                                              /*!< GPIO_T::PUSEL: PUSEL7 Position         */
+#define GPIO_PUSEL_PUSEL7_Msk            (0x3ul << GPIO_PUSEL_PUSEL7_Pos)                  /*!< GPIO_T::PUSEL: PUSEL7 Mask             */
+
+#define GPIO_PUSEL_PUSEL8_Pos            (16)                                              /*!< GPIO_T::PUSEL: PUSEL8 Position         */
+#define GPIO_PUSEL_PUSEL8_Msk            (0x3ul << GPIO_PUSEL_PUSEL8_Pos)                  /*!< GPIO_T::PUSEL: PUSEL8 Mask             */
+
+#define GPIO_PUSEL_PUSEL9_Pos            (18)                                              /*!< GPIO_T::PUSEL: PUSEL9 Position         */
+#define GPIO_PUSEL_PUSEL9_Msk            (0x3ul << GPIO_PUSEL_PUSEL9_Pos)                  /*!< GPIO_T::PUSEL: PUSEL9 Mask             */
+
+#define GPIO_PUSEL_PUSEL10_Pos           (20)                                              /*!< GPIO_T::PUSEL: PUSEL10 Position        */
+#define GPIO_PUSEL_PUSEL10_Msk           (0x3ul << GPIO_PUSEL_PUSEL10_Pos)                 /*!< GPIO_T::PUSEL: PUSEL10 Mask            */
+
+#define GPIO_PUSEL_PUSEL11_Pos           (22)                                              /*!< GPIO_T::PUSEL: PUSEL11 Position        */
+#define GPIO_PUSEL_PUSEL11_Msk           (0x3ul << GPIO_PUSEL_PUSEL11_Pos)                 /*!< GPIO_T::PUSEL: PUSEL11 Mask            */
+
+#define GPIO_PUSEL_PUSEL12_Pos           (24)                                              /*!< GPIO_T::PUSEL: PUSEL12 Position        */
+#define GPIO_PUSEL_PUSEL12_Msk           (0x3ul << GPIO_PUSEL_PUSEL12_Pos)                 /*!< GPIO_T::PUSEL: PUSEL12 Mask            */
+
+#define GPIO_PUSEL_PUSEL13_Pos           (26)                                              /*!< GPIO_T::PUSEL: PUSEL13 Position        */
+#define GPIO_PUSEL_PUSEL13_Msk           (0x3ul << GPIO_PUSEL_PUSEL13_Pos)                 /*!< GPIO_T::PUSEL: PUSEL13 Mask            */
+
+#define GPIO_PUSEL_PUSEL14_Pos           (28)                                              /*!< GPIO_T::PUSEL: PUSEL14 Position        */
+#define GPIO_PUSEL_PUSEL14_Msk           (0x3ul << GPIO_PUSEL_PUSEL14_Pos)                 /*!< GPIO_T::PUSEL: PUSEL14 Mask            */
+
+#define GPIO_PUSEL_PUSEL15_Pos           (30)                                              /*!< GPIO_T::PUSEL: PUSEL15 Position        */
+#define GPIO_PUSEL_PUSEL15_Msk           (0x3ul << GPIO_PUSEL_PUSEL15_Pos)                 /*!< GPIO_T::PUSEL: PUSEL15 Mask            */
+
+#define GPIO_DBCTL_DBCLKSEL_Pos          (0)                                               /*!< GPIO_T::DBCTL: DBCLKSEL Position       */
+#define GPIO_DBCTL_DBCLKSEL_Msk          (0xful << GPIO_DBCTL_DBCLKSEL_Pos)                /*!< GPIO_T::DBCTL: DBCLKSEL Mask           */
+
+#define GPIO_DBCTL_DBCLKSRC_Pos          (4)                                               /*!< GPIO_T::DBCTL: DBCLKSRC Position       */
+#define GPIO_DBCTL_DBCLKSRC_Msk          (0x1ul << GPIO_DBCTL_DBCLKSRC_Pos)                /*!< GPIO_T::DBCTL: DBCLKSRC Mask           */
+
+#define GPIO_DBCTL_ICLKONA_Pos          (16)                                               /*!< GPIO_T::DBCTL: ICLKONA Position        */
+#define GPIO_DBCTL_ICLKONA_Msk          (0x1ul << GPIO_DBCTL_ICLKONA_Pos)                  /*!< GPIO_T::DBCTL: ICLKONA Mask            */
+
+#define GPIO_DBCTL_ICLKONB_Pos          (17)                                               /*!< GPIO_T::DBCTL: ICLKONB Position        */
+#define GPIO_DBCTL_ICLKONB_Msk          (0x1ul << GPIO_DBCTL_ICLKONB_Pos)                  /*!< GPIO_T::DBCTL: ICLKONB Mask            */
+
+#define GPIO_DBCTL_ICLKONC_Pos          (18)                                               /*!< GPIO_T::DBCTL: ICLKONC Position        */
+#define GPIO_DBCTL_ICLKONC_Msk          (0x1ul << GPIO_DBCTL_ICLKONC_Pos)                  /*!< GPIO_T::DBCTL: ICLKONC Mask            */
+
+#define GPIO_DBCTL_ICLKOND_Pos          (19)                                               /*!< GPIO_T::DBCTL: ICLKOND Position        */
+#define GPIO_DBCTL_ICLKOND_Msk          (0x1ul << GPIO_DBCTL_ICLKOND_Pos)                  /*!< GPIO_T::DBCTL: ICLKOND Mask            */
+
+#define GPIO_DBCTL_ICLKONE_Pos          (20)                                               /*!< GPIO_T::DBCTL: ICLKONE Position        */
+#define GPIO_DBCTL_ICLKONE_Msk          (0x1ul << GPIO_DBCTL_ICLKONE_Pos)                  /*!< GPIO_T::DBCTL: ICLKONE Mask            */
+
+#define GPIO_DBCTL_ICLKONF_Pos          (21)                                               /*!< GPIO_T::DBCTL: ICLKONF Position        */
+#define GPIO_DBCTL_ICLKONF_Msk          (0x1ul << GPIO_DBCTL_ICLKONF_Pos)                  /*!< GPIO_T::DBCTL: ICLKONF Mask            */
+
+
+/** @} GPIO_CONST */
+/** @} end of GPIO register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __GPIO_REG_H__ */

--- a/hal/m258ke/nuvoton/i2c_reg.h
+++ b/hal/m258ke/nuvoton/i2c_reg.h
@@ -1,0 +1,719 @@
+/**************************************************************************//**
+ * @file     i2c_reg.h
+ * @version  V1.00
+ * @brief    I2C register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __I2C_REG_H__
+#define __I2C_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/*---------------------- Inter-IC Bus Controller -------------------------*/
+/**
+    @addtogroup I2C Inter-IC Bus Controller (I2C)
+    Memory Mapped Structure for I2C Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var I2C_T::CTL0
+     * Offset: 0x00  I2C Control Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2]     |AA        |Assert Acknowledge Control
+     * |        |          |When AA =1 prior to address or data is received, an acknowledged (low level to SDA) will be returned during the acknowledge clock pulse on the SCL line when 1.) A slave is acknowledging the address sent from master, 2.) The receiver devices are acknowledging the data sent by transmitter
+     * |        |          |When AA=0 prior to address or data received, a Not acknowledged (high level to SDA) will be returned during the acknowledge clock pulse on the SCL line
+     * |[3]     |SI        |I2C Interrupt Flag
+     * |        |          |When a new I2C state is present in the I2C_STATUS0 register, the SI flag is set by hardware
+     * |        |          |If bit INTEN (I2C_CTL0 [7]) is set, the I2C interrupt is requested
+     * |        |          |SI must be cleared by software.
+     * |        |          |Clear SI by writing 1 to this bit.
+     * |        |          |For ACKMEN is set in slave read mode, the SI flag is set in 8th clock period for user to confirm the acknowledge bit and 9th clock period for user to read the data in the data buffer.
+     * |[4]     |STO       |I2C STOP Control
+     * |        |          |In Master mode, setting STO to transmit a STOP condition to bus then I2C controller will check the bus condition if a STOP condition is detected
+     * |        |          |This bit will be cleared by hardware automatically.
+     * |[5]     |STA       |I2C START Control
+     * |        |          |Setting STA to logic 1 to enter Master mode, the I2C hardware sends a START or repeat START condition to bus when the bus is free.
+     * |[6]     |I2CEN     |I2C Controller Enable Bit
+     * |        |          |Set to enable I2C serial function controller
+     * |        |          |When I2CEN=1 the I2C serial function enable
+     * |        |          |The multi-function pin function must set to SDA, and SCL of I2C function first.
+     * |        |          |0 = I2C controller Disabled.
+     * |        |          |1 = I2C controller Enabled.
+     * |[7]     |INTEN     |Enable Interrupt
+     * |        |          |0 = I2C interrupt Disabled.
+     * |        |          |1 = I2C interrupt Enabled.
+     * @var I2C_T::DAT
+     * Offset: 0x08  I2C Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DAT       |I2C Data
+     * |        |          |Bit [7:0] is located with the 8-bit transferred/received data of I2C serial port.
+     * @var I2C_T::STATUS0
+     * Offset: 0x0C  I2C Status Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |STATUS    |I2C Status
+     * |        |          |The three least significant bits are always 0
+     * |        |          |The five most significant bits contain the status code
+     * |        |          |There are 28 possible status codes
+     * |        |          |When the content of I2C_STATUS0 is F8H, no serial interrupt is requested
+     * |        |          |Others I2C_STATUS0 values correspond to defined I2C states
+     * |        |          |When each of these states is entered, a status interrupt is requested (SI = 1)
+     * |        |          |A valid status code is present in I2C_STATUS0 one cycle after SI is set by hardware and is still present one cycle after SI has been reset by software
+     * |        |          |In addition, states 00H stands for a Bus Error
+     * |        |          |A Bus Error occurs when a START or STOP condition is present at an illegal position in the formation frame
+     * |        |          |Example of illegal position are during the serial transfer of an address byte, a data byte or an acknowledge bit.
+     * @var I2C_T::CLKDIV
+     * Offset: 0x10  I2C Clock Divided Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9:0]   |DIVIDER   |I2C Clock Divided
+     * |        |          |Indicates the I2C clock rate: Data Baud Rate of I2C = (system clock) / (4x (I2C_CLKDIV+1)).
+     * |        |          |Note: The minimum value of I2C_CLKDIV is 4.
+     * |[15:12] |NFCNT     |The register bits control the input filter width.
+     * |        |          |0 : filter width 3*PCLK
+     * |        |          |1 : filter width 4*PCLK
+     * |        |          |N : filter width (3+N)*PCKL
+     * |        |          |Note: Filter width Min :3*PCLK, Max : 18*PCLK
+     * @var I2C_T::TOCTL
+     * Offset: 0x14  I2C Time-out Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TOIF      |Time-out Flag
+     * |        |          |This bit is set by hardware when I2C time-out happened and it can interrupt CPU if I2C interrupt enable bit (INTEN) is set to 1.
+     * |        |          |Note: Software can write 1 to clear this bit.
+     * |[1]     |TOCDIV4   |Time-out Counter Input Clock Divided by 4
+     * |        |          |When enabled, the time-out period is extended 4 times.
+     * |        |          |0 = Time-out period is extend 4 times Disabled.
+     * |        |          |1 = Time-out period is extend 4 times Enabled.
+     * |[2]     |TOCEN     |Time-out Counter Enable Bit
+     * |        |          |When enabled, the 14-bit time-out counter will start counting when SI is cleared
+     * |        |          |Setting flag SI to '1' will reset counter and re-start up counting after SI is cleared.
+     * |        |          |0 = Time-out counter Disabled.
+     * |        |          |1 = Time-out counter Enabled.
+     * @var I2C_T::ADDR0~3
+     * Offset: 0x04/0x18/0x1x/0x20  I2C Slave Address0~3 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |GC        |General Call Function
+     * |        |          |0 = General Call Function Disabled.
+     * |        |          |1 = General Call Function Enabled.
+     * |[10:1]  |ADDR      |I2C Address
+     * |        |          |The content of this register is irrelevant when I2C is in Master mode
+     * |        |          |In the slave mode, the seven most significant bits must be loaded with the chip's own address
+     * |        |          |The I2C hardware will react if either of the address is matched.
+     * |        |          |Note: When software set 10'h000, the address can not be used.
+     * @var I2C_T::ADDRMSK0~3
+     * Offset: 0x24/0x28/0x2C/0x30  I2C Slave Address Mask0~3 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[10:1]  |ADDRMSK   |I2C Address Mask
+     * |        |          |0 = Mask Disabled (the received corresponding register bit should be exact the same as address register.).
+     * |        |          |1 = Mask Enabled (the received corresponding address bit is don't care.).
+     * |        |          |I2C bus controllers support multiple address recognition with four address mask register
+     * |        |          |When the bit in the address mask register is set to one, it means the received corresponding address bit is don't-care
+     * |        |          |If the bit is set to zero, that means the received corresponding register bit should be exact the same as address register.
+     * |        |          |Note: The wake-up function can not use address mask.
+     * @var I2C_T::WKCTL
+     * Offset: 0x3C  I2C Wake-up Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKEN      |I2C Wake-up Enable Bit
+     * |        |          |0 = I2C wake-up function Disabled.
+     * |        |          |1 = I2C wake-up function Enabled.
+     * |[7]     |NHDBUSEN  |I2C No Hold BUS Enable Bit
+     * |        |          |0 = I2C hold bus after wake-up.
+     * |        |          |1 = I2C don't hold bus after wake-up.
+     * |        |          |Note: I2C controller could response when WKIF event is not clear, it may cause error data transmitted or received
+     * |        |          |If data transmitted or received when WKIF event is not clear, user must reset I2C controller and execute the original operation again.
+     * @var I2C_T::WKSTS
+     * Offset: 0x40  I2C Wake-up Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKIF      |I2C Wake-up Flag
+     * |        |          |When chip is woken up from Power-down mode by I2C, this bit is set to 1
+     * |        |          |Software can write 1 to clear this bit.
+     * |[1]     |WKAKDONE  |Wakeup Address Frame Acknowledge Bit Done
+     * |        |          |0 = The ACK bit cycle of address match frame isn't done.
+     * |        |          |1 = The ACK bit cycle of address match frame is done in power-down.
+     * |        |          |Note: This bit can't release WKIF. Software can write 1 to clear this bit.
+     * |[2]     |WRSTSWK   |Read/Write Status Bit in Address Wakeup Frame (Read Only)
+     * |        |          |0 = Write command be record on the address match wakeup frame.
+     * |        |          |1 = Read command be record on the address match wakeup frame.
+     * |        |          |Note: This bit will be cleared when software can write 1 to WKAKDONE (I2C_WKSTS[1]) bit.
+     * @var I2C_T::CTL1
+     * Offset: 0x44  I2C Control Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TXPDMAEN  |PDMA Transmit Channel Available
+     * |        |          |0 = Transmit PDMA function Disabled.
+     * |        |          |1 = Transmit PDMA function Enabled.
+     * |[1]     |RXPDMAEN  |PDMA Receive Channel Available
+     * |        |          |0 = Receive PDMA function Disabled.
+     * |        |          |1 = Receive PDMA function Enabled.
+     * |[2]     |PDMARST   |PDMA Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the I2C request to PDMA.
+     * |[3]     |OVRIEN    |I2C over Run Interrupt Control Bit
+     * |        |          |Setting OVRIEN to logic 1 will send a interrupt to system when the TWOFF bit is enabled and there is over run event in received buffer.
+     * |[4]     |UDRIEN    |I2C Under Run Interrupt Control Bit
+     * |        |          |Setting UDRIEN to logic 1 will send a interrupt to system when the TWOFF bit is enabled and there is under run event happened in transmitted buffer.
+     * |[5]     |TWOBUFEN  |Two-level BUFFER Enable Bit
+     * |        |          |0 = Two-level buffer Disabled.
+     * |        |          |1 = Two-level buffer Enabled.
+     * |        |          |Set to enable the two-level buffer for I2C transmitted or received buffer.
+     * |        |          |It is used to improve the performance of the I2C bus.
+     * |        |          |If this bit is set = 1, the control bit of STA for repeat start or STO bit should be set after the current SI is cleared.
+     * |        |          |For example: if there are 4 data shall be transmitted and then stop it.
+     * |        |          |The STO bit shall be set after the 3rd data's SI event being clear.
+     * |        |          |In this time, the 4th data can be transmitted and the I2C stop after the 4th data transmission done.
+     * |[6]     |BUFRST    |Two-level BUFFER Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the related counters, two-level buffer state machine, and the content of data buffer.
+     * |[7]     |NSTRETCH  |No Stretch on the I2C Bus
+     * |        |          |0 = The I2C SCL bus is stretched by hardware if the SI is not cleared in master mode.
+     * |        |          |1 = The I2C SCL bus is not stretched by hardware if the SI is not cleared in master mode.
+     * |[8]     |PDMASTR   |PDMA Stretch Bit
+     * |        |          |0 = I2C send STOP automatically after PDMA transfer done. (only master TX)
+     * |        |          |1 = I2C SCL bus is stretched by hardware after PDMA transfer done if the SI is not cleared
+     * |        |          |(only master TX)
+     * |[9]     |ADDR10EN  |Address 10-bit Function Enable Bit
+     * |        |          |0 = Address match 10-bit function Disabled.
+     * |        |          |1 = Address match 10-bit function Enabled.
+     * @var I2C_T::STATUS1
+     * Offset: 0x48  I2C Status Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ADMAT0    |I2C Address 0 Match Status
+     * |        |          |When address 0 is matched, hardware will inform which address used
+     * |        |          |This bit will set to 1, and software can write 1 to clear this bit.
+     * |[1]     |ADMAT1    |I2C Address 1 Match Status
+     * |        |          |When address 1 is matched, hardware will inform which address used
+     * |        |          |This bit will set to 1, and software can write 1 to clear this bit.
+     * |[2]     |ADMAT2    |I2C Address 2 Match Status
+     * |        |          |When address 2 is matched, hardware will inform which address used
+     * |        |          |This bit will set to 1, and software can write 1 to clear this bit.
+     * |[3]     |ADMAT3    |I2C Address 3 Match Status
+     * |        |          |When address 3 is matched, hardware will inform which address used
+     * |        |          |This bit will set to 1, and software can write 1 to clear this bit.
+     * |[4]     |FULL      |TWO-lEVEL BUFFER FULL
+     * |        |          |This bit indicates two-level buffer TX or RX full or not when the TWOBUFEN = 1.
+     * |        |          |This bit is set when POINTER is equal to 2.
+     * |        |          |Note:This bit is read only.
+     * |[5]     |EMPTY     |TWO-lEVEL BUFFER EMPTY
+     * |        |          |This bit indicates two-level buffer TX or RX empty or not when the TWOBUFEN = 1.
+     * |        |          |This bit is set when POINTER is equal to 0.
+     * |        |          |Note:This bit is read only.
+     * |[6]     |OVR       |I2C over Run Status Bit
+     * |        |          |This bit indicates the received two-level buffer TX or RX is over run when the TWOBUFEN = 1.
+     * |        |          |Note:This bit is read only.
+     * |[7]     |UDR       |I2C Under Run Status Bit
+     * |        |          |This bit indicates the transmitted two-level buffer TX or RX is under run when the TWOBUFEN = 1.
+     * |        |          |Note:This bit is read only.
+     * |[8]     |ONBUSY    |On Bus Busy (Read Only)
+     * |        |          |Indicates that a communication is in progress on the bus
+     * |        |          |It is set by hardware when a START condition is detected
+     * |        |          |It is cleared by hardware when a STOP condition is detected.
+     * |        |          |0 = The bus is IDLE (both SCLK and SDA High).
+     * |        |          |1 = The bus is busy.
+     * @var I2C_T::TMCTL
+     * Offset: 0x4C  I2C Timing Configure Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |STCTL     |Setup Time Configure Control
+     * |        |          |This field is used to generate a delay timing between SDA falling edge and SCL rising edge in transmission mode.
+     * |        |          |The delay setup time is numbers of peripheral clock = STCTL x PCLK.
+     * |        |          |Note: Setup time setting should not make SCL output less than three PCLKs.
+     * |[24:16] |HTCTL     |Hold Time Configure Control
+     * |        |          |This field is used to generate the delay timing between SCL falling edge and SDA rising edge in transmission mode.
+     * |        |          |The delay hold time is numbers of peripheral clock = HTCTL x PCLK.
+     * @var I2C_T::BUSCTL
+     * Offset: 0x50  I2C Bus Management Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ACKMEN    |Acknowledge Control by Manual
+     * |        |          |In order to allow ACK control in slave reception including the command and data, slave byte control mode must be enabled by setting the ACKMEN bit.
+     * |        |          |0 = Slave byte control Disabled.
+     * |        |          |1 = Slave byte control Enabled
+     * |        |          |The 9th bit can response the ACK or NACK according the received data by user
+     * |        |          |When the byte is received, stretching the SCLK signal low between the 8th and 9th SCLK pulse.
+     * |        |          |Note: If the BMDEN =1 and this bit is enabled, the information of I2C_STATUS0 will be fixed as 0xF0 in slave receive condition.
+     * |[1]     |PECEN     |Packet Error Checking Calculation Enable Bit
+     * |        |          |0 = Packet Error Checking Calculation Disabled.
+     * |        |          |1 = Packet Error Checking Calculation Enabled.
+     * |        |          |Note: When I2C enter powerdown mode, the bit should be enabled after wake-up if needed PEC calculation.
+     * |[2]     |BMDEN     |Bus Management Device Default Address Enable Bit
+     * |        |          |0 = Device default address Disable
+     * |        |          |When the address 0'b1100001x coming and the both of BMDEN and ACKMEN are enabled, the device responses NACKed
+     * |        |          |1 = Device default address Enabled
+     * |        |          |When the address 0'b1100001x coming and the both of BMDEN and ACKMEN are enabled, the device responses ACKed.
+     * |[3]     |BMHEN     |Bus Management Host Enable Bit
+     * |        |          |0 = Host function Disabled.
+     * |        |          |1 = Host function Enabled.
+     * |[4]     |ALERTEN   |Bus Management Alert Enable Bit
+     * |        |          |Device Mode (BMHEN =0).
+     * |        |          |0 = Release the BM_ALERT pin high and Alert Response Header disabled: 0001100x followed by NACK if both of BMDEN and ACKMEN are enabled.
+     * |        |          |1 = Drive BM_ALERT pin low and Alert Response Address Header enables: 0001100x followed by ACK if both of BMDEN and ACKMEN are enabled.
+     * |        |          |Host Mode (BMHEN =1).
+     * |        |          |0 = BM_ALERT pin not supported.
+     * |        |          |1 = BM_ALERT pin supported.
+     * |[5]     |SCTLOSTS  |Suspend/Control Data Output Status
+     * |        |          |0 = The output of SUSCON pin is low.
+     * |        |          |1 = The output of SUSCON pin is high.
+     * |[6]     |SCTLOEN   |Suspend or Control Pin Output Enable Bit
+     * |        |          |0 = The SUSCON pin in input.
+     * |        |          |1 = The output enable is active on the SUSCON pin.
+     * |[7]     |BUSEN     |BUS Enable Bit
+     * |        |          |0 = The system management function Disabled.
+     * |        |          |1 = The system management function Enabled.
+     * |        |          |Note: When the bit is enabled, the internal 14-bit counter is used to calculate the time out event of clock low condition.
+     * |[8]     |PECTXEN   |Packet Error Checking Byte Transmission/Reception
+     * |        |          |0 = No PEC transfer.
+     * |        |          |1 = PEC transmission is requested.
+     * |        |          |Note: 1.This bit has no effect in slave mode when ACKMEN =0.
+     * |[9]     |TIDLE     |Timer Check in Idle State
+     * |        |          |The BUSTOUT is used to calculate the time-out of clock low in bus active and the idle period in bus Idle
+     * |        |          |This bit is used to define which condition is enabled.
+     * |        |          |0 = BUSTOUT is used to calculate the clock low period in bus active.
+     * |        |          |1 = BUSTOUT is used to calculate the IDLE period in bus Idle.
+     * |        |          |Note: The BUSY (I2C_BUSSTS[0]) indicate the current bus state.
+     * |[10]    |PECCLR    |PEC Clear at Repeat Start
+     * |        |          |The calculation of PEC starts when PECEN is set to 1 and it is cleared when the STA or STO bit is detected
+     * |        |          |This PECCLR bit is used to enable the condition of REPEAT START can clear the PEC calculation.
+     * |        |          |0 = PEC calculation is cleared by "Repeat Start" function Disabled.
+     * |        |          |1 = PEC calculation is cleared by "Repeat Start" function Enabled.
+     * |[11]    |ACKM9SI   |Acknowledge Manual Enable Extra SI Interrupt
+     * |        |          |0 = There is no SI interrupt in the 9th clock cycle when the BUSEN =1 and ACKMEN =1.
+     * |        |          |1 = There is SI interrupt in the 9th clock cycle when the BUSEN =1 and ACKMEN =1.
+     * |[12]    |BCDIEN    |Packet Error Checking Byte Count Done Interrupt Enable Bit
+     * |        |          |0 = Byte count done interrupt Disabled.
+     * |        |          |1 = Byte count done interrupt Enabled.
+     * |        |          |Note: This bit is used in PECEN =1.
+     * |[13]    |PECDIEN   |Packet Error Checking Byte Transfer Done Interrupt Enable Bit
+     * |        |          |0 = PEC transfer done interrupt Disabled.
+     * |        |          |1 = PEC transfer done interrupt Enabled.
+     * |        |          |Note: This bit is used in PECEN =1.
+     * @var I2C_T::BUSTCTL
+     * Offset: 0x54  I2C Bus Management Timer Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BUSTOEN   |Bus Time Out Enable Bit
+     * |        |          |0 = Bus clock low time-out detection Disabled.
+     * |        |          |1 = Bus clock low time-out detection Enabled (bus clock is low for more than TTime-out (in BIDLE=0) or high more than TTime-out(in BIDLE =1)
+     * |[1]     |CLKTOEN   |Cumulative Clock Low Time Out Enable Bit
+     * |        |          |0 = Cumulative clock low time-out detection Disabled.
+     * |        |          |1 = Cumulative clock low time-out detection Enabled.
+     * |        |          |For Master, it calculates the period from START to ACK
+     * |        |          |For Slave, it calculates the period from START to STOP
+     * |[2]     |BUSTOIEN  |Time-out Interrupt Enable Bit
+     * |        |          |BUSY =1.
+     * |        |          |0 = SCLK low time-out interrupt Disabled.
+     * |        |          |1 = SCLK low time-out interrupt Enabled.
+     * |        |          |BUSY =0.
+     * |        |          |0 = Bus IDLE time-out interrupt Disabled.
+     * |        |          |1 = Bus IDLE time-out interrupt Enabled.
+     * |[3]     |CLKTOIEN  |Extended Clock Time Out Interrupt Enable Bit
+     * |        |          |0 = Clock time out interrupt Disabled.
+     * |        |          |1 = Clock time out interrupt Enabled.
+     * |[4]     |TORSTEN   |Time Out Reset Enable Bit
+     * |        |          |0 = I2C state machine reset Disabled.
+     * |        |          |1 = I2C state machine reset Enabled. (The clock and data bus will be released to high)
+     * @var I2C_T::BUSSTS
+     * Offset: 0x58  I2C Bus Management Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BUSY      |Bus Busy (Read Only)
+     * |        |          |Indicates that a communication is in progress on the bus
+     * |        |          |It is set by hardware when a START condition is detected
+     * |        |          |It is cleared by hardware when a STOP condition is detected
+     * |        |          |0 = Bus is IDLE (both SCLK and SDA High).
+     * |        |          |1 = Bus is busy.
+     * |[1]     |BCDONE    |Byte Count Transmission/Receive Done
+     * |        |          |0 = Byte count transmission/ receive is not finished when the PECEN is set.
+     * |        |          |1 = Byte count transmission/ receive is finished when the PECEN is set.
+     * |        |          |Note: Software can write 1 to clear this bit.
+     * |[2]     |PECERR    |PEC Error in Reception
+     * |        |          |0 = PEC value equal the received PEC data packet.
+     * |        |          |1 = PEC value doesn't match the receive PEC data packet.
+     * |        |          |Note: Software can write 1 to clear this bit.
+     * |[3]     |ALERT     |SMBus Alert Status
+     * |        |          |Device Mode (BMHEN =0).
+     * |        |          |0 = Indicates SMBALERT pin state is low.
+     * |        |          |1 = Indicates SMBALERT pin state is high.
+     * |        |          |Host Mode (BMHEN =1).
+     * |        |          |0 = No SMBALERT event.
+     * |        |          |1 = Indicates there is SMBALERT event (falling edge) is detected in SMALERT pin when the BMHEN = 1 (SMBus host configuration) and the ALERTEN = 1.
+     * |        |          |Note:
+     * |        |          |1. The SMBALERT pin is an open-drain pin, the pull-high resistor is must in the system
+     * |        |          |2. Software can write 1 to clear this bit.
+     * |[4]     |SCTLDIN   |Bus Suspend or Control Signal Input Status (Read Only)
+     * |        |          |0 = The input status of SUSCON pin is 0.
+     * |        |          |1 = The input status of SUSCON pin is 1.
+     * |[5]     |BUSTO     |Bus Time-out Status
+     * |        |          |0 = There is no any time-out or external clock time-out.
+     * |        |          |1 = A time-out or external clock time-out occurred.
+     * |        |          |In bus busy, the bit indicates the total clock low time-out event occurred; otherwise, it indicates the bus idle time-out event occurred.
+     * |        |          |Note: Software can write 1 to clear this bit.
+     * |[6]     |CLKTO     |Clock Low Cumulate Time-out Status
+     * |        |          |0 = Cumulative clock low is no any time-out.
+     * |        |          |1 = Cumulative clock low time-out occurred.
+     * |        |          |Note: Software can write 1 to clear this bit.
+     * |[7]     |PECDONE   |PEC Byte Transmission/Receive Done
+     * |        |          |0 = PEC transmission/ receive is not finished when the PECEN is set.
+     * |        |          |1 = PEC transmission/ receive is finished when the PECEN is set.
+     * |        |          |Note: Software can write 1 to clear this bit.
+     * @var I2C_T::PKTSIZE
+     * Offset: 0x5C  I2C Packet Error Checking Byte Number Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |PLDSIZE   |Transfer Byte Number
+     * |        |          |The transmission or receive byte number in one transaction when the PECEN is set
+     * |        |          |The maximum transaction or receive byte is 256 Bytes.
+     * |        |          |Note: The byte number counting includes address, command code, and data frame.
+     * @var I2C_T::PKTCRC
+     * Offset: 0x60  I2C Packet Error Checking Byte Value Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |PECCRC    |Packet Error Checking Byte Value
+     * |        |          |This byte indicates the packet error checking content after transmission or receive byte count by using the C(x) = X8 + X2 + X + 1
+     * |        |          |It is read only.
+     * @var I2C_T::BUSTOUT
+     * Offset: 0x64  I2C Bus Management Timer Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |BUSTO     |Bus Management Time-out Value
+     * |        |          |Indicates the bus time-out value in bus is IDLE or SCLK low.
+     * |        |          |Note: If the user wants to revise the value of BUSTOUT, the TORSTEN (I2C_BUSTCTL[4]) bit shall be set to 1 and clear to 0 first in the BUSEN(I2C_BUSCTL[7]) is set.
+     * @var I2C_T::CLKTOUT
+     * Offset: 0x68  I2C Bus Management Clock Low Timer Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CLKTO     |Bus Clock Low Timer
+     * |        |          |The field is used to configure the cumulative clock extension time-out.
+     * |        |          |Note: If the user wants to revise the value of CLKLTOUT, the TORSTEN bit shall be set to 1 and clear to 0 first in the BUSEN is set.
+     */
+    __IO uint32_t CTL0;                  /*!< [0x0000] I2C Control Register 0                                           */
+    __IO uint32_t ADDR0;                 /*!< [0x0004] I2C Slave Address Register0                                      */
+    __IO uint32_t DAT;                   /*!< [0x0008] I2C Data Register                                                */
+    __I  uint32_t STATUS0;               /*!< [0x000c] I2C Status Register 0                                            */
+    __IO uint32_t CLKDIV;                /*!< [0x0010] I2C Clock Divided Register                                       */
+    __IO uint32_t TOCTL;                 /*!< [0x0014] I2C Time-out Control Register                                    */
+    __IO uint32_t ADDR1;                 /*!< [0x0018] I2C Slave Address Register1                                      */
+    __IO uint32_t ADDR2;                 /*!< [0x001c] I2C Slave Address Register2                                      */
+    __IO uint32_t ADDR3;                 /*!< [0x0020] I2C Slave Address Register3                                      */
+    __IO uint32_t ADDRMSK0;              /*!< [0x0024] I2C Slave Address Mask Register0                                 */
+    __IO uint32_t ADDRMSK1;              /*!< [0x0028] I2C Slave Address Mask Register1                                 */
+    __IO uint32_t ADDRMSK2;              /*!< [0x002c] I2C Slave Address Mask Register2                                 */
+    __IO uint32_t ADDRMSK3;              /*!< [0x0030] I2C Slave Address Mask Register3                                 */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t WKCTL;                 /*!< [0x003c] I2C Wake-up Control Register                                     */
+    __IO uint32_t WKSTS;                 /*!< [0x0040] I2C Wake-up Status Register                                      */
+    __IO uint32_t CTL1;                  /*!< [0x0044] I2C Control Register 1                                           */
+    __IO uint32_t STATUS1;               /*!< [0x0048] I2C Status Register 1                                            */
+    __IO uint32_t TMCTL;                 /*!< [0x004c] I2C Timing Configure Control Register                            */
+    __IO uint32_t BUSCTL;                /*!< [0x0050] I2C Bus Management Control Register                              */
+    __IO uint32_t BUSTCTL;               /*!< [0x0054] I2C Bus Management Timer Control Register                        */
+    __IO uint32_t BUSSTS;                /*!< [0x0058] I2C Bus Management Status Register                               */
+    __IO uint32_t PKTSIZE;               /*!< [0x005c] I2C Packet Error Checking Byte Number Register                   */
+    __I  uint32_t PKTCRC;                /*!< [0x0060] I2C Packet Error Checking Byte Value Register                    */
+    __IO uint32_t BUSTOUT;               /*!< [0x0064] I2C Bus Management Timer Register                                */
+    __IO uint32_t CLKTOUT;               /*!< [0x0068] I2C Bus Management Clock Low Timer Register                      */
+} I2C_T;
+
+/**
+    @addtogroup I2C_CONST I2C Bit Field Definition
+    Constant Definitions for I2C Controller
+@{ */
+
+#define I2C_CTL0_AA_Pos                  (2)                                               /*!< I2C_T::CTL0: AA Position               */
+#define I2C_CTL0_AA_Msk                  (0x1ul << I2C_CTL0_AA_Pos)                        /*!< I2C_T::CTL0: AA Mask                   */
+
+#define I2C_CTL0_SI_Pos                  (3)                                               /*!< I2C_T::CTL0: SI Position               */
+#define I2C_CTL0_SI_Msk                  (0x1ul << I2C_CTL0_SI_Pos)                        /*!< I2C_T::CTL0: SI Mask                   */
+
+#define I2C_CTL0_STO_Pos                 (4)                                               /*!< I2C_T::CTL0: STO Position              */
+#define I2C_CTL0_STO_Msk                 (0x1ul << I2C_CTL0_STO_Pos)                       /*!< I2C_T::CTL0: STO Mask                  */
+
+#define I2C_CTL0_STA_Pos                 (5)                                               /*!< I2C_T::CTL0: STA Position              */
+#define I2C_CTL0_STA_Msk                 (0x1ul << I2C_CTL0_STA_Pos)                       /*!< I2C_T::CTL0: STA Mask                  */
+
+#define I2C_CTL0_I2CEN_Pos               (6)                                               /*!< I2C_T::CTL0: I2CEN Position            */
+#define I2C_CTL0_I2CEN_Msk               (0x1ul << I2C_CTL0_I2CEN_Pos)                     /*!< I2C_T::CTL0: I2CEN Mask                */
+
+#define I2C_CTL0_INTEN_Pos               (7)                                               /*!< I2C_T::CTL0: INTEN Position            */
+#define I2C_CTL0_INTEN_Msk               (0x1ul << I2C_CTL0_INTEN_Pos)                     /*!< I2C_T::CTL0: INTEN Mask                */
+
+#define I2C_ADDR0_GC_Pos                 (0)                                               /*!< I2C_T::ADDR0: GC Position              */
+#define I2C_ADDR0_GC_Msk                 (0x1ul << I2C_ADDR0_GC_Pos)                       /*!< I2C_T::ADDR0: GC Mask                  */
+
+#define I2C_ADDR0_ADDR_Pos               (1)                                               /*!< I2C_T::ADDR0: ADDR Position            */
+#define I2C_ADDR0_ADDR_Msk               (0x3fful << I2C_ADDR0_ADDR_Pos)                   /*!< I2C_T::ADDR0: ADDR Mask                */
+
+#define I2C_DAT_DAT_Pos                  (0)                                               /*!< I2C_T::DAT: DAT Position               */
+#define I2C_DAT_DAT_Msk                  (0xfful << I2C_DAT_DAT_Pos)                       /*!< I2C_T::DAT: DAT Mask                   */
+
+#define I2C_STATUS0_STATUS_Pos           (0)                                               /*!< I2C_T::STATUS0: STATUS Position        */
+#define I2C_STATUS0_STATUS_Msk           (0xfful << I2C_STATUS0_STATUS_Pos)                /*!< I2C_T::STATUS0: STATUS Mask            */
+
+#define I2C_CLKDIV_DIVIDER_Pos           (0)                                               /*!< I2C_T::CLKDIV: DIVIDER Position        */
+#define I2C_CLKDIV_DIVIDER_Msk           (0x3fful << I2C_CLKDIV_DIVIDER_Pos)               /*!< I2C_T::CLKDIV: DIVIDER Mask            */
+
+#define I2C_CLKDIV_NFCNT_Pos             (12)                                              /*!< I2C_T::CLKDIV: NFCNT Position          */
+#define I2C_CLKDIV_NFCNT_Msk             (0xful << I2C_CLKDIV_NFCNT_Pos)                   /*!< I2C_T::CLKDIV: NFCNT Mask              */
+
+#define I2C_TOCTL_TOIF_Pos               (0)                                               /*!< I2C_T::TOCTL: TOIF Position            */
+#define I2C_TOCTL_TOIF_Msk               (0x1ul << I2C_TOCTL_TOIF_Pos)                     /*!< I2C_T::TOCTL: TOIF Mask                */
+
+#define I2C_TOCTL_TOCDIV4_Pos            (1)                                               /*!< I2C_T::TOCTL: TOCDIV4 Position         */
+#define I2C_TOCTL_TOCDIV4_Msk            (0x1ul << I2C_TOCTL_TOCDIV4_Pos)                  /*!< I2C_T::TOCTL: TOCDIV4 Mask             */
+
+#define I2C_TOCTL_TOCEN_Pos              (2)                                               /*!< I2C_T::TOCTL: TOCEN Position           */
+#define I2C_TOCTL_TOCEN_Msk              (0x1ul << I2C_TOCTL_TOCEN_Pos)                    /*!< I2C_T::TOCTL: TOCEN Mask               */
+
+#define I2C_ADDR1_GC_Pos                 (0)                                               /*!< I2C_T::ADDR1: GC Position              */
+#define I2C_ADDR1_GC_Msk                 (0x1ul << I2C_ADDR1_GC_Pos)                       /*!< I2C_T::ADDR1: GC Mask                  */
+
+#define I2C_ADDR1_ADDR_Pos               (1)                                               /*!< I2C_T::ADDR1: ADDR Position            */
+#define I2C_ADDR1_ADDR_Msk               (0x3fful << I2C_ADDR1_ADDR_Pos)                   /*!< I2C_T::ADDR1: ADDR Mask                */
+
+#define I2C_ADDR2_GC_Pos                 (0)                                               /*!< I2C_T::ADDR2: GC Position              */
+#define I2C_ADDR2_GC_Msk                 (0x1ul << I2C_ADDR2_GC_Pos)                       /*!< I2C_T::ADDR2: GC Mask                  */
+
+#define I2C_ADDR2_ADDR_Pos               (1)                                               /*!< I2C_T::ADDR2: ADDR Position            */
+#define I2C_ADDR2_ADDR_Msk               (0x3fful << I2C_ADDR2_ADDR_Pos)                   /*!< I2C_T::ADDR2: ADDR Mask                */
+
+#define I2C_ADDR3_GC_Pos                 (0)                                               /*!< I2C_T::ADDR3: GC Position              */
+#define I2C_ADDR3_GC_Msk                 (0x1ul << I2C_ADDR3_GC_Pos)                       /*!< I2C_T::ADDR3: GC Mask                  */
+
+#define I2C_ADDR3_ADDR_Pos               (1)                                               /*!< I2C_T::ADDR3: ADDR Position            */
+#define I2C_ADDR3_ADDR_Msk               (0x3fful << I2C_ADDR3_ADDR_Pos)                   /*!< I2C_T::ADDR3: ADDR Mask                */
+
+#define I2C_ADDRMSK0_ADDRMSK_Pos         (1)                                               /*!< I2C_T::ADDRMSK0: ADDRMSK Position      */
+#define I2C_ADDRMSK0_ADDRMSK_Msk         (0x3fful << I2C_ADDRMSK0_ADDRMSK_Pos)             /*!< I2C_T::ADDRMSK0: ADDRMSK Mask          */
+
+#define I2C_ADDRMSK1_ADDRMSK_Pos         (1)                                               /*!< I2C_T::ADDRMSK1: ADDRMSK Position      */
+#define I2C_ADDRMSK1_ADDRMSK_Msk         (0x3fful << I2C_ADDRMSK1_ADDRMSK_Pos)             /*!< I2C_T::ADDRMSK1: ADDRMSK Mask          */
+
+#define I2C_ADDRMSK2_ADDRMSK_Pos         (1)                                               /*!< I2C_T::ADDRMSK2: ADDRMSK Position      */
+#define I2C_ADDRMSK2_ADDRMSK_Msk         (0x3fful << I2C_ADDRMSK2_ADDRMSK_Pos)             /*!< I2C_T::ADDRMSK2: ADDRMSK Mask          */
+
+#define I2C_ADDRMSK3_ADDRMSK_Pos         (1)                                               /*!< I2C_T::ADDRMSK3: ADDRMSK Position      */
+#define I2C_ADDRMSK3_ADDRMSK_Msk         (0x3fful << I2C_ADDRMSK3_ADDRMSK_Pos)             /*!< I2C_T::ADDRMSK3: ADDRMSK Mask          */
+
+#define I2C_WKCTL_WKEN_Pos               (0)                                               /*!< I2C_T::WKCTL: WKEN Position            */
+#define I2C_WKCTL_WKEN_Msk               (0x1ul << I2C_WKCTL_WKEN_Pos)                     /*!< I2C_T::WKCTL: WKEN Mask                */
+
+#define I2C_WKCTL_NHDBUSEN_Pos           (7)                                               /*!< I2C_T::WKCTL: NHDBUSEN Position        */
+#define I2C_WKCTL_NHDBUSEN_Msk           (0x1ul << I2C_WKCTL_NHDBUSEN_Pos)                 /*!< I2C_T::WKCTL: NHDBUSEN Mask            */
+
+#define I2C_WKSTS_WKIF_Pos               (0)                                               /*!< I2C_T::WKSTS: WKIF Position            */
+#define I2C_WKSTS_WKIF_Msk               (0x1ul << I2C_WKSTS_WKIF_Pos)                     /*!< I2C_T::WKSTS: WKIF Mask                */
+
+#define I2C_WKSTS_WKAKDONE_Pos           (1)                                               /*!< I2C_T::WKSTS: WKAKDONE Position        */
+#define I2C_WKSTS_WKAKDONE_Msk           (0x1ul << I2C_WKSTS_WKAKDONE_Pos)                 /*!< I2C_T::WKSTS: WKAKDONE Mask            */
+
+#define I2C_WKSTS_WRSTSWK_Pos            (2)                                               /*!< I2C_T::WKSTS: WRSTSWK Position         */
+#define I2C_WKSTS_WRSTSWK_Msk            (0x1ul << I2C_WKSTS_WRSTSWK_Pos)                  /*!< I2C_T::WKSTS: WRSTSWK Mask             */
+
+#define I2C_CTL1_TXPDMAEN_Pos            (0)                                               /*!< I2C_T::CTL1: TXPDMAEN Position         */
+#define I2C_CTL1_TXPDMAEN_Msk            (0x1ul << I2C_CTL1_TXPDMAEN_Pos)                  /*!< I2C_T::CTL1: TXPDMAEN Mask             */
+
+#define I2C_CTL1_RXPDMAEN_Pos            (1)                                               /*!< I2C_T::CTL1: RXPDMAEN Position         */
+#define I2C_CTL1_RXPDMAEN_Msk            (0x1ul << I2C_CTL1_RXPDMAEN_Pos)                  /*!< I2C_T::CTL1: RXPDMAEN Mask             */
+
+#define I2C_CTL1_PDMARST_Pos             (2)                                               /*!< I2C_T::CTL1: PDMARST Position          */
+#define I2C_CTL1_PDMARST_Msk             (0x1ul << I2C_CTL1_PDMARST_Pos)                   /*!< I2C_T::CTL1: PDMARST Mask              */
+
+#define I2C_CTL1_OVRIEN_Pos              (3)                                               /*!< I2C_T::CTL1: OVRIEN Position           */
+#define I2C_CTL1_OVRIEN_Msk              (0x1ul << I2C_CTL1_OVRIEN_Pos)                    /*!< I2C_T::CTL1: OVRIEN Mask               */
+
+#define I2C_CTL1_UDRIEN_Pos              (4)                                               /*!< I2C_T::CTL1: UDRIEN Position           */
+#define I2C_CTL1_UDRIEN_Msk              (0x1ul << I2C_CTL1_UDRIEN_Pos)                    /*!< I2C_T::CTL1: UDRIEN Mask               */
+
+#define I2C_CTL1_TWOBUFEN_Pos            (5)                                               /*!< I2C_T::CTL1: TWOBUFEN Position         */
+#define I2C_CTL1_TWOBUFEN_Msk            (0x1ul << I2C_CTL1_TWOBUFEN_Pos)                  /*!< I2C_T::CTL1: TWOBUFEN Mask             */
+
+#define I2C_CTL1_BUFRST_Pos              (6)                                               /*!< I2C_T::CTL1: BUFRST Position           */
+#define I2C_CTL1_BUFRST_Msk              (0x1ul << I2C_CTL1_BUFRST_Pos)                    /*!< I2C_T::CTL1: BUFRST Mask               */
+
+#define I2C_CTL1_NSTRETCH_Pos            (7)                                               /*!< I2C_T::CTL1: NSTRETCH Position         */
+#define I2C_CTL1_NSTRETCH_Msk            (0x1ul << I2C_CTL1_NSTRETCH_Pos)                  /*!< I2C_T::CTL1: NSTRETCH Mask             */
+
+#define I2C_CTL1_PDMASTR_Pos             (8)                                               /*!< I2C_T::CTL1: PDMASTR Position          */
+#define I2C_CTL1_PDMASTR_Msk             (0x1ul << I2C_CTL1_PDMASTR_Pos)                   /*!< I2C_T::CTL1: PDMASTR Mask              */
+
+#define I2C_CTL1_ADDR10EN_Pos            (9)                                               /*!< I2C_T::CTL1: ADDR10EN Position         */
+#define I2C_CTL1_ADDR10EN_Msk            (0x1ul << I2C_CTL1_ADDR10EN_Pos)                  /*!< I2C_T::CTL1: ADDR10EN Mask             */
+
+#define I2C_STATUS1_ADMAT0_Pos           (0)                                               /*!< I2C_T::STATUS1: ADMAT0 Position        */
+#define I2C_STATUS1_ADMAT0_Msk           (0x1ul << I2C_STATUS1_ADMAT0_Pos)                 /*!< I2C_T::STATUS1: ADMAT0 Mask            */
+
+#define I2C_STATUS1_ADMAT1_Pos           (1)                                               /*!< I2C_T::STATUS1: ADMAT1 Position        */
+#define I2C_STATUS1_ADMAT1_Msk           (0x1ul << I2C_STATUS1_ADMAT1_Pos)                 /*!< I2C_T::STATUS1: ADMAT1 Mask            */
+
+#define I2C_STATUS1_ADMAT2_Pos           (2)                                               /*!< I2C_T::STATUS1: ADMAT2 Position        */
+#define I2C_STATUS1_ADMAT2_Msk           (0x1ul << I2C_STATUS1_ADMAT2_Pos)                 /*!< I2C_T::STATUS1: ADMAT2 Mask            */
+
+#define I2C_STATUS1_ADMAT3_Pos           (3)                                               /*!< I2C_T::STATUS1: ADMAT3 Position        */
+#define I2C_STATUS1_ADMAT3_Msk           (0x1ul << I2C_STATUS1_ADMAT3_Pos)                 /*!< I2C_T::STATUS1: ADMAT3 Mask            */
+
+#define I2C_STATUS1_FULL_Pos             (4)                                               /*!< I2C_T::STATUS1: FULL Position          */
+#define I2C_STATUS1_FULL_Msk             (0x1ul << I2C_STATUS1_FULL_Pos)                   /*!< I2C_T::STATUS1: FULL Mask              */
+
+#define I2C_STATUS1_EMPTY_Pos            (5)                                               /*!< I2C_T::STATUS1: EMPTY Position         */
+#define I2C_STATUS1_EMPTY_Msk            (0x1ul << I2C_STATUS1_EMPTY_Pos)                  /*!< I2C_T::STATUS1: EMPTY Mask             */
+
+#define I2C_STATUS1_OVR_Pos              (6)                                               /*!< I2C_T::STATUS1: OVR Position           */
+#define I2C_STATUS1_OVR_Msk              (0x1ul << I2C_STATUS1_OVR_Pos)                    /*!< I2C_T::STATUS1: OVR Mask               */
+
+#define I2C_STATUS1_UDR_Pos              (7)                                               /*!< I2C_T::STATUS1: UDR Position           */
+#define I2C_STATUS1_UDR_Msk              (0x1ul << I2C_STATUS1_UDR_Pos)                    /*!< I2C_T::STATUS1: UDR Mask               */
+
+#define I2C_STATUS1_ONBUSY_Pos           (8)                                               /*!< I2C_T::STATUS1: ONBUSY Position        */
+#define I2C_STATUS1_ONBUSY_Msk           (0x1ul << I2C_STATUS1_ONBUSY_Pos)                 /*!< I2C_T::STATUS1: ONBUSY Mask            */
+
+#define I2C_TMCTL_STCTL_Pos              (0)                                               /*!< I2C_T::TMCTL: STCTL Position           */
+#define I2C_TMCTL_STCTL_Msk              (0x1fful << I2C_TMCTL_STCTL_Pos)                  /*!< I2C_T::TMCTL: STCTL Mask               */
+
+#define I2C_TMCTL_HTCTL_Pos              (16)                                              /*!< I2C_T::TMCTL: HTCTL Position           */
+#define I2C_TMCTL_HTCTL_Msk              (0x1fful << I2C_TMCTL_HTCTL_Pos)                  /*!< I2C_T::TMCTL: HTCTL Mask               */
+
+#define I2C_BUSCTL_ACKMEN_Pos            (0)                                               /*!< I2C_T::BUSCTL: ACKMEN Position         */
+#define I2C_BUSCTL_ACKMEN_Msk            (0x1ul << I2C_BUSCTL_ACKMEN_Pos)                  /*!< I2C_T::BUSCTL: ACKMEN Mask             */
+
+#define I2C_BUSCTL_PECEN_Pos             (1)                                               /*!< I2C_T::BUSCTL: PECEN Position          */
+#define I2C_BUSCTL_PECEN_Msk             (0x1ul << I2C_BUSCTL_PECEN_Pos)                   /*!< I2C_T::BUSCTL: PECEN Mask              */
+
+#define I2C_BUSCTL_BMDEN_Pos             (2)                                               /*!< I2C_T::BUSCTL: BMDEN Position          */
+#define I2C_BUSCTL_BMDEN_Msk             (0x1ul << I2C_BUSCTL_BMDEN_Pos)                   /*!< I2C_T::BUSCTL: BMDEN Mask              */
+
+#define I2C_BUSCTL_BMHEN_Pos             (3)                                               /*!< I2C_T::BUSCTL: BMHEN Position          */
+#define I2C_BUSCTL_BMHEN_Msk             (0x1ul << I2C_BUSCTL_BMHEN_Pos)                   /*!< I2C_T::BUSCTL: BMHEN Mask              */
+
+#define I2C_BUSCTL_ALERTEN_Pos           (4)                                               /*!< I2C_T::BUSCTL: ALERTEN Position        */
+#define I2C_BUSCTL_ALERTEN_Msk           (0x1ul << I2C_BUSCTL_ALERTEN_Pos)                 /*!< I2C_T::BUSCTL: ALERTEN Mask            */
+
+#define I2C_BUSCTL_SCTLOSTS_Pos          (5)                                               /*!< I2C_T::BUSCTL: SCTLOSTS Position       */
+#define I2C_BUSCTL_SCTLOSTS_Msk          (0x1ul << I2C_BUSCTL_SCTLOSTS_Pos)                /*!< I2C_T::BUSCTL: SCTLOSTS Mask           */
+
+#define I2C_BUSCTL_SCTLOEN_Pos           (6)                                               /*!< I2C_T::BUSCTL: SCTLOEN Position        */
+#define I2C_BUSCTL_SCTLOEN_Msk           (0x1ul << I2C_BUSCTL_SCTLOEN_Pos)                 /*!< I2C_T::BUSCTL: SCTLOEN Mask            */
+
+#define I2C_BUSCTL_BUSEN_Pos             (7)                                               /*!< I2C_T::BUSCTL: BUSEN Position          */
+#define I2C_BUSCTL_BUSEN_Msk             (0x1ul << I2C_BUSCTL_BUSEN_Pos)                   /*!< I2C_T::BUSCTL: BUSEN Mask              */
+
+#define I2C_BUSCTL_PECTXEN_Pos           (8)                                               /*!< I2C_T::BUSCTL: PECTXEN Position        */
+#define I2C_BUSCTL_PECTXEN_Msk           (0x1ul << I2C_BUSCTL_PECTXEN_Pos)                 /*!< I2C_T::BUSCTL: PECTXEN Mask            */
+
+#define I2C_BUSCTL_TIDLE_Pos             (9)                                               /*!< I2C_T::BUSCTL: TIDLE Position          */
+#define I2C_BUSCTL_TIDLE_Msk             (0x1ul << I2C_BUSCTL_TIDLE_Pos)                   /*!< I2C_T::BUSCTL: TIDLE Mask              */
+
+#define I2C_BUSCTL_PECCLR_Pos            (10)                                              /*!< I2C_T::BUSCTL: PECCLR Position         */
+#define I2C_BUSCTL_PECCLR_Msk            (0x1ul << I2C_BUSCTL_PECCLR_Pos)                  /*!< I2C_T::BUSCTL: PECCLR Mask             */
+
+#define I2C_BUSCTL_ACKM9SI_Pos           (11)                                              /*!< I2C_T::BUSCTL: ACKM9SI Position        */
+#define I2C_BUSCTL_ACKM9SI_Msk           (0x1ul << I2C_BUSCTL_ACKM9SI_Pos)                 /*!< I2C_T::BUSCTL: ACKM9SI Mask            */
+
+#define I2C_BUSCTL_BCDIEN_Pos            (12)                                              /*!< I2C_T::BUSCTL: BCDIEN Position         */
+#define I2C_BUSCTL_BCDIEN_Msk            (0x1ul << I2C_BUSCTL_BCDIEN_Pos)                  /*!< I2C_T::BUSCTL: BCDIEN Mask             */
+
+#define I2C_BUSCTL_PECDIEN_Pos           (13)                                              /*!< I2C_T::BUSCTL: PECDIEN Position        */
+#define I2C_BUSCTL_PECDIEN_Msk           (0x1ul << I2C_BUSCTL_PECDIEN_Pos)                 /*!< I2C_T::BUSCTL: PECDIEN Mask            */
+
+#define I2C_BUSTCTL_BUSTOEN_Pos          (0)                                               /*!< I2C_T::BUSTCTL: BUSTOEN Position       */
+#define I2C_BUSTCTL_BUSTOEN_Msk          (0x1ul << I2C_BUSTCTL_BUSTOEN_Pos)                /*!< I2C_T::BUSTCTL: BUSTOEN Mask           */
+
+#define I2C_BUSTCTL_CLKTOEN_Pos          (1)                                               /*!< I2C_T::BUSTCTL: CLKTOEN Position       */
+#define I2C_BUSTCTL_CLKTOEN_Msk          (0x1ul << I2C_BUSTCTL_CLKTOEN_Pos)                /*!< I2C_T::BUSTCTL: CLKTOEN Mask           */
+
+#define I2C_BUSTCTL_BUSTOIEN_Pos         (2)                                               /*!< I2C_T::BUSTCTL: BUSTOIEN Position      */
+#define I2C_BUSTCTL_BUSTOIEN_Msk         (0x1ul << I2C_BUSTCTL_BUSTOIEN_Pos)               /*!< I2C_T::BUSTCTL: BUSTOIEN Mask          */
+
+#define I2C_BUSTCTL_CLKTOIEN_Pos         (3)                                               /*!< I2C_T::BUSTCTL: CLKTOIEN Position      */
+#define I2C_BUSTCTL_CLKTOIEN_Msk         (0x1ul << I2C_BUSTCTL_CLKTOIEN_Pos)               /*!< I2C_T::BUSTCTL: CLKTOIEN Mask          */
+
+#define I2C_BUSTCTL_TORSTEN_Pos          (4)                                               /*!< I2C_T::BUSTCTL: TORSTEN Position       */
+#define I2C_BUSTCTL_TORSTEN_Msk          (0x1ul << I2C_BUSTCTL_TORSTEN_Pos)                /*!< I2C_T::BUSTCTL: TORSTEN Mask           */
+
+#define I2C_BUSSTS_BUSY_Pos              (0)                                               /*!< I2C_T::BUSSTS: BUSY Position           */
+#define I2C_BUSSTS_BUSY_Msk              (0x1ul << I2C_BUSSTS_BUSY_Pos)                    /*!< I2C_T::BUSSTS: BUSY Mask               */
+
+#define I2C_BUSSTS_BCDONE_Pos            (1)                                               /*!< I2C_T::BUSSTS: BCDONE Position         */
+#define I2C_BUSSTS_BCDONE_Msk            (0x1ul << I2C_BUSSTS_BCDONE_Pos)                  /*!< I2C_T::BUSSTS: BCDONE Mask             */
+
+#define I2C_BUSSTS_PECERR_Pos            (2)                                               /*!< I2C_T::BUSSTS: PECERR Position         */
+#define I2C_BUSSTS_PECERR_Msk            (0x1ul << I2C_BUSSTS_PECERR_Pos)                  /*!< I2C_T::BUSSTS: PECERR Mask             */
+
+#define I2C_BUSSTS_ALERT_Pos             (3)                                               /*!< I2C_T::BUSSTS: ALERT Position          */
+#define I2C_BUSSTS_ALERT_Msk             (0x1ul << I2C_BUSSTS_ALERT_Pos)                   /*!< I2C_T::BUSSTS: ALERT Mask              */
+
+#define I2C_BUSSTS_SCTLDIN_Pos           (4)                                               /*!< I2C_T::BUSSTS: SCTLDIN Position        */
+#define I2C_BUSSTS_SCTLDIN_Msk           (0x1ul << I2C_BUSSTS_SCTLDIN_Pos)                 /*!< I2C_T::BUSSTS: SCTLDIN Mask            */
+
+#define I2C_BUSSTS_BUSTO_Pos             (5)                                               /*!< I2C_T::BUSSTS: BUSTO Position          */
+#define I2C_BUSSTS_BUSTO_Msk             (0x1ul << I2C_BUSSTS_BUSTO_Pos)                   /*!< I2C_T::BUSSTS: BUSTO Mask              */
+
+#define I2C_BUSSTS_CLKTO_Pos             (6)                                               /*!< I2C_T::BUSSTS: CLKTO Position          */
+#define I2C_BUSSTS_CLKTO_Msk             (0x1ul << I2C_BUSSTS_CLKTO_Pos)                   /*!< I2C_T::BUSSTS: CLKTO Mask              */
+
+#define I2C_BUSSTS_PECDONE_Pos           (7)                                               /*!< I2C_T::BUSSTS: PECDONE Position        */
+#define I2C_BUSSTS_PECDONE_Msk           (0x1ul << I2C_BUSSTS_PECDONE_Pos)                 /*!< I2C_T::BUSSTS: PECDONE Mask            */
+
+#define I2C_PKTSIZE_PLDSIZE_Pos          (0)                                               /*!< I2C_T::PKTSIZE: PLDSIZE Position       */
+#define I2C_PKTSIZE_PLDSIZE_Msk          (0x1fful << I2C_PKTSIZE_PLDSIZE_Pos)              /*!< I2C_T::PKTSIZE: PLDSIZE Mask           */
+
+#define I2C_PKTCRC_PECCRC_Pos            (0)                                               /*!< I2C_T::PKTCRC: PECCRC Position         */
+#define I2C_PKTCRC_PECCRC_Msk            (0xfful << I2C_PKTCRC_PECCRC_Pos)                 /*!< I2C_T::PKTCRC: PECCRC Mask             */
+
+#define I2C_BUSTOUT_BUSTO_Pos            (0)                                               /*!< I2C_T::BUSTOUT: BUSTO Position         */
+#define I2C_BUSTOUT_BUSTO_Msk            (0xfful << I2C_BUSTOUT_BUSTO_Pos)                 /*!< I2C_T::BUSTOUT: BUSTO Mask             */
+
+#define I2C_CLKTOUT_CLKTO_Pos            (0)                                               /*!< I2C_T::CLKTOUT: CLKTO Position         */
+#define I2C_CLKTOUT_CLKTO_Msk            (0xfful << I2C_CLKTOUT_CLKTO_Pos)                 /*!< I2C_T::CLKTOUT: CLKTO Mask             */
+
+/** @} I2C_CONST */
+/** @} end of I2C register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __I2C_REG_H__ */

--- a/hal/m258ke/nuvoton/lcd_reg.h
+++ b/hal/m258ke/nuvoton/lcd_reg.h
@@ -1,0 +1,1336 @@
+/**************************************************************************//**
+ * @file     lcd_reg.h
+ * @version  V1.00
+ * @brief    LCD register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2022 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __LCD_REG_H__
+#define __LCD_REG_H__
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup LCD Liquid-Crystal Display(LCD)
+    Memory Mapped Structure for LCD Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var LCD_T::CTL
+     * Offset: 0x00  LCD Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |EN        |LCD Display Enable Bit
+     * |        |          |0 = LCD display function Disabled.
+     * |        |          |1 = LCD display function Enabled.
+     * |        |          |Note 1: When software writes 1 to this bit, the LCD Controller needs some synchronizing time to completely enable the LCD display function
+     * |        |          |Before that, the read value of this bit is still 0.
+     * |        |          |Note 2: When software writes 0 to this bit, the LCD Controller needs some synchronizing time to completely disable the LCD display function
+     * |        |          |Before that, the read value of this bit is still 1.
+     * |[31]    |SYNC      |LCD Enable/Disable Synchronizing Indicator (Read Only)
+     * |        |          |When software writes 0/1 to EN bit (LCD_CTL[0]), the LCD Controller needs some synchronizing time to completely disable/enable the LCD display function
+     * |        |          |During this time, this bit keeps at 1.
+     * |        |          |0 = LCD display function is completely disabled/enabled.
+     * |        |          |1 = LCD display function is not yet completely disabled/enabled.
+     * |        |          |Note 1: The synchronizing time to enable LCD display function is not constant
+     * |        |          |It is between one and two cycles of CLKLCD.
+     * |        |          |Note 2: The LCD display function cannot be disabled until the end of a frame
+     * |        |          |So the maximum synchronizing time to disable LCD display function could be as long as one frame time.
+     * @var LCD_T::PSET
+     * Offset: 0x04  LCD Panel Setting Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |BIAS      |LCD Bias Level Selection
+     * |        |          |This field is used to select the bias level.
+     * |        |          |0 = Reserved.
+     * |        |          |1 = 1/2 Bias.
+     * |        |          |2 = 1/3 Bias.
+     * |        |          |3 = 1/4 Bias.
+     * |[4:2]   |DUTY      |LCD Duty Ratio Selection
+     * |        |          |This field is used to select the duty ratio.
+     * |        |          |0 = 1/1 Duty.
+     * |        |          |1 = 1/2 Duty.
+     * |        |          |2 = 1/3 Duty.
+     * |        |          |3 = 1/4 Duty.
+     * |        |          |4 = 1/5 Duty.
+     * |        |          |5 = 1/6 Duty.
+     * |        |          |6 = 1/7 Duty.
+     * |        |          |7 = 1/8 Duty.
+     * |[5]     |TYPE      |LCD Waveform Type Selection
+     * |        |          |This bit is used to select the waveform type.
+     * |        |          |0 = Type A.
+     * |        |          |1 = Type B.
+     * |[6]     |INV       |LCD Waveform Inverse
+     * |        |          |This bit is used to set the inverse LCD waveform.
+     * |        |          |0 = COM/SEG waveform is normal.
+     * |        |          |1 = COM/SEG waveform is inverse.
+     * |[17:8]  |FREQDIV   |LCD Operating Frequency (FLCD) Divider
+     * |        |          |The field is used to divide CLKLCD to generate the LCD operating frequency.
+     * |        |          |LCD Operating Frequency = (CLKLCD Frequency) / (FREQDIV + 1).
+     * |        |          |Note 1: FREQDIV can be set from 0 to 1023, therefore,
+     * |        |          |the fastest LCD operating frequency is equal to CLKLCD frequency, and
+     * |        |          |the lowest LCD operating frequency is equal to CLKLCD frequency divided by 1024.
+     * |        |          |Note 2: LCD frame rate is
+     * |        |          |(LCD Operating Frequency) x (Duty Ratio) x 1/2 for type A waveform, and
+     * |        |          |(LCD Operating Frequency) x (Duty Ratio) for type B waveform.
+     * |        |          |Example: Assuming the LCD operating frequency is 1 kHz, duty ratio is 1/4, then the LCD frame rate is
+     * |        |          |1 kHz x (1/4) x (1/2) = 125 Hz for type A waveform, and.
+     * |        |          |1 kHz x (1/4) = 250 Hz for type B waveform.
+     * |[21:18] |VSEL      |LCD Operating Voltage (VLCD) Select
+     * |        |          |This field is used to select the LCD operating voltage. (For Charge Pump Only)
+     * |        |          |0 = 3.0 V.
+     * |        |          |1 = 3.2 V.
+     * |        |          |2 = 3.4 V.
+     * |        |          |3 = 3.6 V.
+     * |        |          |4 = 3.8 V.
+     * |        |          |5 = 4.0 V.
+     * |        |          |6 = 4.2 V.
+     * |        |          |7 = 4.4 V.
+     * |        |          |8 = 4.6 V.
+     * |        |          |9 = 4.8 V.
+     * |        |          |10 = 5.0 V.
+     * |        |          |11 = 5.2 V.
+     * |        |          |Others = (Reserved).
+     * |        |          |Note: This field is meaningful only if the VLCD source is the charge pump
+     * |        |          |Otherwise, this field is ignored.
+     * |[27:24] |VTUNE     |LCD Operating Voltage (VLCD) Fine Tuning
+     * |        |          |This field is used to fine tune the LCD operating voltage. (For Charge Pump Only)
+     * |        |          |0 = No tuning.
+     * |        |          |1 = decrease by 1 unit of voltage.
+     * |        |          |2 = decrease by 2 units of voltage.
+     * |        |          |3 = decrease by 3 units of voltage.
+     * |        |          |...
+     * |        |          |7 = decrease by 7 units of voltage.
+     * |        |          |8 = increase by 8 units of voltage.
+     * |        |          |9 = increase by 7 units of voltage.
+     * |        |          |10 = increase by 6 units of voltage.
+     * |        |          |...
+     * |        |          |14 = increase by 2 units of voltage.
+     * |        |          |15 = increase by 1 unit of voltage.
+     * |        |          |Note 1: a unit of voltage is about 0.04 V.
+     * |        |          |Note 2: This field is meaningful only if the VLCD source is the charge pump
+     * |        |          |Otherwise, this field is ignored.
+     * @var LCD_T::FSET
+     * Offset: 0x08  LCD Frame Setting Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BLINK     |LCD Blinking Enable Bit
+     * |        |          |0 = LCD blinking function Disabled.
+     * |        |          |1 = LCD blinking function Enabled.
+     * |[17:8]  |FCV       |Frame Counting Value
+     * |        |          |This field indicates the maximum value that the frame counter can reach.
+     * |        |          |Note 1: The frame counter automatically increases by 1 at the end of every frame
+     * |        |          |When the counter reaches FCV, it will recounts from 0 at the end of the next frame
+     * |        |          |At this moment, the hardware sets a dedicated flag to 1, and triggers a dedicated interrupt if it is enabled.
+     * |        |          |Note 2: For type B waveform, the frame counter increases at the end of odd frames, not even frames.
+     * |[19]    |PTYPE     |Pause Type
+     * |        |          |To indicate when a pause duration occurs
+     * |        |          |0 = In-Frame Pause.
+     * |        |          |1 = In-Duty Pause.
+     * |[23:20] |PTIME     |Pause Time
+     * |        |          |To indicate how long a pause duration is
+     * |        |          |0 = 0 Unit (No Pause).
+     * |        |          |1 = 1 Unit.
+     * |        |          |2 = 2 Units.
+     * |        |          |3 = 3 Units.
+     * |        |          |...
+     * |        |          |15 = 15 Units.
+     * |        |          |1 Unit is about 512 us for In-Frame pause type.
+     * |        |          |1 Unit is about 32 us for In-Duty pause type.
+     * @var LCD_T::DSET
+     * Offset: 0x0C  LCD Driving Setting Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |VSRC      |LCD Operating Voltage (VLCD) Source
+     * |        |          |0 = VLCD Power.
+     * |        |          |1 = AVDD Power.
+     * |        |          |2 = Built-In Charge Pump.
+     * |        |          |3 = (None).
+     * |        |          |Note: Whenever the LCD controller is disabled, all VLCD sources are automatically cut off.
+     * |[2]     |RESMODE   |Resistive Network Driving Mode
+     * |        |          |0 = High-Driving Disabled.
+     * |        |          |1 = High-Driving Enabled.
+     * |[3]     |BUFEN     |Voltage Buffer Enable Bit
+     * |        |          |0 = Voltage Buffer Disabled.
+     * |        |          |1 = Voltage Buffer Enabled.
+     * |        |          |Note: When RES_MODE = 1, the voltage buffers are automatically disabled
+     * |        |          |The setting of BUF_EN bit is ignored.
+     * |[4]     |PSVEN     |Power Saving Mode Enable Bit
+     * |        |          |0 = Power Saving Mode Disabled.
+     * |        |          |1 = Power Saving Mode Enabled.
+     * |        |          |Note: when RES_MODE = 0 and BUF_EN = 0, the output drivers consumes the least driving current
+     * |        |          |In this case, the power saving mode is automatically disabled
+     * |        |          |The setting of PSV_EN bit is ignored.
+     * |[5]     |PSVREV    |Power Saving Timing Reverse
+     * |        |          |0 = Timing of power saving is normal.
+     * |        |          |1 = Timing of power saving is reversed.
+     * |        |          |Note: When the timing is reversed,
+     * |        |          |the original powe-saving period becomes no-power-saving, and
+     * |        |          |the original no-power-saving period becomes power-saving.
+     * |[11:8]  |PSVT1     |Power Saving Enable Time Setting
+     * |        |          |The Enable Time of the power saving mode is calculated as
+     * |        |          |Enable Time = 15.625 us x (PSV_T1 + 1),.
+     * |        |          |where 15.625 us is the half-cycle time of CLKLCD, whose frequency is assumed to be 32 kHz.
+     * |        |          |PSV_T1 can be set as 0, 1, 2, u2026, 15, so
+     * |        |          |the minimum Enable Time is about 15.625 us, and
+     * |        |          |the maximum Enable Time is about 15.625 x 16 = 250 us.
+     * |        |          |Note: In the following two cases, the power saving mode is disabled
+     * |        |          |The setting of PSV_T1 bits is ignored.
+     * |        |          |1. SV_EN = 0.
+     * |        |          |2. RES_MODE = 0 and BUF_EN = 0.
+     * |[15:12] |PSVT2     |Power Saving On Time Setting
+     * |        |          |The On Time of the power saving mode is calculated as
+     * |        |          |On Time = 15.625 us x (PSV_T2 + 1.),
+     * |        |          |where 15.625 us is the half-cycle time of CLKLCD, whose frequency is assumed to be 32 kHz.
+     * |        |          |PSV_T2 can be set as 0, 1, 2, u2026, 15, so
+     * |        |          |the minimum On Time is about 15.625 us, and
+     * |        |          |the maximum On Time is about 15.625 x 16 = 250 us.
+     * |        |          |Note: In the following two cases, the power saving mode is disabled
+     * |        |          |The setting of PSV_T2 bits is ignored.
+     * |        |          |1. SV_EN = 0.
+     * |        |          |2. ES_MODE = 0 and BUF_EN = 0 (In this case, SV_EN is ignored).
+     * |[28:16] |CTOUT     |Charging Timer TimeOut
+     * |        |          |This field is used to specify the timeout value for the charging timer
+     * |        |          |When the charging timer reaches this timeout value, a status bit or an interrupt will occur.
+     * |        |          |The timeout is calculated by the following formula:
+     * |        |          | Timeout = 31.25 us x (CTOUT + 1.),
+     * |        |          |where 31.25 us is the cycle time of CLKLCD, whose frequency is assumed to be 32 kHz.
+     * |        |          |CTOUT can be set as 0, 1, 2,u2026, 8191, so
+     * |        |          |the minimum timeout is 31.25 us, and
+     * |        |          |the maximum timeout is 31.25 x 8192 = 256 ms.
+     * @var LCD_T::OSET
+     * Offset: 0x10  LCD Output Setting Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SEL8      |LCD8 Output Select
+     * |        |          |0 = LCD8 is SEG43.
+     * |        |          |1 = LCD8 is COM4.
+     * |[1]     |SEL9      |LCD9 Output Select
+     * |        |          |0 = LCD9 is SEG42.
+     * |        |          |1 = LCD9 is COM5.
+     * |[2]     |SEL10     |LCD10 Output Select
+     * |        |          |0 = LCD10 is SEG20.
+     * |        |          |1 = LCD10 is COM0.
+     * |[3]     |SEL11     |LCD11 Output Select
+     * |        |          |0 = LCD11 is SEG19.
+     * |        |          |1 = LCD11 is COM1.
+     * |[4]     |SEL12     |LCD12 Output Select
+     * |        |          |0 = LCD12 is SEG18.
+     * |        |          |1 = LCD12 is COM2.
+     * |[5]     |SEL13     |LCD13 Output Select
+     * |        |          |0 = LCD13 is SEG17.
+     * |        |          |1 = LCD13 is COM3.
+     * |[6]     |SEL14     |LCD14 Output Select
+     * |        |          |0 = LCD14 is SEG41.
+     * |        |          |1 = LCD14 is COM6.
+     * |[7]     |SEL15     |LCD15 Output Select
+     * |        |          |0 = LCD15 is SEG40.
+     * |        |          |1 = LCD15 is COM7.
+     * |[8]     |SEL24     |LCD24 Output Select
+     * |        |          |0 = LCD24 is SEG31.
+     * |        |          |1 = LCD24 is COM4.
+     * |[9]     |SEL25     |LCD25 Output Select
+     * |        |          |0 = LCD25 is SEG30.
+     * |        |          |1 = LCD25 is COM5.
+     * |[10]    |SEL26     |LCD26 Output Select
+     * |        |          |0 = LCD26 is SEG29.
+     * |        |          |1 = LCD26 is COM6.
+     * |[11]    |SEL27     |LCD27 Output Select
+     * |        |          |0 = LCD27 is SEG28.
+     * |        |          |1 = LCD27 is COM7.
+     * |[12]    |SEL28     |LCD28 Output Select
+     * |        |          |0 = LCD28 is SEG27.
+     * |        |          |1 = LCD28 is COM2.
+     * |[13]    |SEL29     |LCD29 Output Select
+     * |        |          |0 = LCD29 is SEG26.
+     * |        |          |1 = LCD29 is COM3.
+     * |[15:14] |SEL35     |LCD35 Output Select
+     * |        |          |00 = LCD35 is COM4.
+     * |        |          |01 = LCD35 is SEG20.
+     * |        |          |10 = LCD35 is SEG47.
+     * |        |          |11 = Reserved.
+     * |[17:16] |SEL36     |LCD36 Output Select
+     * |        |          |00 = LCD36 is COM5.
+     * |        |          |01 = LCD36 is SEG19.
+     * |        |          |10 = LCD36 is SEG46.
+     * |        |          |11 = Reserved.
+     * |[19:18] |SEL37     |LCD37 Output Select
+     * |        |          |00 = LCD37 is COM6.
+     * |        |          |01 = LCD37 is SEG18.
+     * |        |          |10 = LCD37 is SEG45.
+     * |        |          |11 = Reserved.
+     * |[21:20] |SEL38     |LCD38 Output Select
+     * |        |          |00 = LCD38 is COM7.
+     * |        |          |01 = LCD38 is SEG17.
+     * |        |          |10 = LCD38 is SEG44.
+     * |        |          |11 = Reserved.
+     * |[22]    |SEL41     |LCD41 Output Select
+     * |        |          |0 = LCD41 is SEG14.
+     * |        |          |1 = LCD41 is COM0.
+     * |[23]    |SEL42     |LCD42 Output Select
+     * |        |          |0 = LCD42 is SEG13.
+     * |        |          |1 = LCD42 is COM1.
+     * |[24]    |SEL47     |LCD47 Output Select
+     * |        |          |0 = LCD47 is SEG08.
+     * |        |          |1 = LCD47 is LCD_V1.
+     * |[25]    |SEL48     |LCD48 Output Select
+     * |        |          |0 = LCD48 is SEG07.
+     * |        |          |1 = LCD48 is LCD_V2.
+     * |[26]    |SEL49     |LCD49 Output Select
+     * |        |          |0 = LCD49 is SEG06.
+     * |        |          |1 = LCD49 is LCD_V3.
+     * @var LCD_T::STS
+     * Offset: 0x14  LCD Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |FCEND     |End of Frame-Counting Flag
+     * |        |          |This flag is automatically set by hardware at the end of a frame, and the frame counter value must be equal to FCV (LCD_FSET[17:8], Frame Counting Value).
+     * |        |          |0 = End of Frame-Counting did not occur.
+     * |        |          |1 = End of Frame-Counting occurred.
+     * |        |          |Note 1: Software can clear this bit by writing 1 to it.
+     * |        |          |Note 2: For type B waveform, this flag is set only at the end of an odd frame.
+     * |[1]     |FEND      |End of Frame Flag
+     * |        |          |This flag is automatically set by hardware at the end of a frame.
+     * |        |          |0 = End of Frame did not occur.
+     * |        |          |1 = End of Frame occurred.
+     * |        |          |Note 1: Software can clear this bit by writing 1 to it.
+     * |        |          |Note 2: For type B waveform, this flag is set only at the end of an odd frame.
+     * |[2]     |CTOUT     |Charging Timeout Flag
+     * |        |          |This flag is automatically set by hardware when the charging timer reaches the timeout value.
+     * |        |          |0 = Charging Timeout did not occur.
+     * |        |          |1 = Charging Timeout occurred.
+     * |        |          |Note: Software can clear this bit by writing 1 to it.
+     * |[28:16] |CTIME     |Charging Timer Value (Read Only)
+     * |        |          |The field contains the value of the charging timer. It records the charging time of the charge pump.
+     * |        |          |The charging timer stops counting when the charge pump stops charging or a timeout occurs
+     * |        |          |At this moment, the hardware dumps the current charging timer value into this field.
+     * |        |          |Charging Time = 31.25 us x (CTIME + 1), where 31.25 us is the cycle time of CLKLCD, whose frequency is assumed to be 32 kHz.
+     * @var LCD_T::INTEN
+     * Offset: 0x18  LCD Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |FCEND     |End of Frame-Counting Interrupt Enable Bit
+     * |        |          |An interrupt occurs at the end of a frame, and the frame counter value must be equal to FCV (LCD_FSET[17:8], Frame Counting Value).
+     * |        |          |0 = End of Frame-Counting Interrupt Disabled.
+     * |        |          |1 = End of Frame-Counting Interrupt Enabled.
+     * |        |          |Note: For type B waveform, the interrupt occurs only at the end of an odd frame.
+     * |[1]     |FEND      |End of Frame Interrupt Enable Bit
+     * |        |          |An interrupt occurs at the end of a frame.
+     * |        |          |0 = End of Frame Interrupt Disabled.
+     * |        |          |1 = End of Frame Interrupt Enabled.
+     * |        |          |Note: For type B waveform, the interrupt occurs only at the end of an odd frame.
+     * |[3]     |CTOUT     |Charging Timeout Interrupt Enable Bit
+     * |        |          |An interrupt occurs when the charging timer reaches the timeout value.
+     * |        |          |0 = Charging Timeout Interrupt Disabled.
+     * |        |          |1 = Charging Timeout Interrupt Enabled.
+     * @var LCD_T::DATA
+     * Offset: 0x20  LCD Segment Display Data Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x24  LCD Segment Display Data Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x28  LCD Segment Display Data Register 2
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x2C  LCD Segment Display Data Register 3
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x30  LCD Segment Display Data Register 4
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x34  LCD Segment Display Data Register 5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x38  LCD Segment Display Data Register 6
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x3C  LCD Segment Display Data Register 7
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x40  LCD Segment Display Data Register 8
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x44  LCD Segment Display Data Register 9
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x48  LCD Segment Display Data Register 10
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     * Offset: 0x4C  LCD Segment Display Data Register 11
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DD0       |Display Data of Segments S, where S is (4 x N) + 0, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD0 corresponds to SEG00, SEG04, SEG08, SEG12, SEG16, SEG20, SEG24, SEG28, SEG32, SEG36, SEG40, and SEG44.
+     * |        |          |Note 2: Each bit, DD0[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD0 (= LCD_DATA07[7:0]) = 1001_0110.
+     * |        |          |LCD_DATA07[7:0] corresponds to SEG28 (4 x 7 + 0 = 2.8)
+     * |        |          |the pixel SEG28-COM0 is light (LCD_DATA07[0] = .0)
+     * |        |          |the pixel SEG28-COM1 is dark (LCD_DATA07[1] = .1)
+     * |        |          |the pixel SEG28-COM2 is dark (LCD_DATA07[2] = .1)
+     * |        |          |the pixel SEG28-COM3 is light (LCD_DATA07[3] = .0)
+     * |        |          |LCD_DATA07[7:4] are ignored, since COMs from 4 to 7 are not used.
+     * |[15:8]  |DD1       |Display Data of Segments S, where S is (4 x N) + 1, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD1 corresponds to SEG01, SEG05, SEG09, SEG13, SEG17, SEG21, SEG25, SEG29, SEG33, SEG37, SEG41, and SEG45.
+     * |        |          |Note 2: Each bit, DD1[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD1 (= LCD_DATA07[15:8]) = 1001_0110.
+     * |        |          |LCD_DATA07[15:8] corresponds to SEG29 (4 x 7 + 1 = 2.9)
+     * |        |          |the pixel SEG29-COM0 is light (LCD_DATA07[8] = .0)
+     * |        |          |the pixel SEG29-COM1 is dark (LCD_DATA07[9] = .1)
+     * |        |          |the pixel SEG29-COM2 is dark (LCD_DATA07[10] = .1)
+     * |        |          |the pixel SEG29-COM3 is light (LCD_DATA07[11] = .0)
+     * |        |          |LCD_DATA07[15:12] are ignored, since COMs from 4 to 7 are not used.
+     * |[23:16] |DD2       |Display Data of Segments S, where S is (4 x N) + 2, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = the pixel is light.
+     * |        |          |1 = the pixel is dark.
+     * |        |          |Note 1: DD2 corresponds to SEG02, SEG06, SEG10, SEG14, SEG18, SEG22, SEG26, SEG30, SEG34, SEG38, SEG42, and SEG46.
+     * |        |          |Note 2: Each bit, DD2[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD2 (= LCD_DATA07[23:16]) = 1001_0110.
+     * |        |          |LCD_DATA07[23:16] corresponds to SEG30 (4 x 7 + 2 = 3.0)
+     * |        |          |the pixel SEG30-COM0 is light (LCD_DATA07[16] = .0)
+     * |        |          |the pixel SEG30-COM1 is dark (LCD_DATA07[17] = .1)
+     * |        |          |the pixel SEG30-COM2 is dark (LCD_DATA07[18] = .1)
+     * |        |          |the pixel SEG30-COM3 is light (LCD_DATA07[19] = .0)
+     * |        |          |LCD_DATA07[23:20] are ignored, since COMs from 4 to 7 are not used.
+     * |[31:24] |DD3       |Display Data of Segments S, where S is (4 x N) + 3, and N is 0, 1, 2, u2026, 11
+     * |        |          |Each bit specifies the brightness of each pixel in a segment.
+     * |        |          |0 = The pixel is light.
+     * |        |          |1 = The pixel is dark.
+     * |        |          |Note 1: DD3 corresponds to SEG03, SEG07, SEG11, SEG15, SEG19, SEG23, SEG27, SEG31, SEG35, SEG39, SEG43, and SEG47.
+     * |        |          |Note 2: Each bit, DD3[n], corresponds to COMn, n = 0-7.
+     * |        |          |[Example] Assuming 1/4 Duty, and DD3 (= LCD_DATA07[31:24]) = 1001_0110.
+     * |        |          |LCD_DATA07[31:24] corresponds to SEG31 (4 x 7 + 3 = 3.1)
+     * |        |          |the pixel SEG31-COM0 is light (LCD_DATA07[24] = .0)
+     * |        |          |the pixel SEG31-COM1 is dark (LCD_DATA07[25] = .1)
+     * |        |          |the pixel SEG31-COM2 is dark (LCD_DATA07[26] = .1)
+     * |        |          |the pixel SEG31-COM3 is light (LCD_DATA07[27] = .0)
+     * |        |          |LCD_DATA07[31:28] are ignored, since COMs from 4 to 7 are not used.
+     */
+
+    __IO uint32_t CTL;                   /*!< [0x0000] LCD Control Register                                             */
+    __IO uint32_t PSET;                  /*!< [0x0004] LCD Panel Setting Register                                       */
+    __IO uint32_t FSET;                  /*!< [0x0008] LCD Frame Setting Register                                       */
+    __IO uint32_t DSET;                  /*!< [0x000c] LCD Driving Setting Register                                     */
+    __IO uint32_t OSET;                  /*!< [0x0010] LCD Output Setting Register                                      */
+    __IO uint32_t STS;                   /*!< [0x0014] LCD Status Register                                              */
+    __IO uint32_t INTEN;                 /*!< [0x0018] LCD Interrupt Enable Register                                    */
+    __I  uint32_t RESERVE0;
+    __IO uint32_t DATA[12];              /*!< [0x0020- 0x004C] LCD Segment Display Data Register 0-11                   */
+
+} LCD_T;
+
+/**
+    @addtogroup LCD_CONST LCD Bit Field Definition
+    Constant Definitions for LCD Controller
+@{ */
+
+#define LCD_CTL_EN_Pos                   (0)                                               /*!< LCD_T::CTL: EN Position                */
+#define LCD_CTL_EN_Msk                   (0x1ul << LCD_CTL_EN_Pos)                         /*!< LCD_T::CTL: EN Mask                    */
+
+#define LCD_CTL_SYNC_Pos                 (31)                                              /*!< LCD_T::CTL: SYNC Position              */
+#define LCD_CTL_SYNC_Msk                 (0x1ul << LCD_CTL_SYNC_Pos)                       /*!< LCD_T::CTL: SYNC Mask                  */
+
+#define LCD_PSET_BIAS_Pos                (0)                                               /*!< LCD_T::PSET: BIAS Position             */
+#define LCD_PSET_BIAS_Msk                (0x3ul << LCD_PSET_BIAS_Pos)                      /*!< LCD_T::PSET: BIAS Mask                 */
+
+#define LCD_PSET_DUTY_Pos                (2)                                               /*!< LCD_T::PSET: DUTY Position             */
+#define LCD_PSET_DUTY_Msk                (0x7ul << LCD_PSET_DUTY_Pos)                      /*!< LCD_T::PSET: DUTY Mask                 */
+
+#define LCD_PSET_TYPE_Pos                (5)                                               /*!< LCD_T::PSET: TYPE Position             */
+#define LCD_PSET_TYPE_Msk                (0x1ul << LCD_PSET_TYPE_Pos)                      /*!< LCD_T::PSET: TYPE Mask                 */
+
+#define LCD_PSET_INV_Pos                 (6)                                               /*!< LCD_T::PSET: INV Position              */
+#define LCD_PSET_INV_Msk                 (0x1ul << LCD_PSET_INV_Pos)                       /*!< LCD_T::PSET: INV Mask                  */
+
+#define LCD_PSET_FREQDIV_Pos             (8)                                               /*!< LCD_T::PSET: FREQDIV Position          */
+#define LCD_PSET_FREQDIV_Msk             (0x3fful << LCD_PSET_FREQDIV_Pos)                 /*!< LCD_T::PSET: FREQDIV Mask              */
+
+#define LCD_PSET_VSEL_Pos                (18)                                              /*!< LCD_T::PSET: VSEL Position             */
+#define LCD_PSET_VSEL_Msk                (0xful << LCD_PSET_VSEL_Pos)                      /*!< LCD_T::PSET: VSEL Mask                 */
+
+#define LCD_PSET_VTUNE_Pos               (24)                                              /*!< LCD_T::PSET: VTUNE Position            */
+#define LCD_PSET_VTUNE_Msk               (0xful << LCD_PSET_VTUNE_Pos)                     /*!< LCD_T::PSET: VTUNE Mask                */
+
+#define LCD_FSET_BLINK_Pos               (0)                                               /*!< LCD_T::FSET: BLINK Position            */
+#define LCD_FSET_BLINK_Msk               (0x1ul << LCD_FSET_BLINK_Pos)                     /*!< LCD_T::FSET: BLINK Mask                */
+
+#define LCD_FSET_FCV_Pos                 (8)                                               /*!< LCD_T::FSET: FCV Position              */
+#define LCD_FSET_FCV_Msk                 (0x3fful << LCD_FSET_FCV_Pos)                     /*!< LCD_T::FSET: FCV Mask                  */
+
+#define LCD_FSET_PTYPE_Pos               (19)                                              /*!< LCD_T::FSET: PTYPE Position            */
+#define LCD_FSET_PTYPE_Msk               (0x1ul << LCD_FSET_PTYPE_Pos)                     /*!< LCD_T::FSET: PTYPE Mask                */
+
+#define LCD_FSET_PTIME_Pos               (20)                                              /*!< LCD_T::FSET: PTIME Position            */
+#define LCD_FSET_PTIME_Msk               (0xful << LCD_FSET_PTIME_Pos)                     /*!< LCD_T::FSET: PTIME Mask                */
+
+#define LCD_DSET_VSRC_Pos                (0)                                               /*!< LCD_T::DSET: VSRC Position             */
+#define LCD_DSET_VSRC_Msk                (0x3ul << LCD_DSET_VSRC_Pos)                      /*!< LCD_T::DSET: VSRC Mask                 */
+
+#define LCD_DSET_RESMODE_Pos             (2)                                               /*!< LCD_T::DSET: RESMODE Position          */
+#define LCD_DSET_RESMODE_Msk             (0x1ul << LCD_DSET_RESMODE_Pos)                   /*!< LCD_T::DSET: RESMODE Mask              */
+
+#define LCD_DSET_BUFEN_Pos               (3)                                               /*!< LCD_T::DSET: BUFEN Position            */
+#define LCD_DSET_BUFEN_Msk               (0x1ul << LCD_DSET_BUFEN_Pos)                     /*!< LCD_T::DSET: BUFEN Mask                */
+
+#define LCD_DSET_PSVEN_Pos               (4)                                               /*!< LCD_T::DSET: PSVEN Position            */
+#define LCD_DSET_PSVEN_Msk               (0x1ul << LCD_DSET_PSVEN_Pos)                     /*!< LCD_T::DSET: PSVEN Mask                */
+
+#define LCD_DSET_PSVREV_Pos              (5)                                               /*!< LCD_T::DSET: PSVREV Position           */
+#define LCD_DSET_PSVREV_Msk              (0x1ul << LCD_DSET_PSVREV_Pos)                    /*!< LCD_T::DSET: PSVREV Mask               */
+
+#define LCD_DSET_PSVT1_Pos               (8)                                               /*!< LCD_T::DSET: PSVT1 Position            */
+#define LCD_DSET_PSVT1_Msk               (0xful << LCD_DSET_PSVT1_Pos)                     /*!< LCD_T::DSET: PSVT1 Mask                */
+
+#define LCD_DSET_PSVT2_Pos               (12)                                              /*!< LCD_T::DSET: PSVT2 Position            */
+#define LCD_DSET_PSVT2_Msk               (0xful << LCD_DSET_PSVT2_Pos)                     /*!< LCD_T::DSET: PSVT2 Mask                */
+
+#define LCD_DSET_CTOUT_Pos               (16)                                              /*!< LCD_T::DSET: CTOUT Position            */
+#define LCD_DSET_CTOUT_Msk               (0x1ffful << LCD_DSET_CTOUT_Pos)                  /*!< LCD_T::DSET: CTOUT Mask                */
+
+#define LCD_OSET_SEL8_Pos                (0)                                               /*!< LCD_T::OSET: SEL8 Position             */
+#define LCD_OSET_SEL8_Msk                (0x1ul << LCD_OSET_SEL8_Pos)                      /*!< LCD_T::OSET: SEL8 Mask                 */
+
+#define LCD_OSET_SEL9_Pos                (1)                                               /*!< LCD_T::OSET: SEL9 Position             */
+#define LCD_OSET_SEL9_Msk                (0x1ul << LCD_OSET_SEL9_Pos)                      /*!< LCD_T::OSET: SEL9 Mask                 */
+
+#define LCD_OSET_SEL10_Pos               (2)                                               /*!< LCD_T::OSET: SEL10 Position            */
+#define LCD_OSET_SEL10_Msk               (0x1ul << LCD_OSET_SEL10_Pos)                     /*!< LCD_T::OSET: SEL10 Mask                */
+
+#define LCD_OSET_SEL11_Pos               (3)                                               /*!< LCD_T::OSET: SEL11 Position            */
+#define LCD_OSET_SEL11_Msk               (0x1ul << LCD_OSET_SEL11_Pos)                     /*!< LCD_T::OSET: SEL11 Mask                */
+
+#define LCD_OSET_SEL12_Pos               (4)                                               /*!< LCD_T::OSET: SEL12 Position            */
+#define LCD_OSET_SEL12_Msk               (0x1ul << LCD_OSET_SEL12_Pos)                     /*!< LCD_T::OSET: SEL12 Mask                */
+
+#define LCD_OSET_SEL13_Pos               (5)                                               /*!< LCD_T::OSET: SEL13 Position            */
+#define LCD_OSET_SEL13_Msk               (0x1ul << LCD_OSET_SEL13_Pos)                     /*!< LCD_T::OSET: SEL13 Mask                */
+
+#define LCD_OSET_SEL14_Pos               (6)                                               /*!< LCD_T::OSET: SEL14 Position            */
+#define LCD_OSET_SEL14_Msk               (0x1ul << LCD_OSET_SEL14_Pos)                     /*!< LCD_T::OSET: SEL14 Mask                */
+
+#define LCD_OSET_SEL15_Pos               (7)                                               /*!< LCD_T::OSET: SEL15 Position            */
+#define LCD_OSET_SEL15_Msk               (0x1ul << LCD_OSET_SEL15_Pos)                     /*!< LCD_T::OSET: SEL15 Mask                */
+
+#define LCD_OSET_SEL24_Pos               (8)                                               /*!< LCD_T::OSET: SEL24 Position            */
+#define LCD_OSET_SEL24_Msk               (0x1ul << LCD_OSET_SEL24_Pos)                     /*!< LCD_T::OSET: SEL24 Mask                */
+
+#define LCD_OSET_SEL25_Pos               (9)                                               /*!< LCD_T::OSET: SEL25 Position            */
+#define LCD_OSET_SEL25_Msk               (0x1ul << LCD_OSET_SEL25_Pos)                     /*!< LCD_T::OSET: SEL25 Mask                */
+
+#define LCD_OSET_SEL26_Pos               (10)                                              /*!< LCD_T::OSET: SEL26 Position            */
+#define LCD_OSET_SEL26_Msk               (0x1ul << LCD_OSET_SEL26_Pos)                     /*!< LCD_T::OSET: SEL26 Mask                */
+
+#define LCD_OSET_SEL27_Pos               (11)                                              /*!< LCD_T::OSET: SEL27 Position            */
+#define LCD_OSET_SEL27_Msk               (0x1ul << LCD_OSET_SEL27_Pos)                     /*!< LCD_T::OSET: SEL27 Mask                */
+
+#define LCD_OSET_SEL28_Pos               (12)                                              /*!< LCD_T::OSET: SEL28 Position            */
+#define LCD_OSET_SEL28_Msk               (0x1ul << LCD_OSET_SEL28_Pos)                     /*!< LCD_T::OSET: SEL28 Mask                */
+
+#define LCD_OSET_SEL29_Pos               (13)                                              /*!< LCD_T::OSET: SEL29 Position            */
+#define LCD_OSET_SEL29_Msk               (0x1ul << LCD_OSET_SEL29_Pos)                     /*!< LCD_T::OSET: SEL29 Mask                */
+
+#define LCD_OSET_SEL35_Pos               (14)                                              /*!< LCD_T::OSET: SEL35 Position            */
+#define LCD_OSET_SEL35_Msk               (0x3ul << LCD_OSET_SEL35_Pos)                     /*!< LCD_T::OSET: SEL35 Mask                */
+
+#define LCD_OSET_SEL36_Pos               (16)                                              /*!< LCD_T::OSET: SEL36 Position            */
+#define LCD_OSET_SEL36_Msk               (0x3ul << LCD_OSET_SEL36_Pos)                     /*!< LCD_T::OSET: SEL36 Mask                */
+
+#define LCD_OSET_SEL37_Pos               (18)                                              /*!< LCD_T::OSET: SEL37 Position            */
+#define LCD_OSET_SEL37_Msk               (0x3ul << LCD_OSET_SEL37_Pos)                     /*!< LCD_T::OSET: SEL37 Mask                */
+
+#define LCD_OSET_SEL38_Pos               (20)                                              /*!< LCD_T::OSET: SEL38 Position            */
+#define LCD_OSET_SEL38_Msk               (0x3ul << LCD_OSET_SEL38_Pos)                     /*!< LCD_T::OSET: SEL38 Mask                */
+
+#define LCD_OSET_SEL41_Pos               (22)                                              /*!< LCD_T::OSET: SEL41 Position            */
+#define LCD_OSET_SEL41_Msk               (0x1ul << LCD_OSET_SEL41_Pos)                     /*!< LCD_T::OSET: SEL41 Mask                */
+
+#define LCD_OSET_SEL42_Pos               (23)                                              /*!< LCD_T::OSET: SEL42 Position            */
+#define LCD_OSET_SEL42_Msk               (0x1ul << LCD_OSET_SEL42_Pos)                     /*!< LCD_T::OSET: SEL42 Mask                */
+
+#define LCD_OSET_SEL47_Pos               (24)                                              /*!< LCD_T::OSET: SEL47 Position            */
+#define LCD_OSET_SEL47_Msk               (0x1ul << LCD_OSET_SEL47_Pos)                     /*!< LCD_T::OSET: SEL47 Mask                */
+
+#define LCD_OSET_SEL48_Pos               (25)                                              /*!< LCD_T::OSET: SEL48 Position            */
+#define LCD_OSET_SEL48_Msk               (0x1ul << LCD_OSET_SEL48_Pos)                     /*!< LCD_T::OSET: SEL48 Mask                */
+
+#define LCD_OSET_SEL49_Pos               (26)                                              /*!< LCD_T::OSET: SEL49 Position            */
+#define LCD_OSET_SEL49_Msk               (0x1ul << LCD_OSET_SEL49_Pos)                     /*!< LCD_T::OSET: SEL49 Mask                */
+
+#define LCD_STS_FCEND_Pos                (0)                                               /*!< LCD_T::STS: FCEND Position             */
+#define LCD_STS_FCEND_Msk                (0x1ul << LCD_STS_FCEND_Pos)                      /*!< LCD_T::STS: FCEND Mask                 */
+
+#define LCD_STS_FEND_Pos                 (1)                                               /*!< LCD_T::STS: FEND Position              */
+#define LCD_STS_FEND_Msk                 (0x1ul << LCD_STS_FEND_Pos)                       /*!< LCD_T::STS: FEND Mask                  */
+
+#define LCD_STS_CTOUT_Pos                (2)                                               /*!< LCD_T::STS: CTOUT Position             */
+#define LCD_STS_CTOUT_Msk                (0x1ul << LCD_STS_CTOUT_Pos)                      /*!< LCD_T::STS: CTOUT Mask                 */
+
+#define LCD_STS_CTIME_Pos                (16)                                              /*!< LCD_T::STS: CTIME Position             */
+#define LCD_STS_CTIME_Msk                (0x1ffful << LCD_STS_CTIME_Pos)                   /*!< LCD_T::STS: CTIME Mask                 */
+
+#define LCD_INTEN_FCEND_Pos              (0)                                               /*!< LCD_T::INTEN: FCEND Position           */
+#define LCD_INTEN_FCEND_Msk              (0x1ul << LCD_INTEN_FCEND_Pos)                    /*!< LCD_T::INTEN: FCEND Mask               */
+
+#define LCD_INTEN_FEND_Pos               (1)                                               /*!< LCD_T::INTEN: FEND Position            */
+#define LCD_INTEN_FEND_Msk               (0x1ul << LCD_INTEN_FEND_Pos)                     /*!< LCD_T::INTEN: FEND Mask                */
+
+#define LCD_INTEN_CTOUT_Pos              (2)                                               /*!< LCD_T::INTEN: CTOUT Position           */
+#define LCD_INTEN_CTOUT_Msk              (0x1ul << LCD_INTEN_CTOUT_Pos)                    /*!< LCD_T::INTEN: CTOUT Mask               */
+
+#define LCD_DATA00_DD0_Pos               (0)                                               /*!< LCD_T::DATA00: DD0 Position            */
+#define LCD_DATA00_DD0_Msk               (0xfful << LCD_DATA00_DD0_Pos)                    /*!< LCD_T::DATA00: DD0 Mask                */
+
+#define LCD_DATA00_DD1_Pos               (8)                                               /*!< LCD_T::DATA00: DD1 Position            */
+#define LCD_DATA00_DD1_Msk               (0xfful << LCD_DATA00_DD1_Pos)                    /*!< LCD_T::DATA00: DD1 Mask                */
+
+#define LCD_DATA00_DD2_Pos               (16)                                              /*!< LCD_T::DATA00: DD2 Position            */
+#define LCD_DATA00_DD2_Msk               (0xfful << LCD_DATA00_DD2_Pos)                    /*!< LCD_T::DATA00: DD2 Mask                */
+
+#define LCD_DATA00_DD3_Pos               (24)                                              /*!< LCD_T::DATA00: DD3 Position            */
+#define LCD_DATA00_DD3_Msk               (0xfful << LCD_DATA00_DD3_Pos)                    /*!< LCD_T::DATA00: DD3 Mask                */
+
+#define LCD_DATA01_DD0_Pos               (0)                                               /*!< LCD_T::DATA01: DD0 Position            */
+#define LCD_DATA01_DD0_Msk               (0xfful << LCD_DATA01_DD0_Pos)                    /*!< LCD_T::DATA01: DD0 Mask                */
+
+#define LCD_DATA01_DD1_Pos               (8)                                               /*!< LCD_T::DATA01: DD1 Position            */
+#define LCD_DATA01_DD1_Msk               (0xfful << LCD_DATA01_DD1_Pos)                    /*!< LCD_T::DATA01: DD1 Mask                */
+
+#define LCD_DATA01_DD2_Pos               (16)                                              /*!< LCD_T::DATA01: DD2 Position            */
+#define LCD_DATA01_DD2_Msk               (0xfful << LCD_DATA01_DD2_Pos)                    /*!< LCD_T::DATA01: DD2 Mask                */
+
+#define LCD_DATA01_DD3_Pos               (24)                                              /*!< LCD_T::DATA01: DD3 Position            */
+#define LCD_DATA01_DD3_Msk               (0xfful << LCD_DATA01_DD3_Pos)                    /*!< LCD_T::DATA01: DD3 Mask                */
+
+#define LCD_DATA02_DD0_Pos               (0)                                               /*!< LCD_T::DATA02: DD0 Position            */
+#define LCD_DATA02_DD0_Msk               (0xfful << LCD_DATA02_DD0_Pos)                    /*!< LCD_T::DATA02: DD0 Mask                */
+
+#define LCD_DATA02_DD1_Pos               (8)                                               /*!< LCD_T::DATA02: DD1 Position            */
+#define LCD_DATA02_DD1_Msk               (0xfful << LCD_DATA02_DD1_Pos)                    /*!< LCD_T::DATA02: DD1 Mask                */
+
+#define LCD_DATA02_DD2_Pos               (16)                                              /*!< LCD_T::DATA02: DD2 Position            */
+#define LCD_DATA02_DD2_Msk               (0xfful << LCD_DATA02_DD2_Pos)                    /*!< LCD_T::DATA02: DD2 Mask                */
+
+#define LCD_DATA02_DD3_Pos               (24)                                              /*!< LCD_T::DATA02: DD3 Position            */
+#define LCD_DATA02_DD3_Msk               (0xfful << LCD_DATA02_DD3_Pos)                    /*!< LCD_T::DATA02: DD3 Mask                */
+
+#define LCD_DATA03_DD0_Pos               (0)                                               /*!< LCD_T::DATA03: DD0 Position            */
+#define LCD_DATA03_DD0_Msk               (0xfful << LCD_DATA03_DD0_Pos)                    /*!< LCD_T::DATA03: DD0 Mask                */
+
+#define LCD_DATA03_DD1_Pos               (8)                                               /*!< LCD_T::DATA03: DD1 Position            */
+#define LCD_DATA03_DD1_Msk               (0xfful << LCD_DATA03_DD1_Pos)                    /*!< LCD_T::DATA03: DD1 Mask                */
+
+#define LCD_DATA03_DD2_Pos               (16)                                              /*!< LCD_T::DATA03: DD2 Position            */
+#define LCD_DATA03_DD2_Msk               (0xfful << LCD_DATA03_DD2_Pos)                    /*!< LCD_T::DATA03: DD2 Mask                */
+
+#define LCD_DATA03_DD3_Pos               (24)                                              /*!< LCD_T::DATA03: DD3 Position            */
+#define LCD_DATA03_DD3_Msk               (0xfful << LCD_DATA03_DD3_Pos)                    /*!< LCD_T::DATA03: DD3 Mask                */
+
+#define LCD_DATA04_DD0_Pos               (0)                                               /*!< LCD_T::DATA04: DD0 Position            */
+#define LCD_DATA04_DD0_Msk               (0xfful << LCD_DATA04_DD0_Pos)                    /*!< LCD_T::DATA04: DD0 Mask                */
+
+#define LCD_DATA04_DD1_Pos               (8)                                               /*!< LCD_T::DATA04: DD1 Position            */
+#define LCD_DATA04_DD1_Msk               (0xfful << LCD_DATA04_DD1_Pos)                    /*!< LCD_T::DATA04: DD1 Mask                */
+
+#define LCD_DATA04_DD2_Pos               (16)                                              /*!< LCD_T::DATA04: DD2 Position            */
+#define LCD_DATA04_DD2_Msk               (0xfful << LCD_DATA04_DD2_Pos)                    /*!< LCD_T::DATA04: DD2 Mask                */
+
+#define LCD_DATA04_DD3_Pos               (24)                                              /*!< LCD_T::DATA04: DD3 Position            */
+#define LCD_DATA04_DD3_Msk               (0xfful << LCD_DATA04_DD3_Pos)                    /*!< LCD_T::DATA04: DD3 Mask                */
+
+#define LCD_DATA05_DD0_Pos               (0)                                               /*!< LCD_T::DATA05: DD0 Position            */
+#define LCD_DATA05_DD0_Msk               (0xfful << LCD_DATA05_DD0_Pos)                    /*!< LCD_T::DATA05: DD0 Mask                */
+
+#define LCD_DATA05_DD1_Pos               (8)                                               /*!< LCD_T::DATA05: DD1 Position            */
+#define LCD_DATA05_DD1_Msk               (0xfful << LCD_DATA05_DD1_Pos)                    /*!< LCD_T::DATA05: DD1 Mask                */
+
+#define LCD_DATA05_DD2_Pos               (16)                                              /*!< LCD_T::DATA05: DD2 Position            */
+#define LCD_DATA05_DD2_Msk               (0xfful << LCD_DATA05_DD2_Pos)                    /*!< LCD_T::DATA05: DD2 Mask                */
+
+#define LCD_DATA05_DD3_Pos               (24)                                              /*!< LCD_T::DATA05: DD3 Position            */
+#define LCD_DATA05_DD3_Msk               (0xfful << LCD_DATA05_DD3_Pos)                    /*!< LCD_T::DATA05: DD3 Mask                */
+
+#define LCD_DATA06_DD0_Pos               (0)                                               /*!< LCD_T::DATA06: DD0 Position            */
+#define LCD_DATA06_DD0_Msk               (0xfful << LCD_DATA06_DD0_Pos)                    /*!< LCD_T::DATA06: DD0 Mask                */
+
+#define LCD_DATA06_DD1_Pos               (8)                                               /*!< LCD_T::DATA06: DD1 Position            */
+#define LCD_DATA06_DD1_Msk               (0xfful << LCD_DATA06_DD1_Pos)                    /*!< LCD_T::DATA06: DD1 Mask                */
+
+#define LCD_DATA06_DD2_Pos               (16)                                              /*!< LCD_T::DATA06: DD2 Position            */
+#define LCD_DATA06_DD2_Msk               (0xfful << LCD_DATA06_DD2_Pos)                    /*!< LCD_T::DATA06: DD2 Mask                */
+
+#define LCD_DATA06_DD3_Pos               (24)                                              /*!< LCD_T::DATA06: DD3 Position            */
+#define LCD_DATA06_DD3_Msk               (0xfful << LCD_DATA06_DD3_Pos)                    /*!< LCD_T::DATA06: DD3 Mask                */
+
+#define LCD_DATA07_DD0_Pos               (0)                                               /*!< LCD_T::DATA07: DD0 Position            */
+#define LCD_DATA07_DD0_Msk               (0xfful << LCD_DATA07_DD0_Pos)                    /*!< LCD_T::DATA07: DD0 Mask                */
+
+#define LCD_DATA07_DD1_Pos               (8)                                               /*!< LCD_T::DATA07: DD1 Position            */
+#define LCD_DATA07_DD1_Msk               (0xfful << LCD_DATA07_DD1_Pos)                    /*!< LCD_T::DATA07: DD1 Mask                */
+
+#define LCD_DATA07_DD2_Pos               (16)                                              /*!< LCD_T::DATA07: DD2 Position            */
+#define LCD_DATA07_DD2_Msk               (0xfful << LCD_DATA07_DD2_Pos)                    /*!< LCD_T::DATA07: DD2 Mask                */
+
+#define LCD_DATA07_DD3_Pos               (24)                                              /*!< LCD_T::DATA07: DD3 Position            */
+#define LCD_DATA07_DD3_Msk               (0xfful << LCD_DATA07_DD3_Pos)                    /*!< LCD_T::DATA07: DD3 Mask                */
+
+#define LCD_DATA08_DD0_Pos               (0)                                               /*!< LCD_T::DATA08: DD0 Position            */
+#define LCD_DATA08_DD0_Msk               (0xfful << LCD_DATA08_DD0_Pos)                    /*!< LCD_T::DATA08: DD0 Mask                */
+
+#define LCD_DATA08_DD1_Pos               (8)                                               /*!< LCD_T::DATA08: DD1 Position            */
+#define LCD_DATA08_DD1_Msk               (0xfful << LCD_DATA08_DD1_Pos)                    /*!< LCD_T::DATA08: DD1 Mask                */
+
+#define LCD_DATA08_DD2_Pos               (16)                                              /*!< LCD_T::DATA08: DD2 Position            */
+#define LCD_DATA08_DD2_Msk               (0xfful << LCD_DATA08_DD2_Pos)                    /*!< LCD_T::DATA08: DD2 Mask                */
+
+#define LCD_DATA08_DD3_Pos               (24)                                              /*!< LCD_T::DATA08: DD3 Position            */
+#define LCD_DATA08_DD3_Msk               (0xfful << LCD_DATA08_DD3_Pos)                    /*!< LCD_T::DATA08: DD3 Mask                */
+
+#define LCD_DATA09_DD0_Pos               (0)                                               /*!< LCD_T::DATA09: DD0 Position            */
+#define LCD_DATA09_DD0_Msk               (0xfful << LCD_DATA09_DD0_Pos)                    /*!< LCD_T::DATA09: DD0 Mask                */
+
+#define LCD_DATA09_DD1_Pos               (8)                                               /*!< LCD_T::DATA09: DD1 Position            */
+#define LCD_DATA09_DD1_Msk               (0xfful << LCD_DATA09_DD1_Pos)                    /*!< LCD_T::DATA09: DD1 Mask                */
+
+#define LCD_DATA09_DD2_Pos               (16)                                              /*!< LCD_T::DATA09: DD2 Position            */
+#define LCD_DATA09_DD2_Msk               (0xfful << LCD_DATA09_DD2_Pos)                    /*!< LCD_T::DATA09: DD2 Mask                */
+
+#define LCD_DATA09_DD3_Pos               (24)                                              /*!< LCD_T::DATA09: DD3 Position            */
+#define LCD_DATA09_DD3_Msk               (0xfful << LCD_DATA09_DD3_Pos)                    /*!< LCD_T::DATA09: DD3 Mask                */
+
+#define LCD_DATA10_DD0_Pos               (0)                                               /*!< LCD_T::DATA10: DD0 Position            */
+#define LCD_DATA10_DD0_Msk               (0xfful << LCD_DATA10_DD0_Pos)                    /*!< LCD_T::DATA10: DD0 Mask                */
+
+#define LCD_DATA10_DD1_Pos               (8)                                               /*!< LCD_T::DATA10: DD1 Position            */
+#define LCD_DATA10_DD1_Msk               (0xfful << LCD_DATA10_DD1_Pos)                    /*!< LCD_T::DATA10: DD1 Mask                */
+
+#define LCD_DATA10_DD2_Pos               (16)                                              /*!< LCD_T::DATA10: DD2 Position            */
+#define LCD_DATA10_DD2_Msk               (0xfful << LCD_DATA10_DD2_Pos)                    /*!< LCD_T::DATA10: DD2 Mask                */
+
+#define LCD_DATA10_DD3_Pos               (24)                                              /*!< LCD_T::DATA10: DD3 Position            */
+#define LCD_DATA10_DD3_Msk               (0xfful << LCD_DATA10_DD3_Pos)                    /*!< LCD_T::DATA10: DD3 Mask                */
+
+#define LCD_DATA11_DD0_Pos               (0)                                               /*!< LCD_T::DATA11: DD0 Position            */
+#define LCD_DATA11_DD0_Msk               (0xfful << LCD_DATA11_DD0_Pos)                    /*!< LCD_T::DATA11: DD0 Mask                */
+
+#define LCD_DATA11_DD1_Pos               (8)                                               /*!< LCD_T::DATA11: DD1 Position            */
+#define LCD_DATA11_DD1_Msk               (0xfful << LCD_DATA11_DD1_Pos)                    /*!< LCD_T::DATA11: DD1 Mask                */
+
+#define LCD_DATA11_DD2_Pos               (16)                                              /*!< LCD_T::DATA11: DD2 Position            */
+#define LCD_DATA11_DD2_Msk               (0xfful << LCD_DATA11_DD2_Pos)                    /*!< LCD_T::DATA11: DD2 Mask                */
+
+#define LCD_DATA11_DD3_Pos               (24)                                              /*!< LCD_T::DATA11: DD3 Position            */
+#define LCD_DATA11_DD3_Msk               (0xfful << LCD_DATA11_DD3_Pos)                    /*!< LCD_T::DATA11: DD3 Mask                */
+
+/** @} LCD_CONST */
+/** @} end of LCD register group */
+/** @} end of REGISTER group */
+
+#endif /* __LCD_REG_H__ */

--- a/hal/m258ke/nuvoton/opa_reg.h
+++ b/hal/m258ke/nuvoton/opa_reg.h
@@ -1,0 +1,137 @@
+/**************************************************************************//**
+ * @file     opa_reg.h
+ * @version  V1.00
+ * @brief    OPA register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __OPA_REG_H__
+#define __OPA_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup OPA OP Amplifier (OPA)
+    Memory Mapped Structure for OPA Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var OPA_T::CTL
+     * Offset: 0x00  OP Amplifier Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |OPEN0     |OP Amplifier 0 Enable Bit
+     * |        |          |0 = Disable OP amplifier0.
+     * |        |          |1 = Enabled OP amplifier0.
+     * |        |          |Note: OP Amplifier 0 output needs wait stable 20us after OPEN0 is set.
+     * |[4]     |OPDOEN0   |OP Amplifier 0 Schmitt Trigger Non-inverting Buffer Enable Bit
+     * |        |          |0 = Disable OP amplifier0 schmitt trigger non-invert buffer.
+     * |        |          |1 = Enable OP amplifier0 schmitt trigger non-invert buffer.
+     * |[8]     |OPDOIEN0  |OP Amplifier 0 Schmitt Trigger Digital Output Interrupt Enable Bit
+     * |        |          |0 = OP Amplifier 0 digital output interrupt function Disabled.
+     * |        |          |1 = OP Amplifier 0 digital output interrupt function Enabled.
+     * |        |          |The OPDOIF0 interrupt flag is set by hardware whenever the OP amplifier 0 Schmitt trigger non-inverting buffer digital
+     * |        |          |output changes state, in the meanwhile, if OPDOIEN0 is set to 1, a comparator interrupt request is generated.
+     * @var OPA_T::STATUS
+     * Offset: 0x04  OP Amplifier Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |OPDO0     |OP Amplifier 0 Digital Output
+     * |        |          |Synchronized to the APB clock to allow reading by software.
+     * |        |          |Cleared when the Schmitt trigger buffer is disabled (OPDOEN0 = 0)
+     * |[4]     |OPDOIF0   |OP Amplifier 0 Schmitt Trigger Digital Output Interrupt Flag
+     * |        |          |OPDOIF0 interrupt flag is set by hardware whenever the OP amplifier 0 Schmitt trigger non-inverting buffer digital
+     * |        |          |output changes state. This bit is cleared by writing 1 to it.
+     * @var OPA_T::CALCTL
+     * Offset: 0x08  OP Amplifier Calibration Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CALTRG0   |OP Amplifier 0 Calibration Trigger Bit
+     * |        |          |0 = Stop, hardware auto clear.
+     * |        |          |1 = Start.
+     * |        |          |Note: Before enable this bit, it should set OPEN0 in advance.
+     * |[16]    |CALRVS0   |OPA0 Calibration Reference Voltage Selection
+     * |        |          |0 = VREF is 1/2 AVDD.
+     * |        |          |1 = VREF from high vcm to low vcm.
+     * @var OPA_T::CALST
+     * Offset: 0x0C  OP Amplifier Calibration Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |DONE0     |OP Amplifier 0 Calibration Done Status
+     * |        |          |0 = Calibrating.
+     * |        |          |1 = Calibration Done.
+     * |[1]     |CALNS0    |OP Amplifier 0 Calibration Result Status for NMOS
+     * |        |          |0 = Pass.
+     * |        |          |1 = Fail.
+     * |[2]     |CALPS0    |OP Amplifier 0 Calibration Result Status for PMOS
+     * |        |          |0 = Pass.
+     * |        |          |1 = Fail.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] OP Amplifier Control Register                                    */
+    __IO uint32_t STATUS;                /*!< [0x0004] OP Amplifier Status Register                                     */
+    __IO uint32_t CALCTL;                /*!< [0x0008] OP Amplifier Calibration Control Register                        */
+    __I  uint32_t CALST;                 /*!< [0x000c] OP Amplifier Calibration Status Register                         */
+} OPA_T;
+
+/**
+    @addtogroup OPA_CONST OPA Bit Field Definition
+    Constant Definitions for OPA Controller
+@{ */
+
+#define OPA_CTL_OPEN0_Pos                (0)                                               /*!< OPA_T::CTL: OPEN0 Position             */
+#define OPA_CTL_OPEN0_Msk                (0x1ul << OPA_CTL_OPEN0_Pos)                      /*!< OPA_T::CTL: OPEN0 Mask                 */
+
+#define OPA_CTL_OPDOEN0_Pos              (4)                                               /*!< OPA_T::CTL: OPDOEN0 Position           */
+#define OPA_CTL_OPDOEN0_Msk              (0x1ul << OPA_CTL_OPDOEN0_Pos)                    /*!< OPA_T::CTL: OPDOEN0 Mask               */
+
+#define OPA_CTL_OPDOIEN0_Pos             (8)                                               /*!< OPA_T::CTL: OPDOIEN0 Position          */
+#define OPA_CTL_OPDOIEN0_Msk             (0x1ul << OPA_CTL_OPDOIEN0_Pos)                   /*!< OPA_T::CTL: OPDOIEN0 Mask              */
+
+#define OPA_STATUS_OPDO0_Pos             (0)                                               /*!< OPA_T::STATUS: OPDO0 Position          */
+#define OPA_STATUS_OPDO0_Msk             (0x1ul << OPA_STATUS_OPDO0_Pos)                   /*!< OPA_T::STATUS: OPDO0 Mask              */
+
+#define OPA_STATUS_OPDOIF0_Pos           (4)                                               /*!< OPA_T::STATUS: OPDOIF0 Position        */
+#define OPA_STATUS_OPDOIF0_Msk           (0x1ul << OPA_STATUS_OPDOIF0_Pos)                 /*!< OPA_T::STATUS: OPDOIF0 Mask            */
+
+#define OPA_CALCTL_CALTRG0_Pos           (0)                                               /*!< OPA_T::CALCTL: CALTRG0 Position        */
+#define OPA_CALCTL_CALTRG0_Msk           (0x1ul << OPA_CALCTL_CALTRG0_Pos)                 /*!< OPA_T::CALCTL: CALTRG0 Mask            */
+
+#define OPA_CALCTL_CALRVS0_Pos           (16)                                              /*!< OPA_T::CALCTL: CALRVS0 Position        */
+#define OPA_CALCTL_CALRVS0_Msk           (0x1ul << OPA_CALCTL_CALRVS0_Pos)                 /*!< OPA_T::CALCTL: CALRVS0 Mask            */
+
+#define OPA_CALST_DONE0_Pos              (0)                                               /*!< OPA_T::CALST: DONE0 Position           */
+#define OPA_CALST_DONE0_Msk              (0x1ul << OPA_CALST_DONE0_Pos)                    /*!< OPA_T::CALST: DONE0 Mask               */
+
+#define OPA_CALST_CALNS0_Pos             (1)                                               /*!< OPA_T::CALST: CALNS0 Position          */
+#define OPA_CALST_CALNS0_Msk             (0x1ul << OPA_CALST_CALNS0_Pos)                   /*!< OPA_T::CALST: CALNS0 Mask              */
+
+#define OPA_CALST_CALPS0_Pos             (2)                                               /*!< OPA_T::CALST: CALPS0 Position          */
+#define OPA_CALST_CALPS0_Msk             (0x1ul << OPA_CALST_CALPS0_Pos)                   /*!< OPA_T::CALST: CALPS0 Mask              */
+
+/** @} OPA_CONST */
+/** @} end of OPA register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __OPA_REG_H__ */

--- a/hal/m258ke/nuvoton/pdma_reg.h
+++ b/hal/m258ke/nuvoton/pdma_reg.h
@@ -1,0 +1,734 @@
+/**************************************************************************//**
+ * @file     pdma_reg.h
+ * @version  V1.00
+ * @brief    PDMA register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __PDMA_REG_H__
+#define __PDMA_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup PDMA Peripheral Direct Memory Access Controller (PDMA)
+    Memory Mapped Structure for PDMA Controller
+    @{
+*/
+
+typedef struct
+{
+    /**
+     * @var DSCT_T::CTL
+     * Offset: 0x00  Descriptor Table Control Register of PDMA Channel n
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |OPMODE    |PDMA Operation Mode Selection
+     * |        |          |00 = Idle state: Channel is stopped or this table is complete, when PDMA finish channel table task, OPMODE will be cleared to idle state automatically.
+     * |        |          |01 = Basic mode: The descriptor table only has one task
+     * |        |          |When this task is finished, the PDMA_INTSTS[n] will be asserted.
+     * |        |          |10 = Scatter-Gather mode: When operating in this mode, user must give the next descriptor table address in PDMA_DSCT_NEXT register; PDMA controller will ignore this task, then load the next task to execute.
+     * |        |          |11 = Reserved.
+     * |        |          |Note: Before filling transfer task in the Descriptor Table, user must check if the descriptor table is complete.
+     * |[2]     |TXTYPE    |Transfer Type
+     * |        |          |0 = Burst transfer type.
+     * |        |          |1 = Single transfer type.
+     * |[6:4]   |BURSIZE   |Burst Size
+     * |        |          |This field is used for peripheral to determine the burst size or used for determine the re-arbitration size.
+     * |        |          |000 = 128 Transfers.
+     * |        |          |001 = 64 Transfers.
+     * |        |          |010 = 32 Transfers.
+     * |        |          |011 = 16 Transfers.
+     * |        |          |100 = 8 Transfers.
+     * |        |          |101 = 4 Transfers.
+     * |        |          |110 = 2 Transfers.
+     * |        |          |111 = 1 Transfers.
+     * |        |          |Note: This field is only useful in burst transfer type.
+     * |[7]     |TBINTDIS  |Table Interrupt Disable Bit
+     * |        |          |This field can be used to decide whether to enable table interrupt or not
+     * |        |          |If the TBINTDIS bit is enabled when PDMA controller finishes transfer task, it will not generates transfer done interrupt.
+     * |        |          |0 = Table interrupt Enabled.
+     * |        |          |1 = Table interrupt Disabled.
+     * |[9:8]   |SAINC     |Source Address Increment
+     * |        |          |This field is used to set the source address increment size.
+     * |        |          |11 = No increment (fixed address).
+     * |        |          |Others = Increment and size is depended on TXWIDTH selection.
+     * |[11:10] |DAINC     |Destination Address Increment
+     * |        |          |This field is used to set the destination address increment size.
+     * |        |          |11 = No increment (fixed address).
+     * |        |          |Others = Increment and size is depended on TXWIDTH selection.
+     * |[13:12] |TXWIDTH   |Transfer Width Selection
+     * |        |          |This field is used for transfer width.
+     * |        |          |00 = One byte (8 bit) is transferred for every operation.
+     * |        |          |01= One half-word (16 bit) is transferred for every operation.
+     * |        |          |10 = One word (32-bit) is transferred for every operation.
+     * |        |          |11 = Reserved.
+     * |        |          |Note: The PDMA transfer source address (PDMA_DSCT_SA) and PDMA transfer destination address (PDMA_DSCT_DA) should be alignment under the TXWIDTH selection
+     * |[14]    |TXACK     |Transfer Acknowledge Selection
+     * |        |          |0 = transfer ack when transfer done.
+     * |        |          |1 = transfer ack when PDMA get transfer data.
+     * |        |          |Note: This function only support UART_RX and SPI_RX.
+     * |[15]    |STRIDEEN  |Stride Mode Enable Bit
+     * |        |          |0 = Stride transfer mode Disabled.
+     * |        |          |1 = Stride transfer mode Enabled.
+     * |[31:16] |TXCNT     |Transfer Count
+     * |        |          |The TXCNT represents the required number of PDMA transfer, the real transfer count is (TXCNT + 1); The maximum transfer count is 65536, every transfer may be byte, half-word or word that is dependent on TXWIDTH field.
+     * |        |          |Note: When PDMA finish each transfer data, this field will be decrease immediately.
+     * @var DSCT_T::SA
+     * Offset: 0x04  Source Address Register of PDMA Channel n
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |SA        |PDMA Transfer Source Address
+     * |        |          |This field indicates a 32-bit source address of PDMA controller.
+     * @var DSCT_T::DA
+     * Offset: 0x08  Destination Address Register of PDMA Channel n
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |DA        |PDMA Transfer Destination Address
+     * |        |          |This field indicates a 32-bit destination address of PDMA controller.
+     * @var DSCT_T::NEXT
+     * Offset: 0x0C  Next Scatter-gather Descriptor Table Offset Address of PDMA Channel n
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |NEXT      |PDMA Next Descriptor Table Offset
+     * |        |          |This field indicates the offset of the next descriptor table address in system memory.
+     * |        |          |Write Operation:
+     * |        |          |If the system memory based address is 0x2000_0000 (PDMA_SCATBA), and the next descriptor table is start from 0x2000_0100, then this field must fill in 0x0100.
+     * |        |          |Read Operation:
+     * |        |          |When operating in scatter-gather mode, the last two bits NEXT[1:0] will become reserved, and indicate the first next address of system memory.
+     * |        |          |When operating in scatter-gather mode, the last two bits NEXT[1:0] will become scatter-gather mode control indicator as below.
+     * |        |          |0 = Idle mode.
+     * |        |          |1 = operating in the basic mode (final scatter-gather table).
+     * |        |          |2 = loading scatter-gather table from SRAM.
+     * |        |          |3 = operating in the scatter-gather mode.
+     * |        |          |Note1: The descriptor table address must be word boundary.
+     * |        |          |Note2: Before filled transfer task in the descriptor table, user must check if the descriptor table is complete.
+     * |[31:16] |EXENEXT   |PDMA Execution Next Descriptor Table Offset
+     * |        |          |This field indicates the offset of next descriptor table address of current execution descriptor table in system memory.
+     * |        |          |Note: write operation is useless in this field.
+     */
+    __IO uint32_t CTL;      /*!< [0x0000] Descriptor Table Control Register of PDMA Channel n.              */
+    __IO uint32_t SA;       /*!< [0x0004] Source Address Register of PDMA Channel n                        */
+    __IO uint32_t DA;       /*!< [0x0008] Destination Address Register of PDMA Channel n                   */
+    __IO uint32_t NEXT;     /*!< [0x000c] First Scatter-Gather Descriptor Table Offset Address of PDMA Channel n */
+
+} DSCT_T;
+
+typedef struct
+{
+    /**
+     * @var STRIDE_T::STC
+     * Offset: 0x500  Stride Transfer Count Register of PDMA Channel n
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |STC       |PDMA Stride Transfer Count
+     * |        |          |The 16-bit register defines the stride transfer count of each row.
+     * @var STRIDE_T::ASOCR
+     * Offset: 0x504  Address Stride Offset Register of PDMA Channel n
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |SASOL     |VDMA Source Address Stride Offset Length
+     * |        |          |The 16-bit register defines the source address stride transfer offset count of each row.
+     * |[31:16] |DASOL     |VDMA Destination Address Stride Offset Length
+     * |        |          |The 16-bit register defines the destination address stride transfer offset count of each row.
+     */
+    __IO uint32_t STC;      /*!< [0x0500] Stride Transfer Count Register of PDMA Channel 0                 */
+    __IO uint32_t ASOCR;    /*!< [0x0504] Address Stride Offset Register of PDMA Channel 0                 */
+} STRIDE_T;
+
+
+
+typedef struct
+{
+    /**
+     * @var PDMA_T::CURSCAT
+     * Offset: 0x100  Current Scatter-gather Descriptor Table Address of PDMA Channel n
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |CURADDR   |PDMA Current Description Address (Read Only)
+     * |        |          |This field indicates a 32-bit current external description address of PDMA controller.
+     * |        |          |Note: This field is read only and used for Scatter-Gather mode only to indicate the current external description address.
+     * @var PDMA_T::CHCTL
+     * Offset: 0x400  PDMA Channel Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CHENn     |PDMA Channel Enable Bits
+     * |        |          |Set this bit to 1 to enable PDMAn operation. Channel cannot be active if it is not set as enabled.
+     * |        |          |0 = PDMA channel [n] Disabled.
+     * |        |          |1 = PDMA channel [n] Enabled.
+     * |        |          |Note: Setting the corresponding bit of PDMA_PAUSE or PDMA_CHRST register will also clear this bit.
+     * @var PDMA_T::PAUSE
+     * Offset: 0x404  PDMA Transfer Pause Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |PAUSEn    |PDMA Channel N Transfer Pause Control (Write Only)
+     * |        |          |User can set PAUSEn bit field to pause the PDMA transfer
+     * |        |          |When user sets PAUSEn bit, the PDMA controller will pause the on-going transfer, then clear the channel enable bit CHEN(PDMA_CHCTL [n], n=0,1..7) and clear request active flag
+     * |        |          |If the paused channel is re-enabled again, the remaining transfers will be processed.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Pause PDMA channel n transfer.
+     * @var PDMA_T::SWREQ
+     * Offset: 0x408  PDMA Software Request Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |SWREQn    |PDMA Software Request (Write Only)
+     * |        |          |Set this bit to 1 to generate a software request to PDMA [n].
+     * |        |          |0 = No effect.
+     * |        |          |1 = Generate a software request.
+     * |        |          |Note1: User can read PDMA_TRGSTS register to know which channel is on active
+     * |        |          |Active flag may be triggered by software request or peripheral request.
+     * |        |          |Note2: If user does not enable corresponding PDMA channel, the software request will be ignored.
+     * @var PDMA_T::TRGSTS
+     * Offset: 0x40C  PDMA Channel Request Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |REQSTSn   |PDMA Channel Request Status (Read Only)
+     * |        |          |This flag indicates whether channel[n] have a request or not, no matter request from software or peripheral
+     * |        |          |When PDMA controller finishes channel transfer, this bit will be cleared automatically.
+     * |        |          |0 = PDMA Channel n has no request.
+     * |        |          |1 = PDMA Channel n has a request.
+     * |        |          |Note: If user pauses or resets each PDMA transfer by setting PDMA_PAUSE or PDMA_CHRST register respectively, this bit will be cleared automatically after finishing the current transfer.
+     * @var PDMA_T::PRISET
+     * Offset: 0x410  PDMA Fixed Priority Setting Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |FPRISETn  |PDMA Fixed Priority Setting
+     * |        |          |Set this bit to 1 to enable fixed priority level.
+     * |        |          |Write Operation:
+     * |        |          |0 = No effect.
+     * |        |          |1 = Set PDMA channel [n] to fixed priority channel.
+     * |        |          |Read Operation:
+     * |        |          |0 = Corresponding PDMA channel is round-robin priority.
+     * |        |          |1 = Corresponding PDMA channel is fixed priority.
+     * |        |          |Note: This field only set to fixed priority, clear fixed priority use PDMA_PRICLR register.
+     * @var PDMA_T::PRICLR
+     * Offset: 0x414  PDMA Fixed Priority Clear Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |FPRICLRn  |PDMA Fixed Priority Clear Bits (Write Only)
+     * |        |          |Set this bit to 1 to clear fixed priority level.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear PDMA channel [n] fixed priority setting.
+     * |        |          |Note: User can read PDMA_PRISET register to know the channel priority.
+    * @var PDMA_T::INTEN
+     * Offset: 0x418  PDMA Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |INTENn    |PDMA Interrupt Enable Bits
+     * |        |          |This field is used to enable PDMA channel[n] interrupt.
+     * |        |          |0 = PDMA channel n interrupt Disabled.
+     * |        |          |1 = PDMA channel n interrupt Enabled.
+     * @var PDMA_T::INTSTS
+     * Offset: 0x41C  PDMA Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ABTIF     |PDMA Read/Write Target Abort Interrupt Flag (Read Only)
+     * |        |          |This bit indicates that PDMA has target abort error; Software can read PDMA_ABTSTS register to find which channel has target abort error.
+     * |        |          |0 = No AHB bus ERROR response received.
+     * |        |          |1 = AHB bus ERROR response received.
+     * |[1]     |TDIF      |Transfer Done Interrupt Flag (Read Only)
+     * |        |          |This bit indicates that PDMA controller has finished transmission; User can read PDMA_TDSTS register to indicate which channel finished transfer.
+     * |        |          |0 = Not finished yet.
+     * |        |          |1 = PDMA channel has finished transmission.
+     * |[2]     |ALIGNF    |Transfer Alignment Interrupt Flag (Read Only)
+     * |        |          |0 = PDMA channel source address and destination address both follow transfer width setting.
+     * |        |          |1 = PDMA channel source address or destination address is not follow transfer width setting.
+     * |[8]     |REQTOF0   |Request Time-out Flag for Channel 0
+     * |        |          |This flag indicates that PDMA controller has waited peripheral request for a period defined by PDMA_TOC0, user can write 1 to clear these bits.
+     * |        |          |0 = No request time-out.
+     * |        |          |1 = Peripheral request time-out.
+     * |[9]     |REQTOF1   |Request Time-out Flag for Channel 1
+     * |        |          |This flag indicates that PDMA controller has waited peripheral request for a period defined by PDMA_TOC1, user can write 1 to clear these bits.
+     * |        |          |0 = No request time-out.
+     * |        |          |1 = Peripheral request time-out.
+     * @var PDMA_T::ABTSTS
+     * Offset: 0x420  PDMA Channel Read/Write Target Abort Flag Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |ABTIFn    |PDMA Read/Write Target Abort Interrupt Status Flag
+     * |        |          |This bit indicates which PDMA controller has target abort error; User can write 1 to clear these bits.
+     * |        |          |0 = No AHB bus ERROR response received when channel n transfer.
+     * |        |          |1 = AHB bus ERROR response received when channel n transfer.
+     * @var PDMA_T::TDSTS
+     * Offset: 0x424  PDMA Channel Transfer Done Flag Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |TDIF0     |Transfer Done Flag
+     * |        |          |This bit indicates whether PDMA controller channel transfer has been finished or not, user can write 1 to clear these bits.
+     * |        |          |0 = PDMA channel transfer has not finished.
+     * |        |          |1 = PDMA channel has finished transmission.
+     * @var PDMA_T::ALIGN
+     * Offset: 0x428  PDMA Transfer Alignment Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |ALIGNn    |Transfer Alignment Flag
+     * |        |          |0 = PDMA channel source address and destination address both follow transfer width setting.
+     * |        |          |1 = PDMA channel source address or destination address is not follow transfer width setting.
+    * @var PDMA_T::TACTSTS
+     * Offset: 0x42C  PDMA Transfer Active Flag Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |TXACTFn   |Transfer on Active Flag (Read Only)
+     * |        |          |This bit indicates which PDMA channel is in active.
+     * |        |          |0 = PDMA channel is not finished.
+     * |        |          |1 = PDMA channel is active.
+     * @var PDMA_T::TOUTPSC
+     * Offset: 0x430  PDMA Time-out Prescaler Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |TOUTPSC0  |PDMA Channel 0 Time-out Clock Source Prescaler Bits
+     * |        |          |000 = PDMA channel 0 time-out clock source is HCLK/28.
+     * |        |          |001 = PDMA channel 0 time-out clock source is HCLK/29.
+     * |        |          |010 = PDMA channel 0 time-out clock source is HCLK/210.
+     * |        |          |011 = PDMA channel 0 time-out clock source is HCLK/211.
+     * |        |          |100 = PDMA channel 0 time-out clock source is HCLK/212.
+     * |        |          |101 = PDMA channel 0 time-out clock source is HCLK/213.
+     * |        |          |110 = PDMA channel 0 time-out clock source is HCLK/214.
+     * |        |          |111 = PDMA channel 0 time-out clock source is HCLK/215.
+     * |[6:4]   |TOUTPSC1  |PDMA Channel 1 Time-out Clock Source Prescaler Bits
+     * |        |          |000 = PDMA channel 1 time-out clock source is HCLK/28.
+     * |        |          |001 = PDMA channel 1 time-out clock source is HCLK/29.
+     * |        |          |010 = PDMA channel 1 time-out clock source is HCLK/210.
+     * |        |          |011 = PDMA channel 1 time-out clock source is HCLK/211.
+     * |        |          |100 = PDMA channel 1 time-out clock source is HCLK/212.
+     * |        |          |101 = PDMA channel 1 time-out clock source is HCLK/213.
+     * |        |          |110 = PDMA channel 1 time-out clock source is HCLK/214.
+     * |        |          |111 = PDMA channel 1 time-out clock source is HCLK/215.
+     * @var PDMA_T::TOUTEN
+     * Offset: 0x434  PDMA Time-out Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |TOUTENn   |PDMA Time-out Enable Bits
+     * |        |          |0 = PDMA Channel n time-out function Disabled.
+     * |        |          |1 = PDMA Channel n time-out function Enabled.
+     * @var PDMA_T::TOUTIEN
+     * Offset: 0x438  PDMA Time-out Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |TOUTIENn  |PDMA Time-out Interrupt Enable Bits
+     * |        |          |0 = PDMA Channel n time-out interrupt Disabled.
+     * |        |          |1 = PDMA Channel n time-out interrupt Enabled.
+     * @var PDMA_T::SCATBA
+     * Offset: 0x43C  PDMA Scatter-gather Descriptor Table Base Address Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:16] |SCATBA    |PDMA Scatter-gather Descriptor Table Address
+     * |        |          |In Scatter-Gather mode, this is the base address for calculating the next link - list address
+     * |        |          |The next link address equation is
+     * |        |          |Next Link Address = PDMA_SCATBA + PDMA_DSCT_NEXT.
+     * |        |          |Note: Only useful in Scatter-Gather mode.
+     * @var PDMA_T::TOC0_1
+     * Offset: 0x440  PDMA Time-out Counter Ch1 and Ch0 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |TOC0      |Time-out Counter for Channel 0
+     * |        |          |This controls the period of time-out function for channel 0
+     * |        |          |The calculation unit is based on 10 kHz clock.
+     * |[31:16] |TOC1      |Time-out Counter for Channel 1
+     * |        |          |This controls the period of time-out function for channel 1
+     * |        |          |The calculation unit is based on 10 kHz clock.
+     * @var PDMA_T::CHRST
+     * Offset: 0x460  PDMA Channel Reset Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CHnRST    |Channel N Reset
+     * |        |          |0 = corresponding channel n is not reset.
+     * |        |          |1 = corresponding channel n is reset.
+     * @var PDMA_T::REQSEL0_3
+     * Offset: 0x480  PDMA Request Source Select Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[6:0]   |REQSRC0   |Channel 0 Request Source Selection
+     * |        |          |This filed defines which peripheral is connected to PDMA channel 0
+     * |        |          |User can configure the peripheral by setting REQSRC0.
+     * |        |          |0 = Disable PDMA peripheral request.
+     * |        |          |1 = Reserved.
+     * |        |          |2 = Channel connects to USB_TX.
+     * |        |          |3 = Channel connects to USB_RX.
+     * |        |          |4 = Channel connects to UART0_TX.
+     * |        |          |5 = Channel connects to UART0_RX.
+     * |        |          |6 = Channel connects to UART1_TX.
+     * |        |          |7 = Channel connects to UART1_RX.
+     * |        |          |8 = Channel connects to UART2_TX.
+     * |        |          |9 = Channel connects to UART2_RX.
+     * |        |          |10=Channel connects to UART3_TX.
+     * |        |          |11 = Channel connects to UART3_RX.
+     * |        |          |12 = Channel connects to UART4_TX.
+     * |        |          |13 = Channel connects to UART4_RX.
+     * |        |          |14 = Channel connects to UART5_TX.
+     * |        |          |15 = Channel connects to UART5_RX.
+     * |        |          |16 = Channel connects to USCI0_TX.
+     * |        |          |17 = Channel connects to USCI0_RX.
+     * |        |          |18 = Channel connects to USCI1_TX.
+     * |        |          |19 = Channel connects to USCI1_RX.
+     * |        |          |20 = Channel connects to SPI0_TX.
+     * |        |          |21 = Channel connects to SPI0_RX.
+     * |        |          |22 = Channel connects to SPI1_TX.
+     * |        |          |23 = Channel connects to SPI1_RX.
+     * |        |          |24 = Channel connects to SPI2_TX.
+     * |        |          |25 = Channel connects to SPI2_RX.
+     * |        |          |26 = Channel connects to SPI3_TX.
+     * |        |          |27 = Channel connects to SPI3_RX.
+     * |        |          |28 = Channel connects to SPI4_TX.
+     * |        |          |29 = Channel connects to SPI4_RX.
+     * |        |          |30 = Reserved.
+     * |        |          |31 = Reserved.
+     * |        |          |32 = Channel connects to PWM0_P1_RX.
+     * |        |          |33 = Channel connects to PWM0_P2_RX.
+     * |        |          |34 = Channel connects to PWM0_P3_RX.
+     * |        |          |35 = Channel connects to PWM1_P1_RX.
+     * |        |          |36 = Channel connects to PWM1_P2_RX.
+     * |        |          |37 = Channel connects to PWM1_P3_RX.
+     * |        |          |38 = Channel connects to I2C0_TX.
+     * |        |          |39 = Channel connects to I2C0_RX.
+     * |        |          |40 = Channel connects to I2C1_TX.
+     * |        |          |41 = Channel connects to I2C1_RX.
+     * |        |          |42 = Channel connects to I2C2_TX.
+     * |        |          |43 = Channel connects to I2C2_RX.
+     * |        |          |44 = Channel connects to I2S0_TX.
+     * |        |          |45 = Channel connects to I2S0_RX.
+     * |        |          |46 = Channel connects to TMR0.
+     * |        |          |47 = Channel connects to TMR1.
+     * |        |          |48 = Channel connects to TMR2.
+     * |        |          |49 = Channel connects to TMR3.
+     * |        |          |50 = Channel connects to ADC_RX.
+     * |        |          |51 = Channel connects to DAC0_TX.
+     * |        |          |52 = Channel connects to DAC1_TX.
+     * |        |          |53 = Channel connects to PWM0_CH0_TX.
+     * |        |          |54 = Channel connects to PWM0_CH1_TX.
+     * |        |          |55 = Channel connects to PWM0_CH2_TX.
+     * |        |          |56 = Channel connects to PWM0_CH3_TX.
+     * |        |          |57 = Channel connects to PWM0_CH4_TX.
+     * |        |          |58 = Channel connects to PWM0_CH5_TX.
+     * |        |          |59 = Channel connects to PWM1_CH0_TX.
+     * |        |          |60 = Channel connects to PWM1_CH1_TX.
+     * |        |          |61 = Channel connects to PWM1_CH2_TX.
+     * |        |          |62 = Channel connects to PWM1_CH3_TX.
+     * |        |          |63 = Channel connects to PWM1_CH4_TX.
+     * |        |          |64 = Channel connects to PWM1_CH5_TX.
+     * |        |          |65 = Channel connects to ETMC_RX.
+     * |        |          |Others = Reserved.
+     * |        |          |Note 1: A peripheral cannot be assigned to two channels at the same time.
+     * |        |          |Note 2: This field is useless when transfer between memory and memory.
+     * |[14:8]  |REQSRC1   |Channel 1 Request Source Selection
+     * |        |          |This filed defines which peripheral is connected to PDMA channel 1
+     * |        |          |User can configure the peripheral setting by REQSRC1.
+     * |        |          |Note: The channel configuration is the same as REQSRC0 field
+     * |        |          |Please refer to the explanation of REQSRC0.
+     * |[22:16] |REQSRC2   |Channel 2 Request Source Selection
+     * |        |          |This filed defines which peripheral is connected to PDMA channel 2
+     * |        |          |User can configure the peripheral setting by REQSRC2.
+     * |        |          |Note: The channel configuration is the same as REQSRC0 field
+     * |        |          |Please refer to the explanation of REQSRC0.
+     * |[30:24] |REQSRC3   |Channel 3 Request Source Selection
+     * |        |          |This filed defines which peripheral is connected to PDMA channel 3
+     * |        |          |User can configure the peripheral setting by REQSRC3.
+     * |        |          |Note: The channel configuration is the same as REQSRC0 field
+     * |        |          |Please refer to the explanation of REQSRC0.
+     * @var PDMA_T::REQSEL4_7
+     * Offset: 0x484  PDMA Request Source Select Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[6:0]   |REQSRC4   |Channel 4 Request Source Selection
+     * |        |          |This filed defines which peripheral is connected to PDMA channel 4
+     * |        |          |User can configure the peripheral setting by REQSRC4.
+     * |        |          |Note: The channel configuration is the same as REQSRC0 field
+     * |        |          |Please refer to the explanation of REQSRC0.
+     * |[14:8]  |REQSRC5   |Channel 5 Request Source Selection
+     * |        |          |This filed defines which peripheral is connected to PDMA channel 5
+     * |        |          |User can configure the peripheral setting by REQSRC5.
+     * |        |          |Note: The channel configuration is the same as REQSRC0 field
+     * |        |          |Please refer to the explanation of REQSRC0.
+     * |[22:16] |REQSRC6   |Channel 6 Request Source Selection
+     * |        |          |This filed defines which peripheral is connected to PDMA channel 6
+     * |        |          |User can configure the peripheral setting by REQSRC6.
+     * |        |          |Note: The channel configuration is the same as REQSRC0 field
+     * |        |          |Please refer to the explanation of REQSRC0.
+     * |[30:24] |REQSRC7   |Channel 7 Request Source Selection
+     * |        |          |This filed defines which peripheral is connected to PDMA channel 7
+     * |        |          |User can configure the peripheral setting by REQSRC7.
+     * |        |          |Note: The channel configuration is the same as REQSRC0 field
+     * |        |          |Please refer to the explanation of REQSRC0.
+     */
+    DSCT_T        DSCT[8];               /*!< [0x0000 ~ 0x007C] Control Register of PDMA Channel 0 ~ 7                  */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[32];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t CURSCAT[8];            /*!< [0x0100 ~ 0x11c] Current Scatter-gather Descriptor Table Address of PDMA Channel n */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[184];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CHCTL;                 /*!< [0x0400] PDMA Channel Control Register                                    */
+    __O  uint32_t PAUSE;                 /*!< [0x0404] PDMA Transfer Pause Control Register                             */
+    __O  uint32_t SWREQ;                 /*!< [0x0408] PDMA Software Request Register                                   */
+    __I  uint32_t TRGSTS;                /*!< [0x040c] PDMA Channel Request Status Register                             */
+    __IO uint32_t PRISET;                /*!< [0x0410] PDMA Fixed Priority Setting Register                             */
+    __O  uint32_t PRICLR;                /*!< [0x0414] PDMA Fixed Priority Clear Register                               */
+    __IO uint32_t INTEN;                 /*!< [0x0418] PDMA Interrupt Enable Register                                   */
+    __IO uint32_t INTSTS;                /*!< [0x041c] PDMA Interrupt Status Register                                   */
+    __IO uint32_t ABTSTS;                /*!< [0x0420] PDMA Channel Read/Write Target Abort Flag Register               */
+    __IO uint32_t TDSTS;                 /*!< [0x0424] PDMA Channel Transfer Done Flag Register                         */
+    __IO uint32_t ALIGN;                 /*!< [0x0428] PDMA Transfer Alignment Status Register                          */
+    __I  uint32_t TACTSTS;               /*!< [0x042c] PDMA Transfer Active Flag Register                               */
+    __IO uint32_t TOUTPSC;               /*!< [0x0430] PDMA Time-out Prescaler Register                                 */
+    __IO uint32_t TOUTEN;                /*!< [0x0434] PDMA Time-out Enable Register                                    */
+    __IO uint32_t TOUTIEN;               /*!< [0x0438] PDMA Time-out Interrupt Enable Register                          */
+    __IO uint32_t SCATBA;                /*!< [0x043c] PDMA Scatter-gather Descriptor Table Base Address Register       */
+    __IO uint32_t TOC0_1;                /*!< [0x0440] PDMA Time-out Counter Ch1 and Ch0 Register                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[7];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CHRST;                 /*!< [0x0460] PDMA Channel Reset Register                                      */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[7];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t REQSEL0_3;             /*!< [0x0480] PDMA Request Source Select Register 0                            */
+    __IO uint32_t REQSEL4_7;             /*!< [0x0484] PDMA Request Source Select Register 1                            */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE4[30];
+    /// @endcond //HIDDEN_SYMBOLS
+    STRIDE_T      STRIDE[6];             /*!< [0x0500 ~ 0x528] Stride Register of PDMA Channel 0 ~ 5                    */
+} PDMA_T;
+
+/**
+    @addtogroup PDMA_CONST PDMA Bit Field Definition
+    Constant Definitions for PDMA Controller
+@{ */
+
+#define PDMA_DSCT_CTL_OPMODE_Pos         (0)                                               /*!< PDMA_T::DSCT_CTL: OPMODE Position      */
+#define PDMA_DSCT_CTL_OPMODE_Msk         (0x3ul << PDMA_DSCT_CTL_OPMODE_Pos)               /*!< PDMA_T::DSCT_CTL: OPMODE Mask          */
+
+#define PDMA_DSCT_CTL_TXTYPE_Pos         (2)                                               /*!< PDMA_T::DSCT_CTL: TXTYPE Position      */
+#define PDMA_DSCT_CTL_TXTYPE_Msk         (0x1ul << PDMA_DSCT_CTL_TXTYPE_Pos)               /*!< PDMA_T::DSCT_CTL: TXTYPE Mask          */
+
+#define PDMA_DSCT_CTL_BURSIZE_Pos        (4)                                               /*!< PDMA_T::DSCT_CTL: BURSIZE Position     */
+#define PDMA_DSCT_CTL_BURSIZE_Msk        (0x7ul << PDMA_DSCT_CTL_BURSIZE_Pos)              /*!< PDMA_T::DSCT_CTL: BURSIZE Mask         */
+
+#define PDMA_DSCT_CTL_TBINTDIS_Pos       (7)                                               /*!< PDMA_T::DSCT_CTL: TBINTDIS Position    */
+#define PDMA_DSCT_CTL_TBINTDIS_Msk       (0x1ul << PDMA_DSCT_CTL_TBINTDIS_Pos)             /*!< PDMA_T::DSCT_CTL: TBINTDIS Mask        */
+
+#define PDMA_DSCT_CTL_SAINC_Pos          (8)                                               /*!< PDMA_T::DSCT_CTL: SAINC Position       */
+#define PDMA_DSCT_CTL_SAINC_Msk          (0x3ul << PDMA_DSCT_CTL_SAINC_Pos)                /*!< PDMA_T::DSCT_CTL: SAINC Mask           */
+
+#define PDMA_DSCT_CTL_DAINC_Pos          (10)                                              /*!< PDMA_T::DSCT_CTL: DAINC Position       */
+#define PDMA_DSCT_CTL_DAINC_Msk          (0x3ul << PDMA_DSCT_CTL_DAINC_Pos)                /*!< PDMA_T::DSCT_CTL: DAINC Mask           */
+
+#define PDMA_DSCT_CTL_TXWIDTH_Pos        (12)                                              /*!< PDMA_T::DSCT_CTL: TXWIDTH Position     */
+#define PDMA_DSCT_CTL_TXWIDTH_Msk        (0x3ul << PDMA_DSCT_CTL_TXWIDTH_Pos)              /*!< PDMA_T::DSCT_CTL: TXWIDTH Mask         */
+
+#define PDMA_DSCT_CTL_TXACK_Pos          (14)                                              /*!< PDMA_T::DSCT_CTL: TXACK Position       */
+#define PDMA_DSCT_CTL_TXACK_Msk          (0x1ul << PDMA_DSCT_CTL_TXACK_Pos)                /*!< PDMA_T::DSCT_CTL: TXACK Mask           */
+
+#define PDMA_DSCT_CTL_STRIDE_EN_Pos       (15)                                              /*!< PDMA_T::DSCT_CTL: STRIDEEN Position    */
+#define PDMA_DSCT_CTL_STRIDE_EN_Msk       (0x1ul << PDMA_DSCT_CTL_STRIDE_EN_Pos)             /*!< PDMA_T::DSCT_CTL: STRIDEEN Mask        */
+
+#define PDMA_DSCT_CTL_TXCNT_Pos          (16)                                              /*!< PDMA_T::DSCT_CTL: TXCNT Position       */
+#define PDMA_DSCT_CTL_TXCNT_Msk          (0xfffful << PDMA_DSCT_CTL_TXCNT_Pos)             /*!< PDMA_T::DSCT_CTL: TXCNT Mask           */
+
+#define PDMA_DSCT_SA_SA_Pos              (0)                                               /*!< PDMA_T::DSCT_SA: SA Position           */
+#define PDMA_DSCT_SA_SA_Msk              (0xfffffffful << PDMA_DSCT_SA_SA_Pos)             /*!< PDMA_T::DSCT_SA: SA Mask               */
+
+#define PDMA_DSCT_DA_DA_Pos              (0)                                               /*!< PDMA_T::DSCT_DA: DA Position           */
+#define PDMA_DSCT_DA_DA_Msk              (0xfffffffful << PDMA_DSCT_DA_DA_Pos)             /*!< PDMA_T::DSCT_DA: DA Mask               */
+
+#define PDMA_DSCT_NEXT_NEXT_Pos          (0)                                               /*!< PDMA_T::DSCT_NEXT: NEXT Position       */
+#define PDMA_DSCT_NEXT_NEXT_Msk          (0xfffful << PDMA_DSCT_NEXT_NEXT_Pos)             /*!< PDMA_T::DSCT_NEXT: NEXT Mask           */
+
+#define PDMA_DSCT_NEXT_EXENEXT_Pos       (16)                                              /*!< PDMA_T::DSCT_NEXT: EXENEXT Position    */
+#define PDMA_DSCT_NEXT_EXENEXT_Msk       (0xfffful << PDMA_DSCT0_NEXT_EXENEXT_Pos)         /*!< PDMA_T::DSCT_NEXT: EXENEXT Mask        */
+
+#define PDMA_CURSCAT_CURADDR_Pos         (0)                                               /*!< PDMA_T::CURSCAT: CURADDR Position      */
+#define PDMA_CURSCAT_CURADDR_Msk         (0xfffffffful << PDMA_CURSCAT_CURADDR_Pos)        /*!< PDMA_T::CURSCAT: CURADDR Mask          */
+
+#define PDMA_CHCTL_CHENn_Pos             (0)                                               /*!< PDMA_T::CHCTL: CHENn Position          */
+#define PDMA_CHCTL_CHENn_Msk             (0xfful << PDMA_CHCTL_CHENn_Pos)                /*!< PDMA_T::CHCTL: CHENn Mask              */
+
+#define PDMA_PAUSE_PAUSEn_Pos            (0)                                               /*!< PDMA_T::PAUSE: PAUSEn Position           */
+#define PDMA_PAUSE_PAUSEn_Msk            (0xfful << PDMA_PAUSE_PAUSEn_Pos)              /*!< PDMA_T::PAUSE: PAUSEn Mask               */
+
+#define PDMA_SWREQ_SWREQn_Pos            (0)                                               /*!< PDMA_T::SWREQ: SWREQn Position         */
+#define PDMA_SWREQ_SWREQn_Msk            (0xfful << PDMA_SWREQ_SWREQn_Pos)               /*!< PDMA_T::SWREQ: SWREQn Mask             */
+
+#define PDMA_TRGSTS_REQSTSn_Pos          (0)                                               /*!< PDMA_T::TRGSTS: REQSTSn Position       */
+#define PDMA_TRGSTS_REQSTSn_Msk          (0xfful << PDMA_TRGSTS_REQSTSn_Pos)             /*!< PDMA_T::TRGSTS: REQSTSn Mask           */
+
+#define PDMA_PRISET_FPRISETn_Pos         (0)                                               /*!< PDMA_T::PRISET: FPRISETn Position      */
+#define PDMA_PRISET_FPRISETn_Msk         (0xfful << PDMA_PRISET_FPRISETn_Pos)            /*!< PDMA_T::PRISET: FPRISETn Mask          */
+
+#define PDMA_PRICLR_FPRICLRn_Pos         (0)                                               /*!< PDMA_T::PRICLR: FPRICLRn Position      */
+#define PDMA_PRICLR_FPRICLRn_Msk         (0xfful << PDMA_PRICLR_FPRICLRn_Pos)            /*!< PDMA_T::PRICLR: FPRICLRn Mask          */
+
+#define PDMA_INTEN_INTENn_Pos            (0)                                               /*!< PDMA_T::INTEN: INTENn Position         */
+#define PDMA_INTEN_INTENn_Msk            (0xfffful << PDMA_INTEN_INTENn_Pos)               /*!< PDMA_T::INTEN: INTENn Mask             */
+
+#define PDMA_INTSTS_ABTIF_Pos            (0)                                               /*!< PDMA_T::INTSTS: ABTIF Position         */
+#define PDMA_INTSTS_ABTIF_Msk            (0x1ul << PDMA_INTSTS_ABTIF_Pos)                  /*!< PDMA_T::INTSTS: ABTIF Mask             */
+
+#define PDMA_INTSTS_TDIF_Pos             (1)                                               /*!< PDMA_T::INTSTS: TDIF Position          */
+#define PDMA_INTSTS_TDIF_Msk             (0x1ul << PDMA_INTSTS_TDIF_Pos)                   /*!< PDMA_T::INTSTS: TDIF Mask              */
+
+#define PDMA_INTSTS_ALIGNF_Pos           (2)                                               /*!< PDMA_T::INTSTS: ALIGNF Position        */
+#define PDMA_INTSTS_ALIGNF_Msk           (0x1ul << PDMA_INTSTS_ALIGNF_Pos)                 /*!< PDMA_T::INTSTS: ALIGNF Mask            */
+
+#define PDMA_INTSTS_REQTOF0_Pos          (8)                                               /*!< PDMA_T::INTSTS: REQTOF0 Position       */
+#define PDMA_INTSTS_REQTOF0_Msk          (0x1ul << PDMA_INTSTS_REQTOF0_Pos)                /*!< PDMA_T::INTSTS: REQTOF0 Mask           */
+
+#define PDMA_INTSTS_REQTOF1_Pos          (9)                                               /*!< PDMA_T::INTSTS: REQTOF1 Position       */
+#define PDMA_INTSTS_REQTOF1_Msk          (0x1ul << PDMA_INTSTS_REQTOF1_Pos)                /*!< PDMA_T::INTSTS: REQTOF1 Mask           */
+
+#define PDMA_ABTSTS_ABTIF0_Pos           (0)                                               /*!< PDMA_T::ABTSTS: ABTIF0 Position        */
+#define PDMA_ABTSTS_ABTIF0_Msk           (0x1ul << PDMA_ABTSTS_ABTIF0_Pos)                 /*!< PDMA_T::ABTSTS: ABTIF0 Mask            */
+
+#define PDMA_ABTSTS_ABTIF1_Pos           (1)                                               /*!< PDMA_T::ABTSTS: ABTIF1 Position        */
+#define PDMA_ABTSTS_ABTIF1_Msk           (0x1ul << PDMA_ABTSTS_ABTIF1_Pos)                 /*!< PDMA_T::ABTSTS: ABTIF1 Mask            */
+
+#define PDMA_ABTSTS_ABTIF2_Pos           (2)                                               /*!< PDMA_T::ABTSTS: ABTIF2 Position        */
+#define PDMA_ABTSTS_ABTIF2_Msk           (0x1ul << PDMA_ABTSTS_ABTIF2_Pos)                 /*!< PDMA_T::ABTSTS: ABTIF2 Mask            */
+
+#define PDMA_ABTSTS_ABTIF3_Pos           (3)                                               /*!< PDMA_T::ABTSTS: ABTIF3 Position        */
+#define PDMA_ABTSTS_ABTIF3_Msk           (0x1ul << PDMA_ABTSTS_ABTIF3_Pos)                 /*!< PDMA_T::ABTSTS: ABTIF3 Mask            */
+
+#define PDMA_ABTSTS_ABTIF4_Pos           (4)                                               /*!< PDMA_T::ABTSTS: ABTIF4 Position        */
+#define PDMA_ABTSTS_ABTIF4_Msk           (0x1ul << PDMA_ABTSTS_ABTIF4_Pos)                 /*!< PDMA_T::ABTSTS: ABTIF4 Mask            */
+
+#define PDMA_ABTSTS_ABTIF5_Pos           (5)                                               /*!< PDMA_T::ABTSTS: ABTIF5 Position        */
+#define PDMA_ABTSTS_ABTIF5_Msk           (0x1ul << PDMA_ABTSTS_ABTIF5_Pos)                 /*!< PDMA_T::ABTSTS: ABTIF5 Mask            */
+
+#define PDMA_ABTSTS_ABTIF6_Pos           (6)                                               /*!< PDMA_T::ABTSTS: ABTIF6 Position        */
+#define PDMA_ABTSTS_ABTIF6_Msk           (0x1ul << PDMA_ABTSTS_ABTIF6_Pos)                 /*!< PDMA_T::ABTSTS: ABTIF6 Mask            */
+
+#define PDMA_ABTSTS_ABTIF7_Pos           (7)                                               /*!< PDMA_T::ABTSTS: ABTIF7 Position        */
+#define PDMA_ABTSTS_ABTIF7_Msk           (0x1ul << PDMA_ABTSTS_ABTIF7_Pos)                 /*!< PDMA_T::ABTSTS: ABTIF7 Mask            */
+
+#define PDMA_TDSTS_TDIF0_Pos             (0)                                               /*!< PDMA_T::TDSTS: TDIF0 Position          */
+#define PDMA_TDSTS_TDIF0_Msk             (0x1ul << PDMA_TDSTS_TDIF0_Pos)                   /*!< PDMA_T::TDSTS: TDIF0 Mask              */
+
+#define PDMA_TDSTS_TDIF1_Pos             (1)                                               /*!< PDMA_T::TDSTS: TDIF1 Position          */
+#define PDMA_TDSTS_TDIF1_Msk             (0x1ul << PDMA_TDSTS_TDIF1_Pos)                   /*!< PDMA_T::TDSTS: TDIF1 Mask              */
+
+#define PDMA_TDSTS_TDIF2_Pos             (2)                                               /*!< PDMA_T::TDSTS: TDIF2 Position          */
+#define PDMA_TDSTS_TDIF2_Msk             (0x1ul << PDMA_TDSTS_TDIF2_Pos)                   /*!< PDMA_T::TDSTS: TDIF2 Mask              */
+
+#define PDMA_TDSTS_TDIF3_Pos             (3)                                               /*!< PDMA_T::TDSTS: TDIF3 Position          */
+#define PDMA_TDSTS_TDIF3_Msk             (0x1ul << PDMA_TDSTS_TDIF3_Pos)                   /*!< PDMA_T::TDSTS: TDIF3 Mask              */
+
+#define PDMA_TDSTS_TDIF4_Pos             (4)                                               /*!< PDMA_T::TDSTS: TDIF4 Position          */
+#define PDMA_TDSTS_TDIF4_Msk             (0x1ul << PDMA_TDSTS_TDIF4_Pos)                   /*!< PDMA_T::TDSTS: TDIF4 Mask              */
+
+#define PDMA_TDSTS_TDIF5_Pos             (5)                                               /*!< PDMA_T::TDSTS: TDIF5 Position          */
+#define PDMA_TDSTS_TDIF5_Msk             (0x1ul << PDMA_TDSTS_TDIF5_Pos)                   /*!< PDMA_T::TDSTS: TDIF5 Mask              */
+
+#define PDMA_TDSTS_TDIF6_Pos             (6)                                               /*!< PDMA_T::TDSTS: TDIF6 Position          */
+#define PDMA_TDSTS_TDIF6_Msk             (0x1ul << PDMA_TDSTS_TDIF6_Pos)                   /*!< PDMA_T::TDSTS: TDIF6 Mask              */
+
+#define PDMA_TDSTS_TDIF7_Pos             (7)                                               /*!< PDMA_T::TDSTS: TDIF7 Position          */
+#define PDMA_TDSTS_TDIF7_Msk             (0x1ul << PDMA_TDSTS_TDIF7_Pos)                   /*!< PDMA_T::TDSTS: TDIF7 Mask              */
+
+#define PDMA_ALIGN_ALIGNn_Pos           (0)                                                /*!< PDMA_T::ALIGN: ALIGNn Position        */
+#define PDMA_ALIGN_ALIGNn_Msk           (0xfful << PDMA_ALIGN_ALIGNn_Pos)                /*!< PDMA_T::ALIGN: ALIGNn Mask            */
+
+#define PDMA_TACTSTS_TXACTFn_Pos         (0)                                               /*!< PDMA_T::TACTSTS: TXACTFn Position      */
+#define PDMA_TACTSTS_TXACTFn_Msk         (0xfful << PDMA_TACTSTS_TXACTFn_Pos)            /*!< PDMA_T::TACTSTS: TXACTFn Mask          */
+
+#define PDMA_TOUTPSC_TOUTPSC0_Pos        (0)                                               /*!< PDMA_T::TOUTPSC: TOUTPSC0 Position     */
+#define PDMA_TOUTPSC_TOUTPSC0_Msk        (0x7ul << PDMA_TOUTPSC_TOUTPSC0_Pos)              /*!< PDMA_T::TOUTPSC: TOUTPSC0 Mask         */
+
+#define PDMA_TOUTPSC_TOUTPSC1_Pos        (4)                                               /*!< PDMA_T::TOUTPSC: TOUTPSC1 Position     */
+#define PDMA_TOUTPSC_TOUTPSC1_Msk        (0x7ul << PDMA_TOUTPSC_TOUTPSC1_Pos)              /*!< PDMA_T::TOUTPSC: TOUTPSC1 Mask         */
+
+#define PDMA_TOUTEN_TOUTENn_Pos          (0)                                               /*!< PDMA_T::TOUTEN: TOUTENn Position       */
+#define PDMA_TOUTEN_TOUTENn_Msk          (0x3ul << PDMA_TOUTEN_TOUTENn_Pos)                /*!< PDMA_T::TOUTEN: TOUTENn Mask           */
+
+#define PDMA_TOUTIEN_TOUTIENn_Pos        (0)                                               /*!< PDMA_T::TOUTIEN: TOUTIENn Position     */
+#define PDMA_TOUTIEN_TOUTIENn_Msk        (0x3ul << PDMA_TOUTIEN_TOUTIENn_Pos)              /*!< PDMA_T::TOUTIEN: TOUTIENn Mask         */
+
+#define PDMA_SCATBA_SCATBA_Pos           (16)                                              /*!< PDMA_T::SCATBA: SCATBA Position        */
+#define PDMA_SCATBA_SCATBA_Msk           (0xfffful << PDMA_SCATBA_SCATBA_Pos)              /*!< PDMA_T::SCATBA: SCATBA Mask            */
+
+#define PDMA_TOC0_1_TOC0_Pos             (0)                                               /*!< PDMA_T::TOC0_1: TOC0 Position          */
+#define PDMA_TOC0_1_TOC0_Msk             (0xfffful << PDMA_TOC0_1_TOC0_Pos)                /*!< PDMA_T::TOC0_1: TOC0 Mask              */
+
+#define PDMA_TOC0_1_TOC1_Pos             (16)                                              /*!< PDMA_T::TOC0_1: TOC1 Position          */
+#define PDMA_TOC0_1_TOC1_Msk             (0xfffful << PDMA_TOC0_1_TOC1_Pos)                /*!< PDMA_T::TOC0_1: TOC1 Mask              */
+
+#define PDMA_CHRST_CHnRST_Pos            (0)                                               /*!< PDMA_T::CHRST: CHnRST Position         */
+#define PDMA_CHRST_CHnRST_Msk            (0xfffful << PDMA_CHRST_CHnRST_Pos)               /*!< PDMA_T::CHRST: CHnRST Mask             */
+
+#define PDMA_REQSEL0_3_REQSRC0_Pos       (0)                                               /*!< PDMA_T::REQSEL0_3: REQSRC0 Position    */
+#define PDMA_REQSEL0_3_REQSRC0_Msk       (0x7ful << PDMA_REQSEL0_3_REQSRC0_Pos)            /*!< PDMA_T::REQSEL0_3: REQSRC0 Mask        */
+
+#define PDMA_REQSEL0_3_REQSRC1_Pos       (8)                                               /*!< PDMA_T::REQSEL0_3: REQSRC1 Position    */
+#define PDMA_REQSEL0_3_REQSRC1_Msk       (0x7ful << PDMA_REQSEL0_3_REQSRC1_Pos)            /*!< PDMA_T::REQSEL0_3: REQSRC1 Mask        */
+
+#define PDMA_REQSEL0_3_REQSRC2_Pos       (16)                                              /*!< PDMA_T::REQSEL0_3: REQSRC2 Position    */
+#define PDMA_REQSEL0_3_REQSRC2_Msk       (0x7ful << PDMA_REQSEL0_3_REQSRC2_Pos)            /*!< PDMA_T::REQSEL0_3: REQSRC2 Mask        */
+
+#define PDMA_REQSEL0_3_REQSRC3_Pos       (24)                                              /*!< PDMA_T::REQSEL0_3: REQSRC3 Position    */
+#define PDMA_REQSEL0_3_REQSRC3_Msk       (0x7ful << PDMA_REQSEL0_3_REQSRC3_Pos)            /*!< PDMA_T::REQSEL0_3: REQSRC3 Mask        */
+
+#define PDMA_REQSEL4_7_REQSRC4_Pos       (0)                                               /*!< PDMA_T::REQSEL4_7: REQSRC4 Position    */
+#define PDMA_REQSEL4_7_REQSRC4_Msk       (0x7ful << PDMA_REQSEL4_7_REQSRC4_Pos)            /*!< PDMA_T::REQSEL4_7: REQSRC4 Mask        */
+
+#define PDMA_REQSEL4_7_REQSRC5_Pos       (8)                                               /*!< PDMA_T::REQSEL4_7: REQSRC5 Position    */
+#define PDMA_REQSEL4_7_REQSRC5_Msk       (0x7ful << PDMA_REQSEL4_7_REQSRC5_Pos)            /*!< PDMA_T::REQSEL4_7: REQSRC5 Mask        */
+
+#define PDMA_REQSEL4_7_REQSRC6_Pos       (16)                                              /*!< PDMA_T::REQSEL4_7: REQSRC6 Position    */
+#define PDMA_REQSEL4_7_REQSRC6_Msk       (0x7ful << PDMA_REQSEL4_7_REQSRC6_Pos)            /*!< PDMA_T::REQSEL4_7: REQSRC6 Mask        */
+
+#define PDMA_REQSEL4_7_REQSRC7_Pos       (24)                                              /*!< PDMA_T::REQSEL4_7: REQSRC7 Position    */
+#define PDMA_REQSEL4_7_REQSRC7_Msk       (0x7ful << PDMA_REQSEL4_7_REQSRC7_Pos)            /*!< PDMA_T::REQSEL4_7: REQSRC7 Mask        */
+
+#define PDMA_STCR_STC_Pos                (0)                                               /*!< PDMA_T::STCR: STC Position             */
+#define PDMA_STCR_STC_Msk                (0xfffful << PDMA_STCR_STC_Pos)                   /*!< PDMA_T::STCR: STC Mask                 */
+
+#define PDMA_ASOCR_SASOL_Pos             (0)                                               /*!< PDMA_T::ASOCR: SASOL Position          */
+#define PDMA_ASOCR_SASOL_Msk             (0xfffful << PDMA_ASOCR_SASOL_Pos)                /*!< PDMA_T::ASOCR: SASOL Mask              */
+
+#define PDMA_ASOCR_DASOL_Pos             (16)                                              /*!< PDMA_T::ASOCR: DASOL Position          */
+#define PDMA_ASOCR_DASOL_Msk             (0xfffful << PDMA_ASOCR_DASOL_Pos)                /*!< PDMA_T::ASOCR: DASOL Mask              */
+
+/** @} PDMA_CONST */
+/** @} end of PDMA register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __PDMA_REG_H__ */

--- a/hal/m258ke/nuvoton/psio_reg.h
+++ b/hal/m258ke/nuvoton/psio_reg.h
@@ -1,0 +1,1453 @@
+/**************************************************************************//**
+ * @file     psio_reg.h
+ * @version  V1.00
+ * @brief    PSIO register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __PSIO_REG_H__
+#define __PSIO_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup PSIO Programable Serial IO (PSIO)
+    Memory Mapped Structure for PSIO Controller
+    @{
+*/
+
+typedef struct
+{
+    /**
+    * @var SCCT_T::SCCTL
+     * Offset: 0x20  PSIO Slot Controller n Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |INISLOT   |Initial Slot Period
+     * |        |          |The initial slot of the repeat period
+     * |        |          |0000 = No use.
+     * |        |          |0001 = SLOT0.
+     * |        |          |0010 = SLOT1.
+     * |        |          |0011 = SLOT2.
+     * |        |          |0100 = SLOT3.
+     * |        |          |0101 = SLOT4.
+     * |        |          |0110 = SLOT5.
+     * |        |          |0111 = SLOT6.
+     * |        |          |1000 = SLOT7.
+     * |[7:4]   |ENDSLOT   |End Slot Period
+     * |        |          |The end slot of the repeat period
+     * |        |          |0000 = No use.
+     * |        |          |0001 = SLOT0.
+     * |        |          |0010 = SLOT1.
+     * |        |          |0011 = SLOT2.
+     * |        |          |0100 = SLOT3.
+     * |        |          |0101 = SLOT4.
+     * |        |          |0110 = SLOT5.
+     * |        |          |0111 = SLOT6.
+     * |        |          |1000 = SLOT7.
+     * |[13:8]  |SPLCNT    |Slot Period Loop Count
+     * |        |          |000000 ~ 111110: loop count
+     * |        |          |000000 = slot period loop count function is disable.
+     * |        |          |000001= repeat selection loop once, which means total go through selected repeat slots 2 times.
+     * |        |          |111111 = loop until stop PSIO slot controller.
+     * |        |          |Note1: If setting this register 111111 with PDMA mode and OUTPUT mode, it will stop automatically when PDMA is finish and output data in shift register is finished.
+     * |        |          |Note2: If setting this register 111111 with PDMA mode and INPUT mode, it will stop automatically when pdma is finish.
+     * |        |          |Note3: If PSIO receives stop instruction during repeat mode, it will stop only when the current loop is finished.
+     * |[15:14] |TRIGSRC   |PSIO_TMRxPSIO_SCn Trigger Source
+     * |        |          |00 = Trigger by software.
+     * |        |          |01 = Trigger PSIO_TMRxPSIO_SCn when related PSIO_PIN occurred falling edge.
+     * |        |          |02 = Trigger PSIO_TMRxPSIO_SCn when related PSIO_PIN occurred rising edge.
+     * |        |          |03 = Trigger PSIO_TMRxPSIO_SCn when related PSIO_PIN occurred rising edge or falling edge.
+     * |        |          |Note1: PSIO slot controller pin can only be trigger by related pins which is setting from PSIOn_GENCTL[25:24] SC_SEL.
+     * |        |          |Note2: Configuring rising or falling signal trigger PSIO, the signal need to hold for at least two PSIO_CLK for de-bounce or PSIO will not be triggered.
+     * |[16]    |START     |PSIO_TMRxPSIO_SCn Start
+     * |        |          |0 = Stop PSIO_TMRxPSIO_SCn.
+     * |        |          |1 = Start PSIO_TMRxPSIO_SCn to count and active related PSIO_PIN.
+     * |        |          |Note: this bit is always read as 0.
+     * |[17]    |REPEAT    |Whole Repeat Mode
+     * |        |          |Slot controller repeats counting forever. It can stop by clear START bit.
+     * |        |          |0 = Repeat mode disabled.
+     * |        |          |1 = Repeat mode enabled.
+     * |        |          |Note1: If this bit is enabled with PDMA mode, slot controller will stop automatically when the PDMA finish transferring number of data.
+     * |        |          |Note2: If PSIO receives stop instruction during repeat mode, it will stop only when the current loop is finished.
+     * |[24]    |BUSY      |PSIO_TMRxPSIO_SCn Busy Flag
+     * |        |          |0 = PSIO_TMRxPSIO_SCn is not busy.
+     * |        |          |1 = PSIO_TMRxPSIO_SCn is busy.
+     * |        |          |Note: This bit will be set to 1 when slot controller start to count automatically and it will be cleared to 0 automatically when slot controller stop counting, too
+     * |[25]    |IDLE      |PSIO_TMRxPSIO_SCn Idle Flag
+     * |        |          |0 = PSIO_TMRxPSIO_SCn is not IDLE.
+     * |        |          |1 = PSIO_TMRxPSIO_SCn is IDLE.
+     * |        |          |Note1: This bit will be cleared to 0 when slot controller start to count automatically.
+     * |        |          |Note2: This bit will be set to 1 when configuring it 1 by software.
+     * |        |          |Note3: This bit is set to distinguish INTERVAL_OUTPUT(PSIOn_GENCTL[5:4]) and INITIAL_OUTPUT(PSIOn_GENCTL[3:2]).
+     * @var SCCT_T::SCSLOT
+     * Offset: 0x24  PSIO Slot Controller n Slot Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |SLOT0     |PSIO Slot Controller Slot0 Tick Count
+     * |        |          |0 to 15
+     * |        |          |Note1: Filling in all 0 to this field indicates to disable this slot.
+     * |        |          |Note2: The disabled slot should not be set between the enabled slots, or the order of enabled slot which is after the disabled slot will not be enable.
+     * |        |          |Note3: The shortest slot length is 6 when I/O mode is switched from output mode to input mode.
+     * |[7:4]   |SLOT1     |PSIO Slot Controller Slot1 Tick Count
+     * |        |          |0 to 15
+     * |        |          |Note1: Filling in all 0 to this field indicates to disable this slot.
+     * |        |          |Note2: The disabled slot should not be set between the enabled slots, or the order of enabled slot which is after the disabled slot will not be enable.
+     * |        |          |Note3: The shortest slot length is 6 when I/O mode is switched from output mode to input mode.
+     * |[11:8]  |SLOT2     |PSIO Slot Controller Slot2 Tick Count
+     * |        |          |0 to 15
+     * |        |          |Note1: Filling in all 0 to this field indicates to disable this slot.
+     * |        |          |Note2: The disabled slot should not be set between the enabled slots, or the order of enabled slot which is after the disabled slot will not be enable.
+     * |        |          |Note3: The shortest slot length is 6 when I/O mode is switched from output mode to input mode.
+     * |[15:12] |SLOT3     |PSIO Slot Controller Slot3 Tick Count
+     * |        |          |0 to 15.
+     * |        |          |Note1: Filling in all 0 to this field indicates to disable this slot.
+     * |        |          |Note2: The disabled slot should not be set between the enabled slots, or the order of enabled slot which is after the disabled slot will not be enable.
+     * |        |          |Note3: The shortest slot length is 6 when I/O mode is switched from output mode to input mode.
+     * |[19:16] |SLOT4     |PSIO Slot Controller Slot4 Tick Count
+     * |        |          |0 to 15
+     * |        |          |Note1: Filling in all 0 to this field indicates to disable this slot.
+     * |        |          |Note2: The disabled slot should not be set between the enabled slots, or the order of enabled slot which is after the disabled slot will not be enable.
+     * |        |          |Note3: The shortest slot length is 6 when I/O mode is switched from output mode to input mode.
+     * |[23:20] |SLOT5     |PSIO Slot Controller Slot5 Tick Count
+     * |        |          |0 to 15
+     * |        |          |Note1: Filling in all 0 to this field indicates to disable this slot.
+     * |        |          |Note2: The disabled slot should not be set between the enabled slots, or the order of enabled slot which is after the disabled slot will not be enable.
+     * |        |          |Note3: The shortest slot length is 6 when I/O mode is switched from output mode to input mode.
+     * |[27:24] |SLOT6     |PSIO Slot Controller Slot6 Tick Count
+     * |        |          |0 to 15
+     * |        |          |Note1: Filling in all 0 to this field indicates to disable this slot.
+     * |        |          |Note2: The disabled slot should not be set between the enabled slots, or the order of enabled slot which is after the disabled slot will not be enable.
+     * |        |          |Note3: The shortest slot length is 6 when I/O mode is switched from output mode to input mode.
+     * |[31:28] |SLOT7     |PSIO Slot Controller Slot7 Tick Count
+     * |        |          |0 to 15
+     * |        |          |Note1: Filling in all 0 to this field indicates to disable this slot.
+     * |        |          |Note2: The disabled slot should not be set between the enabled slots, or the order of enabled slot which is after the disabled slot will not be enable.
+     * |        |          |Note3: The shortest slot length is 6 when I/O mode is switched from output mode to input mode.
+     */
+    __IO uint32_t SCCTL;                 /*!< PSIO Slot Counter n Control register                                     */
+    __IO uint32_t SCSLOT;                /*!< PSIO Slot Counter n Slot Register                                        */
+
+} SCCT_T;
+
+typedef struct
+{
+    /**
+    * @var GNCT_T::GENCTL
+    * Offset: 0x40  PSIOn General Control Register
+    * ---------------------------------------------------------------------------------------------------
+    * |Bits    |Field     |Descriptions
+    * | :----: | :----:   | :---- |
+    * |[1:0]   |IOMODE    |IO Mode
+    * |        |          |I/O mode state represent the I/O state when slot controller has not started counting or slot controller has started counting but has not cross the switch I/O mode check point.
+    * |        |          |00 = Input mode.
+    * |        |          |01 = Output mode.
+    * |        |          |10 = Open-drain.
+    * |        |          |11 = Quasi-bidirectional Mode.
+    * |        |          |Note1: When slot controller stops counting, it will switch to the current I/O mode setting.
+    * |        |          |Note2: When PSIO uses quasi mode or open drain mode to trigger slot controller, the initial or interval state need to be set output high level, or the pin will not be trigger.
+    * |[3:2]   |INITIAL   |Initial Output
+    * |        |          |The output state of PSIO when slot controller stops counting and IDLE (PSIO_SCnCTL[25]) is 1.
+    * |        |          |00 = Low level.
+    * |        |          |01 = High level.
+    * |        |          |10 = Last output.
+    * |        |          |11 = Toggle.
+    * |        |          |Note1: Only when IO_MODE is not input mode, then this register is effective.
+    * |        |          |Note2: This bit is effective only when IDLE(PSIO_SCnCTL[25]) is high.
+    * |[5:4]   |INTERVAL  |Interval Output
+    * |        |          |The output of PSIO when slot controller stops counting and IDLE (PSIO_SCnCTL[25]) is 0.
+    * |        |          |00 = Low level.
+    * |        |          |01 = High level.
+    * |        |          |10 = Last output.
+    * |        |          |11 = Toggle.
+    * |        |          |Note1: Only when IO_MODE is not input mode, then this register is effective.
+    * |        |          |Note2: This bit is effective only when IDLE(PSIO_SCnCTL[25]) is low.
+    * |[11:8]  |SW0CP     |Switch0 Check Point
+    * |        |          |0000 = No use.
+    * |        |          |0001 = CHECK POINT0.
+    * |        |          |0010 = CHECK POINT1.
+    * |        |          |0011 = CHECK POINT 2.
+    * |        |          |0100 = CHECK POINT 3.
+    * |        |          |0101 = CHECK POINT 4.
+    * |        |          |0110 = CHECK POINT 5.
+    * |        |          |0111= CHECK POINT 6.
+    * |        |          |1000 = CHECK POINT 7.
+    * |        |          |Others: reserved
+    * |[15:12] |SW1CP     |Switch1 Check Point
+    * |        |          |0000 = No use.
+    * |        |          |0001 = CHECK POINT0.
+    * |        |          |0010 = CHECK POINT1.
+    * |        |          |0011 = CHECK POINT 2.
+    * |        |          |0100 = CHECK POINT 3.
+    * |        |          |0101 = CHECK POINT 4.
+    * |        |          |0110 = CHECK POINT 5.
+    * |        |          |0111= CHECK POINT 6.
+    * |        |          |1000 = CHECK POINT 7.
+    * |        |          |Others: reserved
+    * |[17:16] |MODESW0   |Mode Switch0 Point
+    * |        |          |Mode at the switch0 point
+    * |        |          |00 = Input mode.
+    * |        |          |01 = Output mode.
+    * |        |          |10 = Open-drain.
+    * |        |          |11 = Quasi-bidirectional Mode.
+    * |[19:18] |MODESW1   |Mode Switch1 Point
+    * |        |          |Mode at the switch1 point
+    * |        |          |00 = Input mode.
+    * |        |          |01 = Output mode.
+    * |        |          |10 = Open-drain mode.
+    * |        |          |11 = Quasi-bidirectional Mode.
+    * |[25:24] |SCSEL     |Slot Controller Selection
+    * |        |          |Select slot controller for check point
+    * |        |          |00 = SLOT CONTROLLER0.
+    * |        |          |01 = SLOT CONTROLLER1.
+    * |        |          |10 = SLOT CONTROLLER2.
+    * |        |          |11 = SLOT CONTROLLER3.
+    * |[26]    |PINEN     |Pin Enable Bit
+    * |        |          |0 = Pin Disabled.
+    * |        |          |1 = Pin Enabled.
+    * @var GNCT_T::DATCTL
+    * Offset: 0x44  PSIOn Data Control Register
+    * ---------------------------------------------------------------------------------------------------
+    * |Bits    |Field     |Descriptions
+    * | :----: | :----:   | :---- |
+    * |[4:0]   |OUTDATWD  |Output Data Width
+    * |        |          |Indicate the data width of OUTPUT DATA register.
+    * |        |          |Output data size = OUTDATWD +1.
+    * |        |          |e.g.
+    * |        |          |5'b00000 = 1 bit.
+    * |        |          |5'b11111=32 bit.
+    * |[12:8]  |INDATWD   |Input Data Width
+    * |        |          |Indicate the data width of INPUT DATA register.
+    * |        |          |Input data size = INDATWD +1.
+    * |        |          |e.g.
+    * |        |          |5'b00000 = 1 bit.
+    * |        |          |5'b11111=32 bit.
+    * |[16]    |ORDER     |Order
+    * |        |          |The order of output data and input data
+    * |        |          |Data transfer start form
+    * |        |          |0 = LSB.
+    * |        |          |1 = MSB.
+    * |[25:24] |OUTDEPTH  |Output Data Depth
+    * |        |          |Represent the data depth of the output buffer, when data width is larger than 16-bit, this setting can be ignored.
+    * |        |          |When the data width is between 9-bit and 16 bit ,
+    * |        |          |0 = OUTDEPTH [0], the data depth is 1.
+    * |        |          |1 = OUTDEPTH [0], the data depth is 2.
+    * |        |          |When the data width is less than or equal to 8-bit.
+    * |        |          |0 = OUTDEPTH, the data depth is 1.
+    * |        |          |1 = OUTDEPTH, the data depth is 2.
+    * |        |          |2 = OUTDEPTH, the data depth is 3.
+    * |        |          |3 = OUTDEPTH, the data depth is 4.
+    * |        |          |Note1: data depth impact when the output empty flag and output under flow flag will be set to 1.
+    * |        |          |Note2: There is no difference of data depth no matter using software program data or PDMA program data.
+    * |[29:28] |INDEPTH   |Input Data Depth
+    * |        |          |Represent the data depth of the input buffer, when data width is larger than 16-bit, this setting can be ignored.
+    * |        |          |When the data width is between 9-bit and 16 bit ,
+    * |        |          |0 = INDEPTH[0], the data depth is 1.
+    * |        |          |1 = INDEPTH[0], the data depth is 2.
+    * |        |          |When the data width is less than or equal to 8-bit.
+    * |        |          |0 = INDEPTH, the data depth is 1.
+    * |        |          |1 = INDEPTH, the data depth is 2.
+    * |        |          |2 = INDEPTH, the data depth is 3.
+    * |        |          |3 = INDEPTH, the data depth is 4.
+    * |        |          |Note1: data depth impact when the full flag and input over flow flag will be set to 1.
+    * |        |          |Note2: There is no difference of data depth no matter using software program data or PDMA program data.
+    * @var GNCT_T::INSTS
+    * Offset: 0x48  PSIOn Input Status Register
+    * ---------------------------------------------------------------------------------------------------
+    * |Bits    |Field     |Descriptions
+    * | :----: | :----:   | :---- |
+    * |[7:0]   |INSTS     |Input Status
+    * |        |          |Status input buffer
+    * |        |          |(read clear)
+    * |        |          |Note: When the valid bit is set, the valid bits number of INSTS is equal to the number of check points from the previous time INSTS update to the current INSTS update.
+    * @var GNCT_T::INDAT
+    * Offset: 0x4C  PSIOn Input Data Register
+    * ---------------------------------------------------------------------------------------------------
+    * |Bits    |Field     |Descriptions
+    * | :----: | :----:   | :---- |
+    * |[31:0]  |INDAT     |Input Data Buffer
+    * |        |          |This register can be read clear.
+    * |        |          |Note: The input data sample time is according to the slot length
+    * |        |          |The sampling time is near 3/4 slot
+    * |        |          |When the slot length is 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, PSIO sample input data when the slot controller count to 1, 2, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9.
+    * @var GNCT_T::OUTDAT
+    * Offset: 0x50  PSIOn Output Data Register
+    * ---------------------------------------------------------------------------------------------------
+    * |Bits    |Field     |Descriptions
+    * | :----: | :----:   | :---- |
+    * |[31:0]  |OUTDAT    |Output Data Buffer
+    * |        |          |This field is used to configure output data.
+    * @var GNCT_T::CPCTL0
+    * Offset: 0x54  PSIOn Check Point Control 0 Register
+    * ---------------------------------------------------------------------------------------------------
+    * |Bits    |Field     |Descriptions
+    * | :----: | :----:   | :---- |
+    * |[2:0]   |CKPT0     |Check Point 0
+    * |        |          |0000 = No use.
+    * |        |          |0001 = SLOT0.
+    * |        |          |0010 = SLOT1.
+    * |        |          |0011 = SLOT2.
+    * |        |          |0100 = SLOT3.
+    * |        |          |0101 = SLOT4.
+    * |        |          |0110 = SLOT5.
+    * |        |          |0111 = SLOT6.
+    * |        |          |1000 = SLOT6.
+    * |        |          |Others = Reserved.
+    * |        |          |Note1: If there are two check points select the same SLOT, pin will follow settings of the smaller check point number.
+    * |        |          |Note2: The correlated SLOT should be filled in order from SLOT0 to SLOT7, or the check point action will not be triggered.
+    * |[6:4]   |CKPT1     |Check Point 1
+    * |        |          |0000 = No use.
+    * |        |          |0001 = SLOT0.
+    * |        |          |0010 = SLOT1.
+    * |        |          |0011 = SLOT2.
+    * |        |          |0100 = SLOT3.
+    * |        |          |0101 = SLOT4.
+    * |        |          |0110 = SLOT5.
+    * |        |          |0111 = SLOT6.
+    * |        |          |1000 = SLOT6.
+    * |        |          |Others = Reserved.
+    * |        |          |Note1: If there are two check points select the same SLOT, pin will follow settings of the smaller check point number.
+    * |        |          |Note2: The correlated SLOT should be filled in order from SLOT0 to SLOT7, or the check point action will not be triggered.
+    * |[10:8]  |CKPT2     |Check Point 2
+    * |        |          |0000 = No use.
+    * |        |          |0001 = SLOT0.
+    * |        |          |0010 = SLOT1.
+    * |        |          |0011 = SLOT2.
+    * |        |          |0100 = SLOT3.
+    * |        |          |0101 = SLOT4.
+    * |        |          |0110 = SLOT5.
+    * |        |          |0111 = SLOT6.
+    * |        |          |1000 = SLOT6.
+    * |        |          |Others = Reserved.
+    * |        |          |Note1: If there are two check points select the same SLOT, pin will follow settings of the smaller check point number.
+    * |        |          |Note2: The correlated SLOT should be filled in order from SLOT0 to SLOT7, or the check point action will not be triggered.
+    * |[14:12] |CKPT3     |Check Point 3
+    * |        |          |0000 = No use.
+    * |        |          |0001 = SLOT0.
+    * |        |          |0010 = SLOT1.
+    * |        |          |0011 = SLOT2.
+    * |        |          |0100 = SLOT3.
+    * |        |          |0101 = SLOT4.
+    * |        |          |0110 = SLOT5.
+    * |        |          |0111 = SLOT6.
+    * |        |          |1000 = SLOT6.
+    * |        |          |Others = Reserved.
+    * |        |          |Note1: If there are two check points select the same SLOT, pin will follow settings of the smaller check point number.
+    * |        |          |Note2: The correlated SLOT should be filled in order from SLOT0 to SLOT7, or the check point action will not be triggered.
+    * |[18:16] |CKPT4     |Check Point 4
+    * |        |          |0000 = No use.
+    * |        |          |0001 = SLOT0.
+    * |        |          |0010 = SLOT1.
+    * |        |          |0011 = SLOT2.
+    * |        |          |0100 = SLOT3.
+    * |        |          |0101 = SLOT4.
+    * |        |          |0110 = SLOT5.
+    * |        |          |0111 = SLOT6.
+    * |        |          |1000 = SLOT6.
+    * |        |          |Others = Reserved.
+    * |        |          |Note1: If there are two check points select the same SLOT, pin will follow settings of the smaller check point number.
+    * |        |          |Note2: The correlated SLOT should be filled in order from SLOT0 to SLOT7, or the check point action will not be triggered.
+    * |[22:20] |CKPT5     |Check Point 5
+    * |        |          |0000 = No use.
+    * |        |          |0001 = SLOT0.
+    * |        |          |0010 = SLOT1.
+    * |        |          |0011 = SLOT2.
+    * |        |          |0100 = SLOT3.
+    * |        |          |0101 = SLOT4.
+    * |        |          |0110 = SLOT5.
+    * |        |          |0111 = SLOT6.
+    * |        |          |1000 = SLOT6.
+    * |        |          |Others = Reserved.
+    * |        |          |Note1: If there are two check points select the same SLOT, pin will follow settings of the smaller check point number.
+    * |        |          |Note2: The correlated SLOT should be filled in order from SLOT0 to SLOT7, or the check point action will not be triggered.
+    * |[26:24] |CKPT6     |Check Point 6
+    * |        |          |0000 = No use.
+    * |        |          |0001 = SLOT0.
+    * |        |          |0010 = SLOT1.
+    * |        |          |0011 = SLOT2.
+    * |        |          |0100 = SLOT3.
+    * |        |          |0101 = SLOT4.
+    * |        |          |0110 = SLOT5.
+    * |        |          |0111 = SLOT6.
+    * |        |          |1000 = SLOT6.
+    * |        |          |Others = Reserved.
+    * |        |          |Note1: If there are two check points select the same SLOT, pin will follow settings of the smaller check point number.
+    * |        |          |Note2: The correlated SLOT should be filled in order from SLOT0 to SLOT7, or the check point action will not be triggered.
+    * |[30:28] |CKPT7     |Check Point 7
+    * |        |          |This field is used to link check point and slot controller slot.
+    * |        |          |0000 = No use.
+    * |        |          |0001 = SLOT0.
+    * |        |          |0010 = SLOT1.
+    * |        |          |0011 = SLOT2.
+    * |        |          |0100 = SLOT3.
+    * |        |          |0101 = SLOT4.
+    * |        |          |0110 = SLOT5.
+    * |        |          |0111 = SLOT6.
+    * |        |          |1000 = SLOT7.
+    * |        |          |Others = Reserved.
+    * |        |          |Note1: If there are two check points select the same SLOT, pin will follow settings of the smaller check point number.
+    * |        |          |Note2: The correlated SLOT should be filled in order from SLOT0 to SLOT7, or the check point action will not be triggered.
+    * @var GNCT_T::CPCTL1
+    * Offset: 0x58  PSIOn Check Point Control1 Register
+    * ---------------------------------------------------------------------------------------------------
+    * |Bits    |Field     |Descriptions
+    * | :----: | :----:   | :---- |
+    * |[2:0]   |CKPT0ACT  |Check Point 0 Action
+    * |        |          |Select check point action at check point0
+    * |        |          |000 = output level low.
+    * |        |          |001 = output level high.
+    * |        |          |010 = output from data buffer.
+    * |        |          |011 = output toggle.
+    * |        |          |100 = input data buffer.
+    * |        |          |101 = input status.
+    * |        |          |110 = input status record and update.
+    * |        |          |Others = reserved.
+    * |        |          |Note: Pin action must meet the correlated I/O mode (PSIOn_GENCTL[1:0])
+    * |[6:4]   |CKPT1ACT  |Check Point 1 Action
+    * |        |          |Select check point action at check point1
+    * |        |          |000 = output level low.
+    * |        |          |001 = output level high.
+    * |        |          |010 = output from data buffer.
+    * |        |          |011 = output toggle.
+    * |        |          |100 = input data buffer.
+    * |        |          |101 = input status.
+    * |        |          |110 = input status record and update.
+    * |        |          |Others = reserved.
+    * |        |          |Note: Pin action must meet the correlated I/O mode (PSIOn_GENCTL[1:0])
+    * |[10:8]  |CKPT2ACT  |Check Point 2 Action
+    * |        |          |Select check point action at check point2
+    * |        |          |000 = output level low.
+    * |        |          |001 = output level high.
+    * |        |          |010 = output from data buffer.
+    * |        |          |011 = output toggle.
+    * |        |          |100 = input data buffer.
+    * |        |          |101 = input status.
+    * |        |          |110 = input status record and update.
+    * |        |          |Others = reserved.
+    * |        |          |Note: Pin action must meet the correlated I/O mode (PSIOn_GENCTL[1:0])
+    * |[14:12] |CKPT3ACT  |Check Point 3 Action
+    * |        |          |Select check point action at check point3
+    * |        |          |000 = output level low.
+    * |        |          |001 = output level high.
+    * |        |          |010 = output from data buffer.
+    * |        |          |011 = output toggle.
+    * |        |          |100 = input data buffer.
+    * |        |          |101 = input status.
+    * |        |          |110 = input status record and update.
+    * |        |          |Others = reserved.
+    * |        |          |Note: Pin action must meet the correlated I/O mode (PSIOn_GENCTL[1:0])
+    * |[18:16] |CKPT4ACT  |Check Point 4 Action
+    * |        |          |Select check point action at check point4
+    * |        |          |000 = output level low.
+    * |        |          |001 = output level high.
+    * |        |          |010 = output from data buffer.
+    * |        |          |011 = output toggle.
+    * |        |          |100 = input data buffer.
+    * |        |          |101 = input status.
+    * |        |          |110 = input status record and update.
+    * |        |          |Others = reserved.
+    * |        |          |Note: Pin action must meet the correlated I/O mode (PSIOn_GENCTL[1:0])
+    * |[22:20] |CKPT5ACT  |Check Point 5 Action
+    * |        |          |Select check point action at check point5
+    * |        |          |000 = output level low.
+    * |        |          |001 = output level high.
+    * |        |          |010 = output from data buffer.
+    * |        |          |011 = output toggle.
+    * |        |          |100 = input data buffer.
+    * |        |          |101 = input status.
+    * |        |          |110 = input status record and update.
+    * |        |          |Others = reserved.
+    * |        |          |Note: Pin action must meet the correlated I/O mode (PSIOn_GENCTL[1:0])
+    * |[26:24] |CKPT6ACT  |Check Point 6 Action
+    * |        |          |Select check point action at check point6
+    * |        |          |000 = output level low.
+    * |        |          |001 = output level high.
+    * |        |          |010 = output from data buffer.
+    * |        |          |011 = output toggle.
+    * |        |          |100 = input data buffer.
+    * |        |          |101 = input status.
+    * |        |          |110 = input status record and update.
+    * |        |          |Others = reserved.
+    * |        |          |Note: Pin action must meet the correlated I/O mode (PSIOn_GENCTL[1:0])
+    * |[30:28] |CKPT7ACT  |Check Point 7 Action
+    * |        |          |Select check point action at check point7
+    * |        |          |000 = output level low.
+    * |        |          |001 = output level high.
+    * |        |          |010 = output from data buffer.
+    * |        |          |011 = output toggle.
+    * |        |          |100 = input data buffer.
+    * |        |          |101 = input status.
+    * |        |          |110 = input status record and update.
+    * |        |          |Others = reserved.
+    * |        |          |Note: Pin action must meet the correlated I/O mode (PSIOn_GENCTL[1:0])
+    */
+    __IO uint32_t GENCTL;                /*!< PSIOn General Control Register                                           */
+    __IO uint32_t DATCTL;                /*!< PSIOn Data Control Register                                              */
+    __I  uint32_t INSTS;                 /*!< PSIOn Input Status Register                                              */
+    __I  uint32_t INDAT;                 /*!< PSIOn Input Data Register                                                */
+    __O  uint32_t OUTDAT;                /*!< PSIOn Output Data Register                                               */
+    __IO uint32_t CPCTL0;                /*!< PSIOn Check Point Control 0 Register                                     */
+    __IO uint32_t CPCTL1;                /*!< PSIOn Check Point Control1 Register                                      */
+    __I  uint32_t RESERVE0[1];
+} GNCT_T;
+
+typedef struct
+{
+    /**
+     * @var PSIO_T::INTCTL
+     * Offset: 0x00  PSIO Interrupt Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |CONI0SS   |Configurable Interrupt 0 Slot Selection
+     * |        |          |0000: NO USE
+     * |        |          |0001: SLOT0
+     * |        |          |0010: SLOT1
+     * |        |          |0011: SLOT2
+     * |        |          |0100: SLOT3
+     * |        |          |0101: SLOT4
+     * |        |          |0110: SLOT5
+     * |        |          |0111: SLOT6
+     * |        |          |1000: SLOT7
+     * |        |          |1001 u2013 1111:Reserved
+     * |[6:4]   |CONI1SS   |Configurable Interrupt 1 Slot Selection
+     * |        |          |0000: NO USE
+     * |        |          |0001: SLOT0
+     * |        |          |0010: SLOT1
+     * |        |          |0011: SLOT2
+     * |        |          |0100: SLOT3
+     * |        |          |0101: SLOT4
+     * |        |          |0110: SLOT5
+     * |        |          |0111: SLOT6
+     * |        |          |1000: SLOT7
+     * |        |          |1001 u2013 1111:Reserved
+     * |[9:8]   |CONI0SCS  |Configurable Interrupt 0 Slot Controller Selection
+     * |        |          |Select Slot controller for INT0
+     * |        |          |00 = Slot controller 0.
+     * |        |          |01 = Slot controller 1.
+     * |        |          |10 = Slot controller 2.
+     * |        |          |11 = Slot controller 3.
+     * |[13:12] |CONI1SCS  |Configurable Interrupt 1 Slot Controller Selection
+     * |        |          |Select Slot controller for INT1
+     * |        |          |00 = Slot controller 0.
+     * |        |          |01 = Slot controller 1.
+     * |        |          |10 = Slot controller 2.
+     * |        |          |11 = Slot controller 3.
+     * |[31]    |LOOPBACK  |Loop Back Test Enable Bit
+     * |        |          |If this bit is enabled, PIN0 output will be connected to PIN1 input, PIN1 output will be connected to PIN0 input.
+     * |        |          |So do the others pin.
+     * @var PSIO_T::INTEN
+     * Offset: 0x04  PSIO Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CON0IE    |Configurable Interrupt 0 Enable Bit
+     * |        |          |This field is used to enable selective interrupt 0.
+     * |        |          |0 = Selective interrupt 0 Disabled.
+     * |        |          |1 = Selective interrupt 0 Enabled.
+     * |[1]     |CON1IE    |Configurable Interrupt 1 Enable Bit
+     * |        |          |This field is used to enable selective interrupt 1.
+     * |        |          |0 = Selective interrupt 1 Disabled.
+     * |        |          |1 = Selective interrupt 1 Enabled.
+     * |[2]     |MISMATIE  |Mismatch Interrupt Enable Bit
+     * |        |          |This field is used to enable mismatch interrupt.
+     * |        |          |0 = Mismatch interrupt Disabled.
+     * |        |          |1 = Mismatch interrupt Enabled.
+     * |[3]     |TERRIE    |Transfer Error Interrupt Enable Bit
+     * |        |          |This field is used to enable transfer error interrupt.
+     * |        |          |0 = Transfer error interrupt Disabled.
+     * |        |          |1 = Transfer error interrupt Enabled.
+     * |[4]     |SC0IE     |Slot Controller 0 Done Interrupt Enable Bit
+     * |        |          |This field is used to enable Slot controller 0 finish interrupt.
+     * |        |          |0 = Slot controller 0 finish interrupt Disabled.
+     * |        |          |1 = Slot controller 0 finish interrupt Enabled.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * |[5]     |SC1IE     |Slot Controller 1 Done Interrupt Enable Bit
+     * |        |          |This field is used to enable Slot controller 1 finish interrupt.
+     * |        |          |0 = Slot controller 1 finish interrupt Disabled.
+     * |        |          |1 = Slot controller 1 finish interrupt Enabled.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * |[6]     |SC2IE     |Slot Controller 2 Done Interrupt Enable Bit
+     * |        |          |This field is used to enable Slot controller 2 finish interrupt.
+     * |        |          |0 = Slot controller 2 finish interrupt Disabled.
+     * |        |          |1 = Slot controller 2 finish interrupt Enabled.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * |[7]     |SC3IE     |Slot Controller 3 Done Interrupt Enable Bit
+     * |        |          |This field is used to enable Slot controller 3 finish interrupt.
+     * |        |          |0 = Slot controller 3 finish interrupt Disabled.
+     * |        |          |1 = Slot controller 3 finish interrupt Enabled.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * @var PSIO_T::INTSTS
+     * Offset: 0x08  PSIO Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CON0IF    |Configurable Interrupt 0 Flag
+     * |        |          |The setting interrupt is trigger at the end of the check point of the pin.
+     * |        |          |The setting interrupt is trigger at the end of the check point of the pin.
+     * |        |          |0 = Condition in PSIO_INTCTL is not triggered.
+     * |        |          |1 = Condition in PSIO_INTCTL is triggered.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * |[1]     |CON1IF    |Configurable Interrupt 1 Flag
+     * |        |          |The setting interrupt is trigger at the end of the check point of the pin.
+     * |        |          |0 = Condition in PSIO_INTCTL is not triggered.
+     * |        |          |1 = Condition in PSIO_INTCTL is triggered.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * |[2]     |MISMATIF  |Mismatch Interrupt Flag
+     * |        |          |This flag shows the amounts of data are not the same in each pins with PDMA enabled.
+     * |        |          |If this situation happens, all slot controllers stop counting.
+     * |        |          |0 = Each pin with PDMA enabled receive or transfer data in the same rate.
+     * |        |          |1 = Each pin with PDMA enabled receive or transfer data in different rate.
+     * |        |          |Note1: This flag is only effective on the pin with PDMA enabled.
+     * |        |          |Note2: This bit can be cleared by writing 1.
+     * |[3]     |TERRIF    |Transfer Error Interrupt Status Flag
+     * |        |          |This field is used for transfer error interrupt status flag
+     * |        |          |The transfer error states is at PSIO_DATCTL register which includes receive buffer overflow error INOVER (PSIOn_DATCTL[14]), transmit buffer shortage error OUTUFER (PSIOn_DATCTL[6])
+     * |        |          |0 = Transfer error interrupt did not occur.
+     * |        |          |1 = Transfer error interrupt occurred.
+     * |        |          |Note1: This field is the status flag of INOVER or OUTUFER.
+     * |        |          |Note2: This bit can only be cleared by writing 1 to coordinate transfer error.
+     * |[4]     |SC0IF     |Slot Controller 0 Done Interrupt Status Flag
+     * |        |          |This field is used for slot controller 0 finish interrupt status flag.
+     * |        |          |0 = Slot controller 0 done interrupt did not occur.
+     * |        |          |1 = Slot controller 0 done interrupt occurred.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * |[5]     |SC1IF     |Slot Controller 1 Done Interrupt Status Flag
+     * |        |          |This field is used for slot controller 1 finish interrupt status flag.
+     * |        |          |0 = Slot controller 1 done interrupt did not occur.
+     * |        |          |1 = Slot controller 1 done interrupt occurred.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * |[6]     |SC2IF     |Slot Controller 2 Done Interrupt Status Flag
+     * |        |          |This field is used for slot controller 2 finish interrupt status flag.
+     * |        |          |0 = Slot controller 2 done interrupt did not occur.
+     * |        |          |1 = Slot controller 2 done interrupt occurred.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * |[7]     |SC3IF     |Slot Controller 3 Done Interrupt Status Flag
+     * |        |          |This field is used for slot controller 3 finish interrupt status flag.
+     * |        |          |0 = Slot controller 3 done interrupt did not occur.
+     * |        |          |1 = Slot controller 3 done interrupt occurred.
+     * |        |          |Note: This bit can be cleared by writing 1.
+     * @var PSIO_T::TRANSTS
+     * Offset: 0x0C  PSIO Transfer Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |INFULL0   |Input Data Full Flag0 (Read Only)
+     * |        |          |0 = The pin0 input data is empty.
+     * |        |          |1 = The pin0 input data is full.
+     * |        |          |Note: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[1]     |INOVER0   |Input Data Overflow Flag0
+     * |        |          |0 = The pin0 input data does not occur overflow.
+     * |        |          |1 = The pin0 input data occurs overflow.
+     * |        |          |Note1: When input Overflow happened, it will keep the current data, and discard the upcoming data.
+     * |        |          |Note2: When overflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[2]     |OUTEPY0   |Output Data Empty Flag0 (Read Only)
+     * |        |          |0 = The pin0 output data is full.
+     * |        |          |1 = The pin0 output data is empty.
+     * |[3]     |OUTUF0    |Output Data Underflow Flag0
+     * |        |          |When PSIO is still output data but PSIOn_OUTDAT have not been ready. This flag will be set to 1.
+     * |        |          |0 = The pin0 output data is not underflow.
+     * |        |          |1 = The pin0 output data is underflow.
+     * |        |          |Note1: When output data shortage happened, it will output 0.
+     * |        |          |Note2: When underflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[4]     |INFULL1   |Input Data Full Flag1 (Read Only)
+     * |        |          |0 = The pin1 input data is empty.
+     * |        |          |1 = The pin1 input data is full.
+     * |        |          |Note: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[5]     |INOVER1   |Input Data Overflow Flag1
+     * |        |          |0 = The pin1 input data does not occur overflow.
+     * |        |          |1 = The pin1 input data occurs overflow.
+     * |        |          |Note1: When input Overflow happened, it will keep the current data, and discard the upcoming data.
+     * |        |          |Note2: When overflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[6]     |OUTEPY1   |Output Data Empty Flag1
+     * |        |          |0 = The pin1 output data is full.
+     * |        |          |1 = The pin1 output data is empty.
+     * |[7]     |OUTUF1    |Output Data Underflow Flag1
+     * |        |          |When PSIO is still output data but PSIOn_OUTDAT have not been ready. This flag will be set to 1.
+     * |        |          |0 = The pin1 output data is not underflow.
+     * |        |          |1 = The pin1 output data is underflow.
+     * |        |          |Note1: When output data shortage happened, it will output 0.
+     * |        |          |Note2: When underflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[8]     |INFULL2   |Input Data Full Flag2 (Read Only)
+     * |        |          |0 = The pin2 input data is empty.
+     * |        |          |1 = The pin2 input data is full.
+     * |        |          |Note: This bit will be cleared automatically when related slot controller start and pin is enabled.
+     * |[9]     |INOVER2   |Input Data Overflow Flag2
+     * |        |          |0 = The pin2 input data does not occur overflow.
+     * |        |          |1 = The pin2 input data occurs overflow.
+     * |        |          |Note1: When input Overflow happened, it will keep the current data, and discard the upcoming data.
+     * |        |          |Note2: When overflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[10]    |OUTEPY2   |Output Data Empty Flag2 (Read Only)
+     * |        |          |0 = The pin2 output data is full.
+     * |        |          |1 = The pin2 output data is empty.
+     * |[11]    |OUTUF2    |Output Data Underflow Flag2
+     * |        |          |When PSIO is still output data but PSIOn_OUTDAT have not been ready. This flag will be set to 1.
+     * |        |          |0 = The pin3 output data is not underflow.
+     * |        |          |1 = The pin3 output data is underflow.
+     * |        |          |Note1: When output data shortage happened, it will output 0.
+     * |        |          |Note2: When underflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[12]    |INFULL3   |Input Data Full Flag3 (Read Only)
+     * |        |          |0 = The pin3 input data is empty.
+     * |        |          |1 = The pin3 input data is full.
+     * |        |          |Note: This bit will be cleared automatically when related slot controller start and pin is enabled.
+     * |[13]    |INOVER3   |Input Data Overflow Flag3
+     * |        |          |0 = The pin3 input data does not occur overflow.
+     * |        |          |1 = The pin3 input data occurs overflow.
+     * |        |          |Note1: When input Overflow happened, it will keep the current data, and discard the upcoming data.
+     * |        |          |Note2: When overflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[14]    |OUTEPY3   |Output Data Empty Flag3 (Read Only)
+     * |        |          |0 = The pin3 output data is full.
+     * |        |          |1 = The pin3 output data is empty.
+     * |[15]    |OUTUF3    |Output Data Underflow Flag3
+     * |        |          |When PSIO is still output data but PSIOn_OUTDAT have not been ready. This flag will be set to 1.
+     * |        |          |0 = The pin3 output data is not underflow.
+     * |        |          |1 = The pin3 output data is underflow.
+     * |        |          |Note1: When output data shortage happened, it will output 0.
+     * |        |          |Note2: When underflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[16]    |INFULL4   |Input Data Full Flag4 (Read Only)
+     * |        |          |0 = The pin4 input data is empty.
+     * |        |          |1 = The pin4 input data is full.
+     * |        |          |Note: This bit will be cleared automatically when related slot controller start and pin is enabled.
+     * |[17]    |INOVER4   |Input Data Overflow Flag4
+     * |        |          |0 = The pin4 input data does not occur overflow.
+     * |        |          |1 = The pin4 input data occurs overflow.
+     * |        |          |Note1: When input Overflow happened, it will keep the current data, and discard the upcoming data.
+     * |        |          |Note2: When overflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[18]    |OUTEPY4   |Output Data Empty Flag4 (Read Only)
+     * |        |          |0 = The pin4 output data is full.
+     * |        |          |1 = The pin4 output data is empty.
+     * |[19]    |OUTUF4    |Output Data Underflow Flag4
+     * |        |          |When PSIO is still output data but PSIOn_OUTDAT have not been ready. This flag will be set to 1.
+     * |        |          |0 = The pin4 output data is not underflow.
+     * |        |          |1 = The pin4 output data is underflow.
+     * |        |          |Note1: When output data shortage happened, it will output 0.
+     * |        |          |Note2: When underflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[20]    |INFULL5   |Input Data Full Flag5 (Read Only)
+     * |        |          |0 = The pin5 input data is empty.
+     * |        |          |1 = The pin5 input data is full.
+     * |        |          |Note: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[21]    |INOVER5   |Input Data Overflow Flag5
+     * |        |          |0 = The pin5 input data does not occur overflow.
+     * |        |          |1 = The pin5 input data occurs overflow.
+     * |        |          |Note1: When input Overflow happened, it will keep the current data, and discard the upcoming data.
+     * |        |          |Note2: When overflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[22]    |OUTEPY5   |Output Data Empty Flag5 (Read Only)
+     * |        |          |0 = The pin5 output data is full.
+     * |        |          |1 = The pin5 output data is empty.
+     * |[23]    |OUTUF5    |Output Data Underflow Flag5
+     * |        |          |When PSIO is still output data but PSIOn_OUTDAT have not been ready. This flag will be set to 1.
+     * |        |          |0 = The pin5 output data is not underflow.
+     * |        |          |1 = The pin5 output data is underflow.
+     * |        |          |Note1: When output data shortage happened, it will output 0.
+     * |        |          |Note2: When underflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin is enabled.
+     * |[24]    |INFULL6   |Input Data Full Flag6 (Read Only)
+     * |        |          |0 = The pin6 input data is empty.
+     * |        |          |1 = The pin6 input data is full.
+     * |        |          |Note: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[25]    |INOVER6   |Input Data Overflow Flag6
+     * |        |          |0 = The pin6 input data does not occur overflow.
+     * |        |          |1 = The pin6 input data occurs overflow.
+     * |        |          |Note1: When input Overflow happened, it will keep the current data, and discard the upcoming data.
+     * |        |          |Note2: When overflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[26]    |OUTEPY6   |Output Data Empty Flag6 (Read Only)
+     * |        |          |0 = The pin6 output data is full.
+     * |        |          |1 = The pin6 output data is empty.
+     * |[27]    |OUTUF6    |Output Data Underflow Flag6
+     * |        |          |When PSIO is still output data but PSIOn_OUTDAT have not been ready. This flag will be set to 1.
+     * |        |          |0 = The pin6 output data is not underflow.
+     * |        |          |1 = The pin6 output data is underflow.
+     * |        |          |Note1: When output data shortage happened, it will output 0.
+     * |        |          |Note2: When underflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[28]    |INFULL7   |Input Data Full Flag7 (Read Only)
+     * |        |          |0 = The pin7 input data is empty.
+     * |        |          |1 = The pin7 input data is full.
+     * |        |          |Note: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[29]    |INOVER7   |Input Data Overflow Flag7
+     * |        |          |0 = The pin7 input data does not occur overflow.
+     * |        |          |1 = The pin7 input data occurs overflow.
+     * |        |          |Note1: When input Overflow happened, it will keep the current data, and discard the upcoming data.
+     * |        |          |Note2: When overflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * |[30]    |OUTEPY7   |Output Data Empty Flag7 (Read Only)
+     * |        |          |0 = The pin7 output data is full.
+     * |        |          |1 = The pin7 output data is empty.
+     * |[31]    |OUTUF7    |Output Data Underflow Flag7
+     * |        |          |When PSIO is still output data but PSIOn_OUTDAT have not been ready. This flag will be set to 1.
+     * |        |          |0 = The pin7 output data is not underflow.
+     * |        |          |1 = The pin7 output data is underflow.
+     * |        |          |Note1: When output data shortage happened, it will output 0.
+     * |        |          |Note2: When underflow happens, related slot controller will be stopped.
+     * |        |          |Note3: This bit can be cleared by configure 1 to it.
+     * |        |          |Note4: This bit will be cleared automatically when related slot controller start and pin enabled.
+     * @var PSIO_T::ISSTS
+     * Offset: 0x10  PSIO Input Status State Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |VALID0    |Input Status Valid 0
+     * |        |          |0 = The pin 0 input Status is not ready.
+     * |        |          |1 = The pin 0 input Status is ready.
+     * |        |          |Note: This valid bit will be cleared automatically if PSIOn_INSTS is read.
+     * |[1]     |INSTSOV0  |Input Status Overflow 0
+     * |        |          |0 = The pin 0 input Status does not overflow.
+     * |        |          |1 = The pin 0 input Status occur overflow.
+     * |        |          |Note: This overflow bit can be write 1 clear..
+     * |[2]     |VALID1    |Input Status Valid 1
+     * |        |          |0 = The pin 1 input Status is not ready.
+     * |        |          |1 = The pin 1 input Status is ready.
+     * |        |          |Note: This valid bit will be cleared automatically if PSIOn_INSTS is read.
+     * |[3]     |INSTSOV1  |Input Status Overflow 1
+     * |        |          |0 = The pin 1 input Status does not overflow.
+     * |        |          |1 = The pin 1 input Status occur overflow.
+     * |        |          |Note: This overflow bit can be write 1 clear..
+     * |[4]     |VALID2    |Input Status Valid 2
+     * |        |          |0 = The pin 2 input Status is not ready.
+     * |        |          |1 = The pin 2 input Status is ready.
+     * |        |          |Note: This valid bit will be cleared automatically if PSIOn_INSTS is read.
+     * |[5]     |INSTSOV2  |Input Status Overflow 2
+     * |        |          |0 = The pin 2 input Status does not overflow.
+     * |        |          |1 = The pin 2 input Status occur overflow.
+     * |        |          |Note: This overflow bit can be write 1 clear..
+     * |[6]     |VALID3    |Input Status Valid 3
+     * |        |          |0 = The pin 3 input Status is not ready.
+     * |        |          |1 = The pin 3 input Status is ready.
+     * |        |          |Note: This valid bit will be cleared automatically if PSIOn_INSTS is read.
+     * |[7]     |INSTSOV3  |Input Status Overflow 3
+     * |        |          |0 = The pin 3 input Status does not overflow.
+     * |        |          |1 = The pin 3 input Status occur overflow.
+     * |        |          |Note: This overflow bit can be write 1 clear..
+     * |[8]     |VALID4    |Input Status Valid 4
+     * |        |          |0 = The pin 4 input Status is not ready.
+     * |        |          |1 = The pin 4 input Status is ready.
+     * |        |          |Note: This valid bit will be cleared automatically if PSIOn_INSTS is read.
+     * |[9]     |INSTSOV4  |Input Status Overflow 4
+     * |        |          |0 = The pin 4 input Status does not overflow.
+     * |        |          |1 = The pin 4 input Status occur overflow.
+     * |        |          |Note: This overflow bit can be write 1 clear..
+     * |[10]    |VALID5    |Input Status Valid 5
+     * |        |          |0 = The pin 5 input Status is not ready.
+     * |        |          |1 = The pin 5 input Status is ready.
+     * |        |          |Note: This valid bit will be cleared automatically if PSIOn_INSTS is read.
+     * |[11]    |INSTSOV5  |Input Status Overflow 5
+     * |        |          |0 = The pin 5 input Status does not overflow.
+     * |        |          |1 = The pin 5 input Status occur overflow.
+     * |        |          |Note: This overflow bit can be write 1 clear..
+     * |[12]    |VALID6    |Input Status Valid 6
+     * |        |          |0 = The pin 6 input Status is not ready.
+     * |        |          |1 = The pin 6 input Status is ready.
+     * |        |          |Note: This valid bit will be cleared automatically if PSIOn_INSTS is read.
+     * |[13]    |INSTSOV6  |Input Status Overflow 6
+     * |        |          |0 = The pin 6 input Status does not overflow.
+     * |        |          |1 = The pin 6 input Status occur overflow.
+     * |        |          |Note: This overflow bit can be write 1 clear..
+     * |[14]    |VALID7    |Input Status Valid 7
+     * |        |          |0 = The pin7 input Status is not ready.
+     * |        |          |1 = The pin7 input Status is ready.
+     * |        |          |Note: This valid bit will be cleared automatically if PSIOn_INSTS is read.
+     * |[15]    |INSTSOV7  |Input Status Overflow 7
+     * |        |          |0 = The pin7 input Status does not overflow.
+     * |        |          |1 = The pin7 input Status occur overflow.
+     * |        |          |Note: This overflow bit can be write 1 clear..
+     * @var PSIO_T::PDMACTL
+     * Offset: 0x14  PSIO PDMA Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |OPIN0EN   |Output PDMA Pin0 Enable Bit
+     * |        |          |0 = Pin0 output PDMA function Disabled.
+     * |        |          |1 = Pin0 output PDMA function Enabled.
+     * |[1]     |OPIN1EN   |Output PDMA Pin1 Enable Bit
+     * |        |          |0 = Pin1 output PDMA function Disabled.
+     * |        |          |1 = Pin1 output PDMA function Enabled.
+     * |[2]     |OPIN2EN   |Output PDMA Pin2 Enable Bit
+     * |        |          |0 = Pin2 output PDMA function Disabled.
+     * |        |          |1 = Pin2 output PDMA function Enabled.
+     * |[3]     |OPIN3EN   |Output PDMA Pin3 Enable Bit
+     * |        |          |0 = Pin3 output PDMA function Disabled.
+     * |        |          |1 = Pin3 output PDMA function Enabled.
+     * |[4]     |OPIN4EN   |Output PDMA Pin4 Enable Bit
+     * |        |          |0 = Pin4 output PDMA function Disabled.
+     * |        |          |1 = Pin4 output PDMA function Enabled.
+     * |[5]     |OPIN5EN   |Output PDMA Pin5 Enable Bit
+     * |        |          |0 = Pin5 output PDMA function Disabled.
+     * |        |          |1 = Pin5 output PDMA function Enabled.
+     * |[6]     |OPIN6EN   |Output PDMA Pin6 Enable Bit
+     * |        |          |0 = Pin6 output PDMA function Disabled.
+     * |        |          |1 = Pin6 output PDMA function Enabled.
+     * |[7]     |OPIN7EN   |Output PDMA Pin7 Enable Bit
+     * |        |          |0 = Pin7 output PDMA function Disabled.
+     * |        |          |1 = Pin7 output PDMA function Enabled.
+     * |[8]     |IPIN0EN   |Input PDMA Pin0 Enable Bit
+     * |        |          |0 = Pin0 input PDMA function Disabled.
+     * |        |          |1 = Pin0 input PDMA function Enabled.
+     * |[9]     |IPIN1EN   |Input PDMA Pin1 Enable Bit
+     * |        |          |0 = Pin1 input PDMA function Disabled.
+     * |        |          |1 = Pin1 input PDMA function Enabled.
+     * |[10]    |IPIN2EN   |Input PDMA Pin2 Enable Bit
+     * |        |          |0 = Pin2 input PDMA function Disabled.
+     * |        |          |1 = Pin2 input PDMA function Enabled.
+     * |[11]    |IPIN3EN   |Input PDMA Pin3 Enable Bit
+     * |        |          |0 = Pin3 input PDMA function Disabled.
+     * |        |          |1 = Pin3 input PDMA function Enabled.
+     * |[12]    |IPIN4EN   |Input PDMA Pin4 Enable Bit
+     * |        |          |0 = Pin4 input PDMA function Disabled.
+     * |        |          |1 = Pin4 input PDMA function Enabled.
+     * |[13]    |IPIN5EN   |Input PDMA Pin5 Enable Bit
+     * |        |          |0 = Pin5 input PDMA function Disabled.
+     * |        |          |1 = Pin5 input PDMA function Enabled.
+     * |[14]    |IPIN6EN   |Input PDMA Pin6 Enable Bit
+     * |        |          |0 = Pin6 input PDMA function Disabled.
+     * |        |          |1 = Pin6 input PDMA function Enabled.
+     * |[15]    |IPIN7EN   |Input PDMA Pin7 Enable Bit
+     * |        |          |0 = Pin7 input PDMA function Disabled.
+     * |        |          |1 = Pin7 input PDMA function Enabled.
+     * |[19:16] |OUTNUM    |PDMA Output Current Number (Read Only)
+     * |        |          |0000 = PDMA IDLE.
+     * |        |          |0001 = pin 0.
+     * |        |          |0010 = pin 1.
+     * |        |          |0011 = pin 2.
+     * |        |          |0100 = pin 3.
+     * |        |          |0101 = pin 4.
+     * |        |          |0110 = pin 5.
+     * |        |          |0111 = pin 6.
+     * |        |          |1000 = pin 7.
+     * |        |          |1001 = PDMA WAIT.
+     * |        |          |Others = reserved.
+     * |        |          |This register shows the current pin number of output register write by PDMA.
+     * |[21:20] |OUTSCSEL  |PDMA Output Data Slot Controller Selection
+     * |        |          |00: slot controller 0.
+     * |        |          |01: slot controller 1.
+     * |        |          |10: slot controller 2.
+     * |        |          |11: slot controller 3.
+     * |[27:24] |INNUM     |PDMA Input Current Number (Read Only)
+     * |        |          |0000 = PDMA IDLE.
+     * |        |          |0001 = pin 0.
+     * |        |          |0010 = pin 1.
+     * |        |          |0011 = pin 2.
+     * |        |          |0100 = pin 3.
+     * |        |          |0101 = pin 4.
+     * |        |          |0110 = pin 5.
+     * |        |          |0111 = pin 6.
+     * |        |          |1000 = pin 7.
+     * |        |          |1001 = PDMA WAIT.
+     * |        |          |Others = reserved.
+     * |        |          |This register shows the current pin number of input register read by PDMA.
+     * |[29:28] |INSCSEL   |PDMA Input Data Slot Controller Selection
+     * |        |          |00: slot controller 0.
+     * |        |          |01: slot controller 1.
+     * |        |          |10: slot controller 2.
+     * |        |          |11: slot controller 3.
+     * @var PSIO_T::PODAT
+     * Offset: 0x18  PSIO PDMA Output Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |PDMAOUT   |PDMA Output Data
+     * |        |          |This register is used for PSIO with PDMA single mode, and set PDMA with fixed address.
+     * |        |          |When PSIO in PDMA mode, setting PDMA to write data to this register.
+     * |        |          |The data in this register will be placed to corresponding PSIOn_OUTDATA register in order, when Output Data Empty Flag is 1 and PDMA mode enabled.
+     * @var PSIO_T::PIDAT
+     * Offset: 0x1C  PSIO PDMA Input Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |PDMAIN    |PDMA Input Data
+     * |        |          |This register is used for PSIO with PDMA single mode, and set PDMA with fixed address.
+     * |        |          |When PSIO in PDMA mode, setting PDMA to read data from this register.
+     * |        |          |The data in this register will be updated from corresponding PSIOn_INDATA register in order, when Input Data Full Flag is 1 and PDMA mode enable.
+     */
+    __IO uint32_t INTCTL;                /*!< [0x0000] PSIO Interrupt Control Register                                  */
+    __IO uint32_t INTEN;                 /*!< [0x0004] PSIO Interrupt Enable Register                                   */
+    __IO uint32_t INTSTS;                /*!< [0x0008] PSIO Interrupt Status Register                                   */
+    __IO uint32_t TRANSTS;               /*!< [0x000c] PSIO Transfer Status Register                                    */
+    __IO uint32_t ISSTS;                 /*!< [0x0010] PSIO Input Status State Register                                 */
+    __IO uint32_t PDMACTL;               /*!< [0x0014] PSIO PDMA Control Register                                       */
+    __O  uint32_t PODAT;                 /*!< [0x0018] PSIO PDMA Output Data Register                                   */
+    __IO uint32_t PIDAT;                 /*!< [0x001c] PSIO PDMA Input Data Register                                    */
+    SCCT_T        SCCT[4];               /*!< [0x0020 ~ 0x0048] PSIO Slot Controller Registers                          */
+    GNCT_T        GNCT[8];               /*!< [0x0040 ~ 0x0138] PSIO Control Registers                                  */
+} PSIO_T;
+
+/**
+    @addtogroup PSIO_CONST PSIO Bit Field Definition
+    Constant Definitions for PSIO Controller
+@{ */
+
+#define PSIO_INTCTL_CONI0SS_Pos         (0)                                               /*!< PSIO_T::INTCTL: INT0CSEL Position      */
+#define PSIO_INTCTL_CONI0SS_Msk         (0xful << PSIO_INTCTL_CONI0SS_Pos)               /*!< PSIO_T::INTCTL: INT0CSEL Mask          */
+
+#define PSIO_INTCTL_CONI1SS_Pos         (4)                                               /*!< PSIO_T::INTCTL: INT1CSEL Position      */
+#define PSIO_INTCTL_CONI1SS_Msk         (0xful << PSIO_INTCTL_CONI1SS_Pos)               /*!< PSIO_T::INTCTL: INT1CSEL Mask          */
+
+#define PSIO_INTCTL_CONI0SCS_Pos         (8)                                               /*!< PSIO_T::INTCTL: INT0SSEL Position      */
+#define PSIO_INTCTL_CONI0SCS_Msk         (0x3ul << PSIO_INTCTL_CONI0SCS_Pos)               /*!< PSIO_T::INTCTL: INT0SSEL Mask          */
+
+#define PSIO_INTCTL_CONI1SCS_Pos         (12)                                              /*!< PSIO_T::INTCTL: INT1SSEL Position      */
+#define PSIO_INTCTL_CONI1SCS_Msk         (0x3ul << PSIO_INTCTL_CONI1SCS_Pos)               /*!< PSIO_T::INTCTL: INT1SSEL Mask          */
+
+#define PSIO_INTCTL_LOOPBACK_Pos         (31)                                              /*!< PSIO_T::INTCTL: LOOPBACK Position      */
+#define PSIO_INTCTL_LOOPBACK_Msk         (0x1ul << PSIO_INTCTL_LOOPBACK_Pos)               /*!< PSIO_T::INTCTL: LOOPBACK Mask          */
+
+#define PSIO_INTEN_CON0IE_Pos            (0)                                               /*!< PSIO_T::INTEN: INTEN0 Position         */
+#define PSIO_INTEN_CON0IE_Msk            (0x1ul << PSIO_INTEN_CON0IE_Pos)                  /*!< PSIO_T::INTEN: INTEN0 Mask             */
+
+#define PSIO_INTEN_CON1IE_Pos            (1)                                               /*!< PSIO_T::INTEN: INTEN1 Position         */
+#define PSIO_INTEN_CON1IE_Msk            (0x1ul << PSIO_INTEN_CON1IE_Pos)                  /*!< PSIO_T::INTEN: INTEN1 Mask             */
+
+#define PSIO_INTEN_MISMATIE_Pos          (2)                                               /*!< PSIO_T::INTEN: MISMATIE Position       */
+#define PSIO_INTEN_MISMATIE_Msk          (0x1ul << PSIO_INTEN_MISMATIE_Pos)                /*!< PSIO_T::INTEN: MISMATIE Mask           */
+
+#define PSIO_INTEN_TERRIE_Pos            (3)                                               /*!< PSIO_T::INTEN: TERRIE Position         */
+#define PSIO_INTEN_TERRIE_Msk            (0x1ul << PSIO_INTEN_TERRIE_Pos)                  /*!< PSIO_T::INTEN: TERRIE Mask             */
+
+#define PSIO_INTEN_SC0IE_Pos             (4)                                                /*!< PSIO_T::INTEN: SC0IE Position         */
+#define PSIO_INTEN_SC0IE_Msk             (0x1ul << PSIO_INTEN_SC0IE_Pos)                    /*!< PSIO_T::INTEN: SC0IE Mask             */
+
+#define PSIO_INTEN_SC1IE_Pos             (5)                                                /*!< PSIO_T::INTEN: SC1IE Position         */
+#define PSIO_INTEN_SC1IE_Msk             (0x1ul << PSIO_INTEN_SC1IE_Pos)                    /*!< PSIO_T::INTEN: SC1IE Mask             */
+
+#define PSIO_INTEN_SC2IE_Pos             (6)                                                /*!< PSIO_T::INTEN: SC2IE Position         */
+#define PSIO_INTEN_SC2IE_Msk             (0x1ul << PSIO_INTEN_SC2IE_Pos)                    /*!< PSIO_T::INTEN: SC2IE Mask             */
+
+#define PSIO_INTEN_SC3IE_Pos             (7)                                                /*!< PSIO_T::INTEN: SC3IE Position         */
+#define PSIO_INTEN_SC3IE_Msk             (0x1ul << PSIO_INTEN_SC3IE_Pos)                    /*!< PSIO_T::INTEN: SC3IE Mask             */
+
+#define PSIO_INTSTS_CON0IF_Pos           (0)                                               /*!< PSIO_T::INTSTS: INTIF0 Position        */
+#define PSIO_INTSTS_CON0IF_Msk           (0x1ul << PSIO_INTSTS_CON0IF_Pos)                 /*!< PSIO_T::INTSTS: INTIF0 Mask            */
+
+#define PSIO_INTSTS_CON1IF_Pos           (1)                                               /*!< PSIO_T::INTSTS: INTIF1 Position        */
+#define PSIO_INTSTS_CON1IF_Msk           (0x1ul << PSIO_INTSTS_CON1IF_Pos)                 /*!< PSIO_T::INTSTS: INTIF1 Mask            */
+
+#define PSIO_INTSTS_MISMATIF_Pos         (2)                                                /*!< PSIO_T::INTSTS: MISMATIF Position      */
+#define PSIO_INTSTS_MISMATIF_Msk         (0x1ul << PSIO_INTSTS_MISMATIF_Pos)               /*!< PSIO_T::INTSTS: MISMATIF Mask          */
+
+#define PSIO_INTSTS_TERRIF_Pos           (3)                                               /*!< PSIO_T::INTSTS: TERRIF Position        */
+#define PSIO_INTSTS_TERRIF_Msk           (0x1ul << PSIO_INTSTS_TERRIF_Pos)                 /*!< PSIO_T::INTSTS: TERRIF Mask            */
+
+#define PSIO_INTSTS_SC0IF_Pos            (4)                                               /*!< PSIO_T::INTSTS: SC0IF Position         */
+#define PSIO_INTSTS_SC0IF_Msk            (0x1ul << PSIO_INTSTS_SC0IF_Pos)                  /*!< PSIO_T::INTSTS: SC0IF Mask             */
+
+#define PSIO_INTSTS_SC1IF_Pos            (5)                                               /*!< PSIO_T::INTSTS: SC1IF Position         */
+#define PSIO_INTSTS_SC1IF_Msk            (0x1ul << PSIO_INTSTS_SC1IF_Pos)                  /*!< PSIO_T::INTSTS: SC1IF Mask             */
+
+#define PSIO_INTSTS_SC2IF_Pos            (6)                                               /*!< PSIO_T::INTSTS: SC2IF Position         */
+#define PSIO_INTSTS_SC2IF_Msk            (0x1ul << PSIO_INTSTS_SC2IF_Pos)                  /*!< PSIO_T::INTSTS: SC2IF Mask             */
+
+#define PSIO_INTSTS_SC3IF_Pos            (7)                                               /*!< PSIO_T::INTSTS: SC3IF Position         */
+#define PSIO_INTSTS_SC3IF_Msk            (0x1ul << PSIO_INTSTS_SC3IF_Pos)                  /*!< PSIO_T::INTSTS: SC3IF Mask             */
+
+#define PSIO_TRANSTS_INFULL0_Pos         (0)                                               /*!< PSIO_T::TRANSTS: INFULL0 Position      */
+#define PSIO_TRANSTS_INFULL0_Msk         (0x1ul << PSIO_TRANSTS_INFULL0_Pos)               /*!< PSIO_T::TRANSTS: INFULL0 Mask          */
+
+#define PSIO_TRANSTS_INOVER0_Pos         (1)                                               /*!< PSIO_T::TRANSTS: INOVER0 Position      */
+#define PSIO_TRANSTS_INOVER0_Msk         (0x1ul << PSIO_TRANSTS_INOVER0_Pos)               /*!< PSIO_T::TRANSTS: INOVER0 Mask          */
+
+#define PSIO_TRANSTS_OUTEPY0_Pos         (2)                                               /*!< PSIO_T::TRANSTS: OUTEPY0 Position      */
+#define PSIO_TRANSTS_OUTEPY0_Msk         (0x1ul << PSIO_TRANSTS_OUTEPY0_Pos)               /*!< PSIO_T::TRANSTS: OUTEPY0 Mask          */
+
+#define PSIO_TRANSTS_OUTUF0_Pos          (3)                                               /*!< PSIO_T::TRANSTS: OUTUF0 Position       */
+#define PSIO_TRANSTS_OUTUF0_Msk          (0x1ul << PSIO_TRANSTS_OUTUF0_Pos)                /*!< PSIO_T::TRANSTS: OUTUF0 Mask           */
+
+#define PSIO_TRANSTS_INFULL1_Pos         (4)                                               /*!< PSIO_T::TRANSTS: INFULL1 Position      */
+#define PSIO_TRANSTS_INFULL1_Msk         (0x1ul << PSIO_TRANSTS_INFULL1_Pos)               /*!< PSIO_T::TRANSTS: INFULL1 Mask          */
+
+#define PSIO_TRANSTS_INOVER1_Pos         (5)                                               /*!< PSIO_T::TRANSTS: INOVER1 Position      */
+#define PSIO_TRANSTS_INOVER1_Msk         (0x1ul << PSIO_TRANSTS_INOVER1_Pos)               /*!< PSIO_T::TRANSTS: INOVER1 Mask          */
+
+#define PSIO_TRANSTS_OUTEPY1_Pos         (6)                                               /*!< PSIO_T::TRANSTS: OUTEPY1 Position      */
+#define PSIO_TRANSTS_OUTEPY1_Msk         (0x1ul << PSIO_TRANSTS_OUTEPY1_Pos)               /*!< PSIO_T::TRANSTS: OUTEPY1 Mask          */
+
+#define PSIO_TRANSTS_OUTUF1_Pos          (7)                                               /*!< PSIO_T::TRANSTS: OUTUF1 Position       */
+#define PSIO_TRANSTS_OUTUF1_Msk          (0x1ul << PSIO_TRANSTS_OUTUF1_Pos)                /*!< PSIO_T::TRANSTS: OUTUF1 Mask           */
+
+#define PSIO_TRANSTS_INFULL2_Pos         (8)                                               /*!< PSIO_T::TRANSTS: INFULL2 Position      */
+#define PSIO_TRANSTS_INFULL2_Msk         (0x1ul << PSIO_TRANSTS_INFULL2_Pos)               /*!< PSIO_T::TRANSTS: INFULL2 Mask          */
+
+#define PSIO_TRANSTS_INOVER2_Pos         (9)                                               /*!< PSIO_T::TRANSTS: INOVER2 Position      */
+#define PSIO_TRANSTS_INOVER2_Msk         (0x1ul << PSIO_TRANSTS_INOVER2_Pos)               /*!< PSIO_T::TRANSTS: INOVER2 Mask          */
+
+#define PSIO_TRANSTS_OUTEPY2_Pos         (10)                                              /*!< PSIO_T::TRANSTS: OUTEPY2 Position      */
+#define PSIO_TRANSTS_OUTEPY2_Msk         (0x1ul << PSIO_TRANSTS_OUTEPY2_Pos)               /*!< PSIO_T::TRANSTS: OUTEPY2 Mask          */
+
+#define PSIO_TRANSTS_OUTUF2_Pos          (11)                                              /*!< PSIO_T::TRANSTS: OUTUF2 Position       */
+#define PSIO_TRANSTS_OUTUF2_Msk          (0x1ul << PSIO_TRANSTS_OUTUF2_Pos)                /*!< PSIO_T::TRANSTS: OUTUF2 Mask           */
+
+#define PSIO_TRANSTS_INFULL3_Pos         (12)                                              /*!< PSIO_T::TRANSTS: INFULL3 Position      */
+#define PSIO_TRANSTS_INFULL3_Msk         (0x1ul << PSIO_TRANSTS_INFULL3_Pos)               /*!< PSIO_T::TRANSTS: INFULL3 Mask          */
+
+#define PSIO_TRANSTS_INOVER3_Pos         (13)                                              /*!< PSIO_T::TRANSTS: INOVER3 Position      */
+#define PSIO_TRANSTS_INOVER3_Msk         (0x1ul << PSIO_TRANSTS_INOVER3_Pos)               /*!< PSIO_T::TRANSTS: INOVER3 Mask          */
+
+#define PSIO_TRANSTS_OUTEPY3_Pos         (14)                                              /*!< PSIO_T::TRANSTS: OUTEPY3 Position      */
+#define PSIO_TRANSTS_OUTEPY3_Msk         (0x1ul << PSIO_TRANSTS_OUTEPY3_Pos)               /*!< PSIO_T::TRANSTS: OUTEPY3 Mask          */
+
+#define PSIO_TRANSTS_OUTUF3_Pos          (15)                                              /*!< PSIO_T::TRANSTS: OUTUF3 Position       */
+#define PSIO_TRANSTS_OUTUF3_Msk          (0x1ul << PSIO_TRANSTS_OUTUF3_Pos)                /*!< PSIO_T::TRANSTS: OUTUF3 Mask           */
+
+#define PSIO_TRANSTS_INFULL4_Pos         (16)                                              /*!< PSIO_T::TRANSTS: INFULL4 Position      */
+#define PSIO_TRANSTS_INFULL4_Msk         (0x1ul << PSIO_TRANSTS_INFULL4_Pos)               /*!< PSIO_T::TRANSTS: INFULL4 Mask          */
+
+#define PSIO_TRANSTS_INOVER4_Pos         (17)                                              /*!< PSIO_T::TRANSTS: INOVER4 Position      */
+#define PSIO_TRANSTS_INOVER4_Msk         (0x1ul << PSIO_TRANSTS_INOVER4_Pos)               /*!< PSIO_T::TRANSTS: INOVER4 Mask          */
+
+#define PSIO_TRANSTS_OUTEPY4_Pos         (18)                                              /*!< PSIO_T::TRANSTS: OUTEPY4 Position      */
+#define PSIO_TRANSTS_OUTEPY4_Msk         (0x1ul << PSIO_TRANSTS_OUTEPY4_Pos)               /*!< PSIO_T::TRANSTS: OUTEPY4 Mask          */
+
+#define PSIO_TRANSTS_OUTUF4_Pos          (19)                                              /*!< PSIO_T::TRANSTS: OUTUF4 Position       */
+#define PSIO_TRANSTS_OUTUF4_Msk          (0x1ul << PSIO_TRANSTS_OUTUF4_Pos)                /*!< PSIO_T::TRANSTS: OUTUF4 Mask           */
+
+#define PSIO_TRANSTS_INFULL5_Pos         (20)                                              /*!< PSIO_T::TRANSTS: INFULL5 Position      */
+#define PSIO_TRANSTS_INFULL5_Msk         (0x1ul << PSIO_TRANSTS_INFULL5_Pos)               /*!< PSIO_T::TRANSTS: INFULL5 Mask          */
+
+#define PSIO_TRANSTS_INOVER5_Pos         (21)                                              /*!< PSIO_T::TRANSTS: INOVER5 Position      */
+#define PSIO_TRANSTS_INOVER5_Msk         (0x1ul << PSIO_TRANSTS_INOVER5_Pos)               /*!< PSIO_T::TRANSTS: INOVER5 Mask          */
+
+#define PSIO_TRANSTS_OUTEPY5_Pos         (22)                                              /*!< PSIO_T::TRANSTS: OUTEPY5 Position      */
+#define PSIO_TRANSTS_OUTEPY5_Msk         (0x1ul << PSIO_TRANSTS_OUTEPY5_Pos)               /*!< PSIO_T::TRANSTS: OUTEPY5 Mask          */
+
+#define PSIO_TRANSTS_OUTUF5_Pos          (23)                                              /*!< PSIO_T::TRANSTS: OUTUF5 Position       */
+#define PSIO_TRANSTS_OUTUF5_Msk          (0x1ul << PSIO_TRANSTS_OUTUF5_Pos)                /*!< PSIO_T::TRANSTS: OUTUF5 Mask           */
+
+#define PSIO_TRANSTS_INFULL6_Pos         (24)                                              /*!< PSIO_T::TRANSTS: INFULL6 Position      */
+#define PSIO_TRANSTS_INFULL6_Msk         (0x1ul << PSIO_TRANSTS_INFULL6_Pos)               /*!< PSIO_T::TRANSTS: INFULL6 Mask          */
+
+#define PSIO_TRANSTS_INOVER6_Pos         (25)                                              /*!< PSIO_T::TRANSTS: INOVER6 Position      */
+#define PSIO_TRANSTS_INOVER6_Msk         (0x1ul << PSIO_TRANSTS_INOVER6_Pos)               /*!< PSIO_T::TRANSTS: INOVER6 Mask          */
+
+#define PSIO_TRANSTS_OUTEPY6_Pos         (26)                                              /*!< PSIO_T::TRANSTS: OUTEPY6 Position      */
+#define PSIO_TRANSTS_OUTEPY6_Msk         (0x1ul << PSIO_TRANSTS_OUTEPY6_Pos)               /*!< PSIO_T::TRANSTS: OUTEPY6 Mask          */
+
+#define PSIO_TRANSTS_OUTUF6_Pos          (27)                                              /*!< PSIO_T::TRANSTS: OUTUF6 Position       */
+#define PSIO_TRANSTS_OUTUF6_Msk          (0x1ul << PSIO_TRANSTS_OUTUF6_Pos)                /*!< PSIO_T::TRANSTS: OUTUF6 Mask           */
+
+#define PSIO_TRANSTS_INFULL7_Pos         (28)                                              /*!< PSIO_T::TRANSTS: INFULL7 Position      */
+#define PSIO_TRANSTS_INFULL7_Msk         (0x1ul << PSIO_TRANSTS_INFULL7_Pos)               /*!< PSIO_T::TRANSTS: INFULL7 Mask          */
+
+#define PSIO_TRANSTS_INOVER7_Pos         (29)                                              /*!< PSIO_T::TRANSTS: INOVER7 Position      */
+#define PSIO_TRANSTS_INOVER7_Msk         (0x1ul << PSIO_TRANSTS_INOVER7_Pos)               /*!< PSIO_T::TRANSTS: INOVER7 Mask          */
+
+#define PSIO_TRANSTS_OUTEPY7_Pos         (30)                                              /*!< PSIO_T::TRANSTS: OUTEPY7 Position      */
+#define PSIO_TRANSTS_OUTEPY7_Msk         (0x1ul << PSIO_TRANSTS_OUTEPY7_Pos)               /*!< PSIO_T::TRANSTS: OUTEPY7 Mask          */
+
+#define PSIO_TRANSTS_OUTUF7_Pos          (31)                                              /*!< PSIO_T::TRANSTS: OUTUF7 Position       */
+#define PSIO_TRANSTS_OUTUF7_Msk          (0x1ul << PSIO_TRANSTS_OUTUF7_Pos)                /*!< PSIO_T::TRANSTS: OUTUF7 Mask           */
+
+#define PSIO_ISSTS_VALID0_Pos            (0)                                                /*!< PSIO_T::ISSTS: VALID0 Position         */
+#define PSIO_ISSTS_VALID0_Msk            (0x1ul << PSIO_ISSTS_VALID0_Pos)                   /*!< PSIO_T::ISSTS: VALID0 Mask             */
+
+#define PSIO_ISSTS_INSTSOV0_Pos          (1)                                                /*!< PSIO_T::ISSTS: INSTSOV0 Position       */
+#define PSIO_ISSTS_INSTSOV0_Msk          (0x1ul << PSIO_ISSTS_INSTSOV0_Pos)                 /*!< PSIO_T::ISSTS: INSTSOV0 Mask           */
+
+#define PSIO_ISSTS_VALID1_Pos            (2)                                                /*!< PSIO_T::ISSTS: VALID1 Position         */
+#define PSIO_ISSTS_VALID1_Msk            (0x1ul << PSIO_ISSTS_VALID1_Pos)                   /*!< PSIO_T::ISSTS: VALID1 Mask             */
+
+#define PSIO_ISSTS_INSTSOV1_Pos          (3)                                                /*!< PSIO_T::ISSTS: INSTSOV1 Position       */
+#define PSIO_ISSTS_INSTSOV1_Msk          (0x1ul << PSIO_ISSTS_INSTSOV1_Pos)                 /*!< PSIO_T::ISSTS: INSTSOV1 Mask           */
+
+#define PSIO_ISSTS_VALID2_Pos            (4)                                                /*!< PSIO_T::ISSTS: VALID2 Position         */
+#define PSIO_ISSTS_VALID2_Msk            (0x1ul << PSIO_ISSTS_VALID2_Pos)                   /*!< PSIO_T::ISSTS: VALID2 Mask             */
+
+#define PSIO_ISSTS_INSTSOV2_Pos          (5)                                                /*!< PSIO_T::ISSTS: INSTSOV2 Position       */
+#define PSIO_ISSTS_INSTSOV2_Msk          (0x1ul << PSIO_ISSTS_INSTSOV2_Pos)                 /*!< PSIO_T::ISSTS: INSTSOV2 Mask           */
+
+#define PSIO_ISSTS_VALID3_Pos            (6)                                                /*!< PSIO_T::ISSTS: VALID3 Position         */
+#define PSIO_ISSTS_VALID3_Msk            (0x1ul << PSIO_ISSTS_VALID3_Pos)                   /*!< PSIO_T::ISSTS: VALID3 Mask             */
+
+#define PSIO_ISSTS_INSTSOV3_Pos          (7)                                                /*!< PSIO_T::ISSTS: INSTSOV3 Position       */
+#define PSIO_ISSTS_INSTSOV3_Msk          (0x1ul << PSIO_ISSTS_INSTSOV3_Pos)                 /*!< PSIO_T::ISSTS: INSTSOV3 Mask           */
+
+#define PSIO_ISSTS_VALID4_Pos            (8)                                                /*!< PSIO_T::ISSTS: VALID4 Position         */
+#define PSIO_ISSTS_VALID4_Msk            (0x1ul << PSIO_ISSTS_VALID4_Pos)                   /*!< PSIO_T::ISSTS: VALID4 Mask             */
+
+#define PSIO_ISSTS_INSTSOV4_Pos          (9)                                                /*!< PSIO_T::ISSTS: INSTSOV4 Position       */
+#define PSIO_ISSTS_INSTSOV4_Msk          (0x1ul << PSIO_ISSTS_INSTSOV4_Pos)                 /*!< PSIO_T::ISSTS: INSTSOV4 Mask           */
+
+#define PSIO_ISSTS_VALID5_Pos            (10)                                               /*!< PSIO_T::ISSTS: VALID5 Position         */
+#define PSIO_ISSTS_VALID5_Msk            (0x1ul << PSIO_ISSTS_VALID5_Pos)                   /*!< PSIO_T::ISSTS: VALID5 Mask             */
+
+#define PSIO_ISSTS_INSTSOV5_Pos          (11)                                               /*!< PSIO_T::ISSTS: INSTSOV5 Position       */
+#define PSIO_ISSTS_INSTSOV5_Msk          (0x1ul << PSIO_ISSTS_INSTSOV5_Pos)                 /*!< PSIO_T::ISSTS: INSTSOV5 Mask           */
+
+#define PSIO_ISSTS_VALID6_Pos            (12)                                               /*!< PSIO_T::ISSTS: VALID6 Position         */
+#define PSIO_ISSTS_VALID6_Msk            (0x1ul << PSIO_ISSTS_VALID6_Pos)                   /*!< PSIO_T::ISSTS: VALID6 Mask             */
+
+#define PSIO_ISSTS_INSTSOV6_Pos          (13)                                               /*!< PSIO_T::ISSTS: INSTSOV6 Position       */
+#define PSIO_ISSTS_INSTSOV6_Msk          (0x1ul << PSIO_ISSTS_INSTSOV6_Pos)                 /*!< PSIO_T::ISSTS: INSTSOV6 Mask           */
+
+#define PSIO_ISSTS_VALID7_Pos            (14)                                               /*!< PSIO_T::ISSTS: VALID7 Position         */
+#define PSIO_ISSTS_VALID7_Msk            (0x1ul << PSIO_ISSTS_VALID7_Pos)                   /*!< PSIO_T::ISSTS: VALID7 Mask             */
+
+#define PSIO_ISSTS_INSTSOV7_Pos          (15)                                               /*!< PSIO_T::ISSTS: INSTSOV7 Position       */
+#define PSIO_ISSTS_INSTSOV7_Msk          (0x1ul << PSIO_ISSTS_INSTSOV7_Pos)                 /*!< PSIO_T::ISSTS: INSTSOV7 Mask           */
+
+#define PSIO_PDMACTL_OPIN0EN_Pos         (0)                                               /*!< PSIO_T::PDMACTL: OPIN0EN Position      */
+#define PSIO_PDMACTL_OPIN0EN_Msk         (0x1ul << PSIO_PDMACTL_OPIN0EN_Pos)               /*!< PSIO_T::PDMACTL: OPIN0EN Mask          */
+
+#define PSIO_PDMACTL_OPIN1EN_Pos         (1)                                               /*!< PSIO_T::PDMACTL: OPIN1EN Position      */
+#define PSIO_PDMACTL_OPIN1EN_Msk         (0x1ul << PSIO_PDMACTL_OPIN1EN_Pos)               /*!< PSIO_T::PDMACTL: OPIN1EN Mask          */
+
+#define PSIO_PDMACTL_OPIN2EN_Pos         (2)                                               /*!< PSIO_T::PDMACTL: OPIN2EN Position      */
+#define PSIO_PDMACTL_OPIN2EN_Msk         (0x1ul << PSIO_PDMACTL_OPIN2EN_Pos)               /*!< PSIO_T::PDMACTL: OPIN2EN Mask          */
+
+#define PSIO_PDMACTL_OPIN3EN_Pos         (3)                                               /*!< PSIO_T::PDMACTL: OPIN3EN Position      */
+#define PSIO_PDMACTL_OPIN3EN_Msk         (0x1ul << PSIO_PDMACTL_OPIN3EN_Pos)               /*!< PSIO_T::PDMACTL: OPIN3EN Mask          */
+
+#define PSIO_PDMACTL_OPIN4EN_Pos         (4)                                               /*!< PSIO_T::PDMACTL: OPIN4EN Position      */
+#define PSIO_PDMACTL_OPIN4EN_Msk         (0x1ul << PSIO_PDMACTL_OPIN4EN_Pos)               /*!< PSIO_T::PDMACTL: OPIN4EN Mask          */
+
+#define PSIO_PDMACTL_OPIN5EN_Pos         (5)                                               /*!< PSIO_T::PDMACTL: OPIN5EN Position      */
+#define PSIO_PDMACTL_OPIN5EN_Msk         (0x1ul << PSIO_PDMACTL_OPIN5EN_Pos)               /*!< PSIO_T::PDMACTL: OPIN5EN Mask          */
+
+#define PSIO_PDMACTL_OPIN6EN_Pos         (6)                                               /*!< PSIO_T::PDMACTL: OPIN6EN Position      */
+#define PSIO_PDMACTL_OPIN6EN_Msk         (0x1ul << PSIO_PDMACTL_OPIN6EN_Pos)               /*!< PSIO_T::PDMACTL: OPIN6EN Mask          */
+
+#define PSIO_PDMACTL_OPIN7EN_Pos         (7)                                               /*!< PSIO_T::PDMACTL: OPIN7EN Position      */
+#define PSIO_PDMACTL_OPIN7EN_Msk         (0x1ul << PSIO_PDMACTL_OPIN7EN_Pos)               /*!< PSIO_T::PDMACTL: OPIN7EN Mask          */
+
+#define PSIO_PDMACTL_IPIN0EN_Pos         (8)                                               /*!< PSIO_T::PDMACTL: IPIN0EN Position      */
+#define PSIO_PDMACTL_IPIN0EN_Msk         (0x1ul << PSIO_PDMACTL_IPIN0EN_Pos)               /*!< PSIO_T::PDMACTL: IPIN0EN Mask          */
+
+#define PSIO_PDMACTL_IPIN1EN_Pos         (9)                                               /*!< PSIO_T::PDMACTL: IPIN1EN Position      */
+#define PSIO_PDMACTL_IPIN1EN_Msk         (0x1ul << PSIO_PDMACTL_IPIN1EN_Pos)               /*!< PSIO_T::PDMACTL: IPIN1EN Mask          */
+
+#define PSIO_PDMACTL_IPIN2EN_Pos         (10)                                              /*!< PSIO_T::PDMACTL: IPIN2EN Position      */
+#define PSIO_PDMACTL_IPIN2EN_Msk         (0x1ul << PSIO_PDMACTL_IPIN2EN_Pos)               /*!< PSIO_T::PDMACTL: IPIN2EN Mask          */
+
+#define PSIO_PDMACTL_IPIN3EN_Pos         (11)                                              /*!< PSIO_T::PDMACTL: IPIN3EN Position      */
+#define PSIO_PDMACTL_IPIN3EN_Msk         (0x1ul << PSIO_PDMACTL_IPIN3EN_Pos)               /*!< PSIO_T::PDMACTL: IPIN3EN Mask          */
+
+#define PSIO_PDMACTL_IPIN4EN_Pos         (12)                                              /*!< PSIO_T::PDMACTL: IPIN4EN Position      */
+#define PSIO_PDMACTL_IPIN4EN_Msk         (0x1ul << PSIO_PDMACTL_IPIN4EN_Pos)               /*!< PSIO_T::PDMACTL: IPIN4EN Mask          */
+
+#define PSIO_PDMACTL_IPIN5EN_Pos         (13)                                              /*!< PSIO_T::PDMACTL: IPIN5EN Position      */
+#define PSIO_PDMACTL_IPIN5EN_Msk         (0x1ul << PSIO_PDMACTL_IPIN5EN_Pos)               /*!< PSIO_T::PDMACTL: IPIN5EN Mask          */
+
+#define PSIO_PDMACTL_IPIN6EN_Pos         (14)                                              /*!< PSIO_T::PDMACTL: IPIN6EN Position      */
+#define PSIO_PDMACTL_IPIN6EN_Msk         (0x1ul << PSIO_PDMACTL_IPIN6EN_Pos)               /*!< PSIO_T::PDMACTL: IPIN6EN Mask          */
+
+#define PSIO_PDMACTL_IPIN7EN_Pos         (15)                                              /*!< PSIO_T::PDMACTL: IPIN7EN Position      */
+#define PSIO_PDMACTL_IPIN7EN_Msk         (0x1ul << PSIO_PDMACTL_IPIN7EN_Pos)               /*!< PSIO_T::PDMACTL: IPIN7EN Mask          */
+
+#define PSIO_PDMACTL_OUTNUM_Pos          (16)                                              /*!< PSIO_T::PDMACTL: OUTNUM Position       */
+#define PSIO_PDMACTL_OUTNUM_Msk          (0x7ul << PSIO_PDMACTL_OUTNUM_Pos)                /*!< PSIO_T::PDMACTL: OUTNUM Mask           */
+
+#define PSIO_PDMACTL_OUTSCSEL_Pos        (20)                                              /*!< PSIO_T::PDMACTL: OUTSCSEL Position     */
+#define PSIO_PDMACTL_OUTSCSEL_Msk        (0x3ul << PSIO_PDMACTL_OUTSCSEL_Pos)              /*!< PSIO_T::PDMACTL: OUTSCSEL Mask         */
+
+#define PSIO_PDMACTL_INNUM_Pos           (24)                                              /*!< PSIO_T::PDMACTL: INNUM Position        */
+#define PSIO_PDMACTL_INNUM_Msk           (0x7ul << PSIO_PDMACTL_INNUM_Pos)                 /*!< PSIO_T::PDMACTL: INNUM Mask            */
+
+#define PSIO_PDMACTL_INSCSEL_Pos         (28)                                              /*!< PSIO_T::PDMACTL: INSCSEL Position      */
+#define PSIO_PDMACTL_INSCSEL_Msk         (0x3ul << PSIO_PDMACTL_INSCSEL_Pos)               /*!< PSIO_T::PDMACTL: INSCSEL Mask          */
+
+#define PSIO_PODAT_PDMAOUT_Pos           (0)                                               /*!< PSIO_T::PODAT: PDMAOUT Position        */
+#define PSIO_PODAT_PDMAOUT_Msk           (0xfffffffful << PSIO_PODAT_PDMAOUT_Pos)          /*!< PSIO_T::PODAT: PDMAOUT Mask            */
+
+#define PSIO_PIDAT_PDMA_IN_Pos           (0)                                               /*!< PSIO_T::PIDAT: PDMA_IN Position        */
+#define PSIO_PIDAT_PDMA_IN_Msk           (0xfffffffful << PSIO_PIDAT_PDMA_IN_Pos)          /*!< PSIO_T::PIDAT: PDMA_IN Mask            */
+
+#define PSIO_SCCT_SCCTL_INISLOT_Pos      (0)                                               /*!< PSIO_T::SCCTL: INISLOT Position       */
+#define PSIO_SCCT_SCCTL_INISLOT_Msk      (0xful << PSIO_SCCT_SCCTL_INISLOT_Pos)            /*!< PSIO_T::SCCTL: INISLOT Mask           */
+
+#define PSIO_SCCT_SCCTL_ENDSLOT_Pos      (4)                                               /*!< PSIO_T::SCCTL: ENDSLOT Position       */
+#define PSIO_SCCT_SCCTL_ENDSLOT_Msk      (0xful << PSIO_SCCT_SCCTL_ENDSLOT_Pos)            /*!< PSIO_T::SCCTL: ENDSLOT Mask           */
+
+#define PSIO_SCCT_SCCTL_SPLCNT_Pos       (8)                                               /*!< PSIO_T::SCCTL: SPLCNT Position        */
+#define PSIO_SCCT_SCCTL_SPLCNT_Msk       (0x3ful << PSIO_SCCT_SCCTL_SPLCNT_Pos)            /*!< PSIO_T::SCCTL: SPLCNT Mask            */
+
+#define PSIO_SCCT_SCCTL_TRIGSRC_Pos          (14)                                              /*!< PSIO_T::SCCTL: TRIGSRC Position       */
+#define PSIO_SCCT_SCCTL_TRIGSRC_Msk          (0x3ul << PSIO_SCCT_SCCTL_TRIGSRC_Pos)                /*!< PSIO_T::SCCTL: TRIGSRC Mask           */
+
+#define PSIO_SCCT_SCCTL_START_Pos            (16)                                              /*!< PSIO_T::SCCTL: START Position         */
+#define PSIO_SCCT_SCCTL_START_Msk            (0x1ul << PSIO_SCCT_SCCTL_START_Pos)                  /*!< PSIO_T::SCCTL: START Mask             */
+
+#define PSIO_SCCT_SCCTL_REPEAT_Pos           (17)                                              /*!< PSIO_T::SCCTL: REPEAT Position        */
+#define PSIO_SCCT_SCCTL_REPEAT_Msk           (0x1ul << PSIO_SCCT_SCCTL_REPEAT_Pos)                 /*!< PSIO_T::SCCTL: REPEAT Mask            */
+
+#define PSIO_SCCT_SCCTL_STOP_Pos            (18)                                                /*!< PSIO_T::SCCTL: STOP Position        */
+#define PSIO_SCCT_SCCTL_STOP_Msk            (0x1ul << PSIO_SCCT_SCCTL_STOP_Pos)                 /*!< PSIO_T::SCCTL: STOP Mask            */
+
+#define PSIO_SCCT_SCCTL_BUSY_Pos             (24)                                              /*!< PSIO_T::SCCTL: BUSY Position          */
+#define PSIO_SCCT_SCCTL_BUSY_Msk             (0x1ul << PSIO_SCCT_SCCTL_BUSY_Pos)                   /*!< PSIO_T::SCCTL: BUSY Mask              */
+
+#define PSIO_SCCT_SCCTL_IDLE_Pos             (25)                                              /*!< PSIO_T::SCCTL: IDLE Position          */
+#define PSIO_SCCT_SCCTL_IDLE_Msk             (0x1ul << PSIO_SCCT_SCCTL_IDLE_Pos)                   /*!< PSIO_T::SCCTL: IDLE Mask              */
+
+#define PSIO_SCCT_SCSLOT_SLOT0CNT_Pos        (0)                                               /*!< PSIO_T::SCSLOT: SLOT0CNT Position     */
+#define PSIO_SCCT_SCSLOT_SLOT0CNT_Msk        (0xful << PSIO_SCCT_SCSLOT_SLOT0CNT_Pos)              /*!< PSIO_T::SCSLOT: SLOT0CNT Mask         */
+
+#define PSIO_SCCT_SCSLOT_SLOT1CNT_Pos        (4)                                               /*!< PSIO_T::SCSLOT: SLOT1CNT Position     */
+#define PSIO_SCCT_SCSLOT_SLOT1CNT_Msk        (0xful << PSIO_SCCT_SCSLOT_SLOT1CNT_Pos)              /*!< PSIO_T::SCSLOT: SLOT1CNT Mask         */
+
+#define PSIO_SCCT_SCSLOT_SLOT2CNT_Pos        (8)                                               /*!< PSIO_T::SCSLOT: SLOT2CNT Position     */
+#define PSIO_SCCT_SCSLOT_SLOT2CNT_Msk        (0xful << PSIO_SCCT_SCSLOT_SLOT2CNT_Pos)              /*!< PSIO_T::SCSLOT: SLOT2CNT Mask         */
+
+#define PSIO_SCCT_SCSLOT_SLOT3CNT_Pos        (12)                                              /*!< PSIO_T::SCSLOT: SLOT3CNT Position     */
+#define PSIO_SCCT_SCSLOT_SLOT3CNT_Msk        (0xful << PSIO_SCCT_SCSLOT_SLOT3CNT_Pos)              /*!< PSIO_T::SCSLOT: SLOT3CNT Mask         */
+
+#define PSIO_SCCT_SCSLOT_SLOT4CNT_Pos        (16)                                              /*!< PSIO_T::SCSLOT: SLOT4CNT Position     */
+#define PSIO_SCCT_SCSLOT_SLOT4CNT_Msk        (0xful << PSIO_SCCT_SCSLOT_SLOT4CNT_Pos)              /*!< PSIO_T::SCSLOT: SLOT4CNT Mask         */
+
+#define PSIO_SCCT_SCSLOT_SLOT5CNT_Pos        (20)                                              /*!< PSIO_T::SCSLOT: SLOT5CNT Position     */
+#define PSIO_SCCT_SCSLOT_SLOT5CNT_Msk        (0xful << PSIO_SCCT_SCSLOT_SLOT5CNT_Pos)              /*!< PSIO_T::SCSLOT: SLOT5CNT Mask         */
+
+#define PSIO_SCCT_SCSLOT_SLOT6CNT_Pos        (24)                                              /*!< PSIO_T::SCSLOT: SLOT6CNT Position     */
+#define PSIO_SCCT_SCSLOT_SLOT6CNT_Msk        (0xful << PSIO_SCCT_SCSLOT_SLOT6CNT_Pos)              /*!< PSIO_T::SCSLOT: SLOT6CNT Mask         */
+
+#define PSIO_SCCT_SCSLOT_SLOT7CNT_Pos        (28)                                              /*!< PSIO_T::SCSLOT: SLOT7CNT Position     */
+#define PSIO_SCCT_SCSLOT_SLOT7CNT_Msk        (0xful << PSIO_SCCT_SCSLOT_SLOT7CNT_Pos)              /*!< PSIO_T::SCSLOT: SLOT7CNT Mask         */
+
+#define PSIO_GNCT_GENCTL_IOMODE_Pos           (0)                                               /*!< PSIO_T::GENCTL: IOMODE Position        */
+#define PSIO_GNCT_GENCTL_IOMODE_Msk           (0x3ul << PSIO_GNCT_GENCTL_IOMODE_Pos)                 /*!< PSIO_T::GENCTL: IOMODE Mask            */
+
+#define PSIO_GNCT_GENCTL_INITIAL_Pos          (2)                                               /*!< PSIO_T::GENCTL: INITIAL Position       */
+#define PSIO_GNCT_GENCTL_INITIAL_Msk          (0x3ul << PSIO_GNCT_GENCTL_INITIAL_Pos)                /*!< PSIO_T::GENCTL: INITIAL Mask           */
+
+#define PSIO_GNCT_GENCTL_INTERVAL_Pos         (4)                                               /*!< PSIO_T::GENCTL: INTERVAL Position      */
+#define PSIO_GNCT_GENCTL_INTERVAL_Msk         (0x3ul << PSIO_GNCT_GENCTL_INTERVAL_Pos)               /*!< PSIO_T::GENCTL: INTERVAL Mask          */
+
+#define PSIO_GNCT_GENCTL_SW0CP_Pos            (8)                                               /*!< PSIO_T::GENCTL: SW0CP Position         */
+#define PSIO_GNCT_GENCTL_SW0CP_Msk            (0xful << PSIO_GNCT_GENCTL_SW0CP_Pos)                  /*!< PSIO_T::GENCTL: SW0CP Mask             */
+
+#define PSIO_GNCT_GENCTL_SW1CP_Pos            (12)                                              /*!< PSIO_T::GENCTL: SW1CP Position         */
+#define PSIO_GNCT_GENCTL_SW1CP_Msk            (0xful << PSIO_GNCT_GENCTL_SW1CP_Pos)                  /*!< PSIO_T::GENCTL: SW1CP Mask             */
+
+#define PSIO_GNCT_GENCTL_MODESW0_Pos          (16)                                              /*!< PSIO_T::GENCTL: MODESW0 Position       */
+#define PSIO_GNCT_GENCTL_MODESW0_Msk          (0x3ul << PSIO_GNCT_GENCTL_MODESW0_Pos)                /*!< PSIO_T::GENCTL: MODESW0 Mask           */
+
+#define PSIO_GNCT_GENCTL_MODESW1_Pos          (18)                                              /*!< PSIO_T::GENCTL: MODESW1 Position       */
+#define PSIO_GNCT_GENCTL_MODESW1_Msk          (0x3ul << PSIO_GNCT_GENCTL_MODESW1_Pos)                /*!< PSIO_T::GENCTL: MODESW1 Mask           */
+
+#define PSIO_GNCT_GENCTL_SCSEL_Pos            (24)                                              /*!< PSIO_T::GENCTL: SCSEL Position         */
+#define PSIO_GNCT_GENCTL_SCSEL_Msk            (0x3ul << PSIO_GNCT_GENCTL_SCSEL_Pos)                  /*!< PSIO_T::GENCTL: SCSEL Mask             */
+
+#define PSIO_GNCT_GENCTL_PINEN_Pos            (26)                                              /*!< PSIO_T::GENCTL: PINEN Position         */
+#define PSIO_GNCT_GENCTL_PINEN_Msk            (0x1ul << PSIO_GNCT_GENCTL_PINEN_Pos)             /*!< PSIO_T::GENCTL: PINEN Mask             */
+
+#define PSIO_GNCT_DATCTL_OUTDATWD_Pos         (0)                                               /*!< PSIO_T::DATCTL: OUTDATWD Position      */
+#define PSIO_GNCT_DATCTL_OUTDATWD_Msk         (0x1ful << PSIO_GNCT_DATCTL_OUTDATWD_Pos)              /*!< PSIO_T::DATCTL: OUTDATWD Mask          */
+
+#define PSIO_GNCT_DATCTL_INDATWD_Pos          (8)                                               /*!< PSIO_T::DATCTL: INDATWD Position       */
+#define PSIO_GNCT_DATCTL_INDATWD_Msk          (0x1ful << PSIO_GNCT_DATCTL_INDATWD_Pos)               /*!< PSIO_T::DATCTL: INDATWD Mask           */
+
+#define PSIO_GNCT_DATCTL_ORDER_Pos            (16)                                              /*!< PSIO_T::DATCTL: ORDER Position         */
+#define PSIO_GNCT_DATCTL_ORDER_Msk            (0x1ul << PSIO_GNCT_DATCTL_ORDER_Pos)                  /*!< PSIO_T::DATCTL: ORDER Mask             */
+
+#define PSIO_GNCT_DATCTL_OUTDEPTH_Pos         (24)                                              /*!< PSIO_T::DATCTL: OUTDEPTH Position         */
+#define PSIO_GNCT_DATCTL_OUTDEPTH_Msk         (0x3ul << PSIO_GNCT_DATCTL_OUTDEPTH_Pos)          /*!< PSIO_T::DATCTL: OUTDEPTH Mask             */
+
+#define PSIO_GNCT_DATCTL_INDEPTH_Pos          (28)                                              /*!< PSIO_T::DATCTL: INDEPTH Position         */
+#define PSIO_GNCT_DATCTL_INDEPTH_Msk          (0x3ul << PSIO_GNCT_DATCTL_INDEPTH_Pos)           /*!< PSIO_T::DATCTL: INDEPTH Mask             */
+
+#define PSIO_GNCT_INSTS_INSTS_Pos             (0)                                               /*!< PSIO_T::INSTS: INSTS Position          */
+#define PSIO_GNCT_INSTS_INSTS_Msk             (0x3ffffffful << PSIO_GNCT_INSTS_INSTS_Pos)            /*!< PSIO_T::INSTS: INSTS Mask              */
+
+#define PSIO_GNCT_INSTS_INSTSOV_Pos           (30)                                              /*!< PSIO_T::INSTS: INSTSOV Position        */
+#define PSIO_GNCT_INSTS_INSTSOV_Msk           (0x1ul << PSIO_GNCT_INSTS_INSTSOV_Pos)                 /*!< PSIO_T::INSTS: INSTSOV Mask            */
+
+#define PSIO_GNCT_INSTS_VALID_Pos             (31)                                              /*!< PSIO_T::INSTS: VALID Position          */
+#define PSIO_GNCT_INSTS_VALID_Msk             (0x1ul << PSIO_GNCT_INSTS_VALID_Pos)                   /*!< PSIO_T::INSTS: VALID Mask              */
+
+#define PSIO_GNCT_INDAT_INDAT_Pos             (0)                                               /*!< PSIO_T::INDAT: INDAT Position          */
+#define PSIO_GNCT_INDAT_INDAT_Msk             (0xfffffffful << PSIO_GNCT_INDAT_INDAT_Pos)            /*!< PSIO_T::INDAT: INDAT Mask              */
+
+#define PSIO_GNCT_OUTDAT_OUTDAT_Pos           (0)                                               /*!< PSIO_T::OUTDAT: OUTDAT Position        */
+#define PSIO_GNCT_OUTDAT_OUTDAT_Msk           (0xfffffffful << PSIO_GNCT_OUTDAT_OUTDAT_Pos)          /*!< PSIO_T::OUTDAT: OUTDAT Mask            */
+
+#define PSIO_GNCT_CPCTL0_CKPT0_Pos            (0)                                               /*!< PSIO_T::CPCTL0: CKPT0 Position         */
+#define PSIO_GNCT_CPCTL0_CKPT0_Msk            (0xFul << PSIO_GNCT_CPCTL0_CKPT0_Pos)                  /*!< PSIO_T::CPCTL0: CKPT0 Mask             */
+
+#define PSIO_GNCT_CPCTL0_CKPT1_Pos            (4)                                               /*!< PSIO_T::CPCTL0: CKPT1 Position         */
+#define PSIO_GNCT_CPCTL0_CKPT1_Msk            (0xFul << PSIO_GNCT_CPCTL0_CKPT1_Pos)                  /*!< PSIO_T::CPCTL0: CKPT1 Mask             */
+
+#define PSIO_GNCT_CPCTL0_CKPT2_Pos            (8)                                               /*!< PSIO_T::CPCTL0: CKPT2 Position         */
+#define PSIO_GNCT_CPCTL0_CKPT2_Msk            (0xFul << PSIO_GNCT_CPCTL0_CKPT2_Pos)                  /*!< PSIO_T::CPCTL0: CKPT2 Mask             */
+
+#define PSIO_GNCT_CPCTL0_CKPT3_Pos            (12)                                              /*!< PSIO_T::CPCTL0: CKPT3 Position         */
+#define PSIO_GNCT_CPCTL0_CKPT3_Msk            (0xFul << PSIO_GNCT_CPCTL0_CKPT3_Pos)                  /*!< PSIO_T::CPCTL0: CKPT3 Mask             */
+
+#define PSIO_GNCT_CPCTL0_CKPT4_Pos            (16)                                              /*!< PSIO_T::CPCTL0: CKPT4 Position         */
+#define PSIO_GNCT_CPCTL0_CKPT4_Msk            (0xFul << PSIO_GNCT_CPCTL0_CKPT4_Pos)                  /*!< PSIO_T::CPCTL0: CKPT4 Mask             */
+
+#define PSIO_GNCT_CPCTL0_CKPT5_Pos            (20)                                              /*!< PSIO_T::CPCTL0: CKPT5 Position         */
+#define PSIO_GNCT_CPCTL0_CKPT5_Msk            (0xFul << PSIO_GNCT_CPCTL0_CKPT5_Pos)                  /*!< PSIO_T::CPCTL0: CKPT5 Mask             */
+
+#define PSIO_GNCT_CPCTL0_CKPT6_Pos            (24)                                              /*!< PSIO_T::CPCTL0: CKPT6 Position         */
+#define PSIO_GNCT_CPCTL0_CKPT6_Msk            (0xFul << PSIO_GNCT_CPCTL0_CKPT6_Pos)                  /*!< PSIO_T::CPCTL0: CKPT6 Mask             */
+
+#define PSIO_GNCT_CPCTL0_CKPT7_Pos            (28)                                              /*!< PSIO_T::CPCTL0: CKPT7 Position         */
+#define PSIO_GNCT_CPCTL0_CKPT7_Msk            (0xFul << PSIO_GNCT_CPCTL0_CKPT7_Pos)                  /*!< PSIO_T::CPCTL0: CKPT7 Mask             */
+
+#define PSIO_GNCT_CPCTL1_CKPT0ACT_Pos         (0)                                               /*!< PSIO_T::CPCTL1: CKPT0ACT Position      */
+#define PSIO_GNCT_CPCTL1_CKPT0ACT_Msk         (0x7ul << PSIO_GNCT_CPCTL1_CKPT0ACT_Pos)               /*!< PSIO_T::CPCTL1: CKPT0ACT Mask          */
+
+#define PSIO_GNCT_CPCTL1_CKPT1ACT_Pos         (4)                                               /*!< PSIO_T::CPCTL1: CKPT1ACT Position      */
+#define PSIO_GNCT_CPCTL1_CKPT1ACT_Msk         (0x7ul << PSIO_GNCT_CPCTL1_CKPT1ACT_Pos)               /*!< PSIO_T::CPCTL1: CKPT1ACT Mask          */
+
+#define PSIO_GNCT_CPCTL1_CKPT2ACT_Pos         (8)                                               /*!< PSIO_T::CPCTL1: CKPT2ACT Position      */
+#define PSIO_GNCT_CPCTL1_CKPT2ACT_Msk         (0x7ul << PSIO_GNCT_CPCTL1_CKPT2ACT_Pos)               /*!< PSIO_T::CPCTL1: CKPT2ACT Mask          */
+
+#define PSIO_GNCT_CPCTL1_CKPT3ACT_Pos         (12)                                              /*!< PSIO_T::CPCTL1: CKPT3ACT Position      */
+#define PSIO_GNCT_CPCTL1_CKPT3ACT_Msk         (0x7ul << PSIO_GNCT_CPCTL1_CKPT3ACT_Pos)               /*!< PSIO_T::CPCTL1: CKPT3ACT Mask          */
+
+#define PSIO_GNCT_CPCTL1_CKPT4ACT_Pos         (16)                                              /*!< PSIO_T::CPCTL1: CKPT4ACT Position      */
+#define PSIO_GNCT_CPCTL1_CKPT4ACT_Msk         (0x7ul << PSIO_GNCT_CPCTL1_CKPT4ACT_Pos)               /*!< PSIO_T::CPCTL1: CKPT4ACT Mask          */
+
+#define PSIO_GNCT_CPCTL1_CKPT5ACT_Pos         (20)                                              /*!< PSIO_T::CPCTL1: CKPT5ACT Position      */
+#define PSIO_GNCT_CPCTL1_CKPT5ACT_Msk         (0x7ul << PSIO_GNCT_CPCTL1_CKPT5ACT_Pos)               /*!< PSIO_T::CPCTL1: CKPT5ACT Mask          */
+
+#define PSIO_GNCT_CPCTL1_CKPT6ACT_Pos         (24)                                              /*!< PSIO_T::CPCTL1: CKPT6ACT Position      */
+#define PSIO_GNCT_CPCTL1_CKPT6ACT_Msk         (0x7ul << PSIO_GNCT_CPCTL1_CKPT6ACT_Pos)               /*!< PSIO_T::CPCTL1: CKPT6ACT Mask          */
+
+#define PSIO_GNCT_CPCTL1_CKPT7ACT_Pos         (28)                                              /*!< PSIO_T::CPCTL1: CKPT7ACT Position      */
+#define PSIO_GNCT_CPCTL1_CKPT7ACT_Msk         (0x7ul << PSIO_GNCT_CPCTL1_CKPT7ACT_Pos)               /*!< PSIO_T::CPCTL1: CKPT7ACT Mask          */
+
+/** @} PSIO_CONST */
+/** @} end of PSIO register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __PSIO_REG_H__ */

--- a/hal/m258ke/nuvoton/pwm_reg.h
+++ b/hal/m258ke/nuvoton/pwm_reg.h
@@ -1,0 +1,2683 @@
+/**************************************************************************//**
+ * @file     pwm_reg.h
+ * @version  V1.00
+ * @brief    PWM register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __PWM_REG_H__
+#define __PWM_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup PWM Pulse Width Modulation Controller (PWM)
+    Memory Mapped Structure for PWM Controller
+    @{
+*/
+
+typedef struct
+{
+    /**
+     * @var CAPDAT_T::RCAPDAT
+     * Offset: 0x20C~0x238  PWM Rising Capture Data Register 0~5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |RCAPDAT   |PWM Rising Capture Data (Read Only)
+     * |        |          |When rising capture condition happened, the PWM counter value will be saved in this register.
+     * @var CAPDAT_T::FCAPDAT
+     * Offset: 0x210  PWM Falling Capture Data Register 0~5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |FCAPDAT   |PWWM Falling Capture Data (Read Only)
+     * |        |          |When falling capture condition happened, the PWWM counter value will be saved in this register.
+     */
+    __IO uint32_t RCAPDAT; /*!< [0x20C/0x214/0x21C/0x224/0x22C/0x234] PWM Rising Capture Data Register 0~5 */
+    __IO uint32_t FCAPDAT; /*!< [0x210/0x218/0x220/0x228/0x230/0x238] PWM Falling Capture Data Register 0~5 */
+} CAPDAT_T;
+
+typedef struct
+{
+
+
+    /**
+     * @var PWM_T::CTL0
+     * Offset: 0x00  PWM Control Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CTRLDn    |Center Load Enable Bits
+     * |        |          |In up-down counter type, PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the center point of a period
+     * |[16]    |IMMLDENn  |Immediately Load Enable Bits
+     * |        |          |0 = PERIOD will load to PBUF at the end point of each period
+     * |        |          |CMPDAT will load to CMPBUF at the end point or center point of each period by setting CTRLD bit.
+     * |        |          |1 = PERIOD/CMPDAT will load to PBUF and CMPBUF immediately when software update PERIOD/CMPDAT.
+     * |        |          |Note: If IMMLDENn is enabled, WINLDENn and CTRLDn will be invalid.
+     * |[30]    |DBGHALT   |ICE Debug Mode Counter Halt (Write Protect)
+     * |        |          |If counter halt is enabled, PWM all counters will keep current value until exit ICE debug mode.
+     * |        |          |0 = ICE debug mode counter halt Disable.
+     * |        |          |1 = ICE debug mode counter halt Enable.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[31]    |DBGTRIOFF |ICE Debug Mode Acknowledge Disable Bit (Write Protect)
+     * |        |          |0 = ICE debug mode acknowledgement effects PWM output.
+     * |        |          |PWM pin will be forced as tri-state while ICE debug mode acknowledged.
+     * |        |          |1 = ICE debug mode acknowledgement disabled.
+     * |        |          |PWM pin will keep output no matter ICE debug mode acknowledged or not.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * @var PWM_T::CTL1
+     * Offset: 0x04  PWM Control Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |CNTTYPE0  |PWM Counter Behavior Type 0
+     * |        |          |The two bits control channel1 and channel0
+     * |        |          |00 = Up counter type (supported in capture mode).
+     * |        |          |01 = Down count type (supported in capture mode).
+     * |        |          |10 = Up-down counter type.
+     * |        |          |11 = Reserved.
+     * |[5:4]   |CNTTYPE2  |PWM Counter Behavior Type 2
+     * |        |          |The two bits control channel3 and channel2
+     * |        |          |00 = Up counter type (supported in capture mode).
+     * |        |          |01 = Down count type (supported in capture mode).
+     * |        |          |10 = Up-down counter type.
+     * |        |          |11 = Reserved.
+     * |[9:8]   |CNTTYPE4  |PWM Counter Behavior Type 4
+     * |        |          |The two bits control channel5 and channel4
+     * |        |          |00 = Up counter type (supported in capture mode).
+     * |        |          |01 = Down count type (supported in capture mode).
+     * |        |          |10 = Up-down counter type.
+     * |        |          |11 = Reserved.
+     * |[26:24] |OUTMODEn  |PWM Output Mode
+     * |        |          |Each bit n controls the output mode of corresponding PWM channel n.
+     * |        |          |0 = PWM independent mode.
+     * |        |          |1 = PWM complementary mode.
+     * |        |          |Note: When operating in group function, these bits must all set to the same mode.
+     * @var PWM_T::CLKSRC
+     * Offset: 0x10  PWM Clock Source Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |ECLKSRC0  |PWM_CH01 External Clock Source Select
+     * |        |          |000 = PWMx_CLK, x denotes 0 or 1.
+     * |        |          |001 = TIMER0 overflow.
+     * |        |          |010 = TIMER1 overflow.
+     * |        |          |011 = TIMER2 overflow.
+     * |        |          |100 = TIMER3 overflow.
+     * |        |          |Others = Reserved.
+     * |[10:8]  |ECLKSRC2  |PWM_CH23 External Clock Source Select
+     * |        |          |000 = PWMx_CLK, x denotes 0 or 1.
+     * |        |          |001 = TIMER0 overflow.
+     * |        |          |010 = TIMER1 overflow.
+     * |        |          |011 = TIMER2 overflow.
+     * |        |          |100 = TIMER3 overflow.
+     * |        |          |Others = Reserved.
+     * |[18:16] |ECLKSRC4  |PWM_CH45 External Clock Source Select
+     * |        |          |000 = PWMx_CLK, x denotes 0 or 1.
+     * |        |          |001 = TIMER0 overflow.
+     * |        |          |010 = TIMER1 overflow.
+     * |        |          |011 = TIMER2 overflow.
+     * |        |          |100 = TIMER3 overflow.
+     * |        |          |Others = Reserved.
+     * @var PWM_T::CLKPSC[3]
+     * Offset: 0x14~0x1C  PWM Clock Prescale Register 0/1, 2/3, 4/5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[11:0]  |CLKPSC    |PWM Counter Clock Prescale
+     * |        |          |The clock of PWM counter is decided by clock prescaler
+     * |        |          |Each PWM pair share one PWM counter clock prescaler
+     * |        |          |The clock of PWM counter is divided by (CLKPSC+ 1)
+     * @var PWM_T::CNTEN
+     * Offset: 0x20  PWM Counter Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTEN0    |PWM Counter Enable Bit 0
+     * |        |          |0 = PWM Counter and clock prescaler Stop Running.
+     * |        |          |1 = PWM Counter and clock prescaler Start Running.
+     * |[2]     |CNTEN2    |PWM Counter Enable Bit 2
+     * |        |          |0 = PWM Counter and clock prescaler Stop Running.
+     * |        |          |1 = PWM Counter and clock prescaler Start Running.
+     * |[4]     |CNTEN4    |PWM Counter Enable Bit 4
+     * |        |          |0 = PWM Counter and clock prescaler Stop Running.
+     * |        |          |1 = PWM Counter and clock prescaler Start Running.
+     * @var PWM_T::CNTCLR
+     * Offset: 0x24  PWM Clear Counter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTCLR0   |Clear PWM Counter Control Bit 0
+     * |        |          |It is automatically cleared by hardware.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear 16-bit PWM counter to 0000H.
+     * |[2]     |CNTCLR2   |Clear PWM Counter Control Bit 2
+     * |        |          |It is automatically cleared by hardware.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear 16-bit PWM counter to 0000H.
+     * |[4]     |CNTCLR4   |Clear PWM Counter Control Bit 4
+     * |        |          |It is automatically cleared by hardware.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear 16-bit PWM counter to 0000H.
+     * @var PWM_T::PERIOD[6]
+     * Offset: 0x30~0x44  PWM Period Register 0, 2, 4
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |PERIOD    |PWM Period Register
+     * |        |          |Up-Count mode: In this mode, PWM counter counts from 0 to PERIOD, and restarts from 0.
+     * |        |          |Down-Count mode: In this mode, PWM counter counts from PERIOD to 0, and restarts from PERIOD.
+     * |        |          |PWM period time = (PERIOD+1) * PWM_CLK period.
+     * |        |          |Up-Down-Count mode: In this mode, PWM counter counts from 0 to PERIOD, then decrements to 0 and repeats again.
+     * |        |          |PWM period time = 2 * PERIOD * PWM_CLK period.
+     * @var PWM_T::CMPDAT[6]
+     * Offset: 0x50~0x64  PWM Comparator Register 0~5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CMP       |PWM Comparator Register
+     * |        |          |CMP is used to compare with CNTR to generate PWM waveform, interrupt and trigger EADC.
+     * |        |          |In independent mode, PWM_CMPDAT0~5 denote as 6 independent PWM_CH0~5 compared point.
+     * |        |          |In complementary mode, PWM_CMPDAT0, 2, 4 denote as first compared point, and PWM_CMPDAT1, 3, 5 denote as second compared point for the corresponding 3 complementary pairs PWM_CH0 and PWM_CH1, PWM_CH2 and PWM_CH3, PWM_CH4 and PWM_CH5.
+     * @var PWM_T::DTCTL[3]
+     * Offset: 0x70~0x78  PWM Dead-time Control Register 0/1, 2/3, 4/5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[11:0]  |DTCNT     |Dead-time Counter (Write Protect)
+     * |        |          |The dead-time can be calculated from the following formula:
+     * |        |          |DTCKSEL=0: Dead-time = (DTCNT[11:0]+1) * PWM_CLK period.
+     * |        |          |DTCKSEL=1: Dead-time = (DTCNT[11:0]+1) * PWM_CLK period * (CLKPSC+1).
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[16]    |DTEN      |Enable Dead-time Insertion for PWM Pair (PWM_CH0, PWM_CH1) (PWM_CH2, PWM_CH3) (PWM_CH4, PWM_CH5) (Write Protect)
+     * |        |          |Dead-time insertion is only active when this pair of complementary PWM is enabled
+     * |        |          |If dead- time insertion is inactive, the outputs of pin pair are complementary without any delay.
+     * |        |          |0 = Dead-time insertion Disabled on the pin pair.
+     * |        |          |1 = Dead-time insertion Enabled on the pin pair.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[24]    |DTCKSEL   |Dead-time Clock Select (Write Protect)
+     * |        |          |0 = Dead-time clock source from PWM_CLK.
+     * |        |          |1 = Dead-time clock source from prescaler output.
+     * |        |          |Note: This bit is write protected. Refer to REGWRPROT register.
+     * @var PWM_T::CNT[6]
+     * Offset: 0x90~0xA4  PWM Counter Register 0, 2, 4
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CNT       |PWM Data Register (Read Only)
+     * |        |          |User can monitor CNTR to know the current value in 16-bit period counter.
+     * |[16]    |DIRF      |PWM Direction Indicator Flag (Read Only)
+     * |        |          |0 = Counter is counting down.
+     * |        |          |1 = Counter is counting up.
+     * @var PWM_T::WGCTL0
+     * Offset: 0xB0  PWM Generation Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |ZPCTL0    |PWM Zero Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM zero point output Low.
+     * |        |          |10 = PWM zero point output High.
+     * |        |          |11 = PWM zero point output Toggle.
+     * |        |          |Note: PWM can control output level when PWM counter counts to 0.
+     * |[3:2]   |ZPCTL1    |PWM Zero Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM zero point output Low.
+     * |        |          |10 = PWM zero point output High.
+     * |        |          |11 = PWM zero point output Toggle.
+     * |        |          |Note: PWM can control output level when PWM counter counts to 0.
+     * |[5:4]   |ZPCTL2    |PWM Zero Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM zero point output Low.
+     * |        |          |10 = PWM zero point output High.
+     * |        |          |11 = PWM zero point output Toggle.
+     * |        |          |Note: PWM can control output level when PWM counter counts to 0.
+     * |[7:6]   |ZPCTL3    |PWM Zero Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM zero point output Low.
+     * |        |          |10 = PWM zero point output High.
+     * |        |          |11 = PWM zero point output Toggle.
+     * |        |          |Note: PWM can control output level when PWM counter counts to 0.
+     * |[9:8]   |ZPCTL4    |PWM Zero Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM zero point output Low.
+     * |        |          |10 = PWM zero point output High.
+     * |        |          |11 = PWM zero point output Toggle.
+     * |        |          |Note: PWM can control output level when PWM counter counts to 0.
+     * |[11:10] |ZPCTL5    |PWM Zero Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM zero point output Low.
+     * |        |          |10 = PWM zero point output High.
+     * |        |          |11 = PWM zero point output Toggle.
+     * |        |          |Note: PWM can control output level when PWM counter counts to 0.
+     * |[17:16] |PRDPCTL0  |PWM Period (Center) Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM period (center) point output Low.
+     * |        |          |10 = PWM period (center) point output High.
+     * |        |          |11 = PWM period (center) point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts to (PERIODn+1).
+     * |        |          |Note2: This bit is center point control when PWM counter operating in up-down counter type.
+     * |[19:18] |PRDPCTL1  |PWM Period (Center) Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM period (center) point output Low.
+     * |        |          |10 = PWM period (center) point output High.
+     * |        |          |11 = PWM period (center) point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts to (PERIODn+1).
+     * |        |          |Note2: This bit is center point control when PWM counter operating in up-down counter type.
+     * |[21:20] |PRDPCTL2  |PWM Period (Center) Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM period (center) point output Low.
+     * |        |          |10 = PWM period (center) point output High.
+     * |        |          |11 = PWM period (center) point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts to (PERIODn+1).
+     * |        |          |Note2: This bit is center point control when PWM counter operating in up-down counter type.
+     * |[23:22] |PRDPCTL3  |PWM Period (Center) Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM period (center) point output Low.
+     * |        |          |10 = PWM period (center) point output High.
+     * |        |          |11 = PWM period (center) point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts to (PERIODn+1).
+     * |        |          |Note2: This bit is center point control when PWM counter operating in up-down counter type.
+     * |[25:24] |PRDPCTL4  |PWM Period (Center) Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM period (center) point output Low.
+     * |        |          |10 = PWM period (center) point output High.
+     * |        |          |11 = PWM period (center) point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts to (PERIODn+1).
+     * |        |          |Note2: This bit is center point control when PWM counter operating in up-down counter type.
+     * |[27:26] |PRDPCTL5  |PWM Period (Center) Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM period (center) point output Low.
+     * |        |          |10 = PWM period (center) point output High.
+     * |        |          |11 = PWM period (center) point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts to (PERIODn+1).
+     * |        |          |Note2: This bit is center point control when PWM counter operating in up-down counter type.
+     * @var PWM_T::WGCTL1
+     * Offset: 0xB4  PWM Generation Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |CMPUCTL0  |PWM Compare Up Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare up point output Low.
+     * |        |          |10 = PWM compare up point output High.
+     * |        |          |11 = PWM compare up point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts up to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPUCTL1, 3, 5 is used as another CMPUCTL for channel 0, 2, 4.
+     * |[3:2]   |CMPUCTL1  |PWM Compare Up Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare up point output Low.
+     * |        |          |10 = PWM compare up point output High.
+     * |        |          |11 = PWM compare up point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts up to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPUCTL1, 3, 5 is used as another CMPUCTL for channel 0, 2, 4.
+     * |[5:4]   |CMPUCTL2  |PWM Compare Up Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare up point output Low.
+     * |        |          |10 = PWM compare up point output High.
+     * |        |          |11 = PWM compare up point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts up to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPUCTL1, 3, 5 is used as another CMPUCTL for channel 0, 2, 4.
+     * |[7:6]   |CMPUCTL3  |PWM Compare Up Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare up point output Low.
+     * |        |          |10 = PWM compare up point output High.
+     * |        |          |11 = PWM compare up point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts up to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPUCTL1, 3, 5 is used as another CMPUCTL for channel 0, 2, 4.
+     * |[9:8]   |CMPUCTL4  |PWM Compare Up Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare up point output Low.
+     * |        |          |10 = PWM compare up point output High.
+     * |        |          |11 = PWM compare up point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts up to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPUCTL1, 3, 5 is used as another CMPUCTL for channel 0, 2, 4.
+     * |[11:10] |CMPUCTL5  |PWM Compare Up Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare up point output Low.
+     * |        |          |10 = PWM compare up point output High.
+     * |        |          |11 = PWM compare up point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts up to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPUCTL1, 3, 5 is used as another CMPUCTL for channel 0, 2, 4.
+     * |[17:16] |CMPDCTL0  |PWM Compare Down Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare down point output Low.
+     * |        |          |10 = PWM compare down point output High.
+     * |        |          |11 = PWM compare down point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts down to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPDCTL1, 3, 5 is used as another CMPDCTL for channel 0, 2, 4.
+     * |[19:18] |CMPDCTL1  |PWM Compare Down Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare down point output Low.
+     * |        |          |10 = PWM compare down point output High.
+     * |        |          |11 = PWM compare down point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts down to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPDCTL1, 3, 5 is used as another CMPDCTL for channel 0, 2, 4.
+     * |[21:20] |CMPDCTL2  |PWM Compare Down Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare down point output Low.
+     * |        |          |10 = PWM compare down point output High.
+     * |        |          |11 = PWM compare down point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts down to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPDCTL1, 3, 5 is used as another CMPDCTL for channel 0, 2, 4.
+     * |[23:22] |CMPDCTL3  |PWM Compare Down Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare down point output Low.
+     * |        |          |10 = PWM compare down point output High.
+     * |        |          |11 = PWM compare down point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts down to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPDCTL1, 3, 5 is used as another CMPDCTL for channel 0, 2, 4.
+     * |[25:24] |CMPDCTL4  |PWM Compare Down Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare down point output Low.
+     * |        |          |10 = PWM compare down point output High.
+     * |        |          |11 = PWM compare down point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts down to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPDCTL1, 3, 5 is used as another CMPDCTL for channel 0, 2, 4.
+     * |[27:26] |CMPDCTL5  |PWM Compare Down Point Control
+     * |        |          |00 = Do nothing.
+     * |        |          |01 = PWM compare down point output Low.
+     * |        |          |10 = PWM compare down point output High.
+     * |        |          |11 = PWM compare down point output Toggle.
+     * |        |          |Note1: PWM can control output level when PWM counter counts down to CMPDAT.
+     * |        |          |Note2: In complementary mode, CMPDCTL1, 3, 5 is used as another CMPDCTL for channel 0, 2, 4.
+     * @var PWM_T::MSKEN
+     * Offset: 0xB8  PWM Mask Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MSKEN0    |PWM Mask Enable Bits
+     * |        |          |The PWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding PWM channel n will output MSKDATn (PWM_MSK[5:0]) data.
+     * |        |          |0 = PWM output signal is non-masked.
+     * |        |          |1 = PWM output signal is masked and output MSKDATn data.
+     * |[1]     |MSKEN1    |PWM Mask Enable Bits
+     * |        |          |The PWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding PWM channel n will output MSKDATn (PWM_MSK[5:0]) data.
+     * |        |          |0 = PWM output signal is non-masked.
+     * |        |          |1 = PWM output signal is masked and output MSKDATn data.
+     * |[2]     |MSKEN2    |PWM Mask Enable Bits
+     * |        |          |The PWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding PWM channel n will output MSKDATn (PWM_MSK[5:0]) data.
+     * |        |          |0 = PWM output signal is non-masked.
+     * |        |          |1 = PWM output signal is masked and output MSKDATn data.
+     * |[3]     |MSKEN3    |PWM Mask Enable Bits
+     * |        |          |The PWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding PWM channel n will output MSKDATn (PWM_MSK[5:0]) data.
+     * |        |          |0 = PWM output signal is non-masked.
+     * |        |          |1 = PWM output signal is masked and output MSKDATn data.
+     * |[4]     |MSKEN4    |PWM Mask Enable Bits
+     * |        |          |The PWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding PWM channel n will output MSKDATn (PWM_MSK[5:0]) data.
+     * |        |          |0 = PWM output signal is non-masked.
+     * |        |          |1 = PWM output signal is masked and output MSKDATn data.
+     * |[5]     |MSKEN5    |PWM Mask Enable Bits
+     * |        |          |The PWM output signal will be masked when this bit is enabled
+     * |        |          |The corresponding PWM channel n will output MSKDATn (PWM_MSK[5:0]) data.
+     * |        |          |0 = PWM output signal is non-masked.
+     * |        |          |1 = PWM output signal is masked and output MSKDATn data.
+     * @var PWM_T::MSK
+     * Offset: 0xBC  PWM Mask Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MSKDAT0   |PWM Mask Data Bit
+     * |        |          |This data bit control the state of PWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Output logic low to PWM channel n.
+     * |        |          |1 = Output logic high to PWM channel n.
+     * |[1]     |MSKDAT1   |PWM Mask Data Bit
+     * |        |          |This data bit control the state of PWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Output logic low to PWM channel n.
+     * |        |          |1 = Output logic high to PWM channel n.
+     * |[2]     |MSKDAT2   |PWM Mask Data Bit
+     * |        |          |This data bit control the state of PWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Output logic low to PWM channel n.
+     * |        |          |1 = Output logic high to PWM channel n.
+     * |[3]     |MSKDAT3   |PWM Mask Data Bit
+     * |        |          |This data bit control the state of PWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Output logic low to PWM channel n.
+     * |        |          |1 = Output logic high to PWM channel n.
+     * |[4]     |MSKDAT4   |PWM Mask Data Bit
+     * |        |          |This data bit control the state of PWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Output logic low to PWM channel n.
+     * |        |          |1 = Output logic high to PWM channel n.
+     * |[5]     |MSKDAT5   |PWM Mask Data Bit
+     * |        |          |This data bit control the state of PWMn output pin, if corresponding mask function is enabled
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Output logic low to PWM channel n.
+     * |        |          |1 = Output logic high to PWM channel n.
+     * @var PWM_T::BNF
+     * Offset: 0xC0  PWM Brake Noise Filter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BRK0NFEN  |PWM Brake 0 Noise Filter Enable Bit
+     * |        |          |0 = Noise filter of PWM Brake 0 Disabled.
+     * |        |          |1 = Noise filter of PWM Brake 0 Enabled.
+     * |[3:1]   |BRK0NFSEL |Brake 0 Edge Detector Filter Clock Selection
+     * |        |          |000 = Filter clock = HCLK.
+     * |        |          |001 = Filter clock = HCLK/2.
+     * |        |          |010 = Filter clock = HCLK/4.
+     * |        |          |011 = Filter clock = HCLK/8.
+     * |        |          |100 = Filter clock = HCLK/16.
+     * |        |          |101 = Filter clock = HCLK/32.
+     * |        |          |110 = Filter clock = HCLK/64.
+     * |        |          |111 = Filter clock = HCLK/128.
+     * |[6:4]   |BRK0NFCNT |Brake 0 Edge Detector Filter Count
+     * |        |          |The register bits control the Brake0 filter counter to count from 0 to BRK1FCNT.
+     * |[7]     |BRK0PINV  |Brake 0 Pin Inverse
+     * |        |          |0 = The state of pin PWMx_BRAKE0 is passed to the negative edge detector.
+     * |        |          |1 = The inversed state of pin PWMx_BRAKE10 is passed to the negative edge detector.
+     * |[8]     |BRK1FEN   |PWM Brake 1 Noise Filter Enable Bit
+     * |        |          |0 = Noise filter of PWM Brake 1 Disabled.
+     * |        |          |1 = Noise filter of PWM Brake 1 Enabled.
+     * |[11:9]  |BRK1NFSEL |Brake 1 Edge Detector Filter Clock Selection
+     * |        |          |000 = Filter clock = HCLK.
+     * |        |          |001 = Filter clock = HCLK/2.
+     * |        |          |010 = Filter clock = HCLK/4.
+     * |        |          |011 = Filter clock = HCLK/8.
+     * |        |          |100 = Filter clock = HCLK/16.
+     * |        |          |101 = Filter clock = HCLK/32.
+     * |        |          |110 = Filter clock = HCLK/64.
+     * |        |          |111 = Filter clock = HCLK/128.
+     * |[14:12] |BRK1FCNT  |Brake 1 Edge Detector Filter Count
+     * |        |          |The register bits control the Brake1 filter counter to count from 0 to BRK1FCNT.
+     * |[15]    |BRK1PINV  |Brake 1 Pin Inverse
+     * |        |          |0 = The state of pin PWMx_BRAKE1 is passed to the negative edge detector.
+     * |        |          |1 = The inversed state of pin PWMx_BRAKE1 is passed to the negative edge detector.
+     * |[16]    |BK0SRC    |Brake 0 Pin Source Select
+     * |        |          |For PWM0 setting:
+     * |        |          |0 = Brake 0 pin source come from PWM0_BRAKE0.
+     * |        |          |1 = Brake 0 pin source come from PWM1_BRAKE0.
+     * |        |          |For PWM1 setting:
+     * |        |          |0 = Brake 0 pin source come from PWM1_BRAKE0.
+     * |        |          |1 = Brake 0 pin source come from PWM0_BRAKE0.
+     * |[24]    |BK1SRC    |Brake 1 Pin Source Select
+     * |        |          |For PWM0 setting:
+     * |        |          |0 = Brake 1 pin source come from PWM0_BRAKE1.
+     * |        |          |1 = Brake 1 pin source come from PWM1_BRAKE1.
+     * |        |          |For PWM1 setting:
+     * |        |          |0 = Brake 1 pin source come from PWM1_BRAKE1.
+     * |        |          |1 = Brake 1 pin source come from PWM0_BRAKE1.
+     * @var PWM_T::FAILBRK
+     * Offset: 0xC4  PWM System Fail Brake Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CSSBRKEN  |Clock Security System Detection Trigger PWM Brake Function 0 Enable Bit
+     * |        |          |0 = Brake Function triggered by CSS detection Disabled.
+     * |        |          |1 = Brake Function triggered by CSS detection Enabled.
+     * |[1]     |BODBRKEN  |Brown-out Detection Trigger PWM Brake Function 0 Enable Bit
+     * |        |          |0 = Brake Function triggered by BOD Disabled.
+     * |        |          |1 = Brake Function triggered by BOD Enabled.
+     * |[3]     |CORBRKEN  |Core Lockup Detection Trigger PWM Brake Function 0 Enable Bit
+     * |        |          |0 = Brake Function triggered by Core lockup detection Disabled.
+     * |        |          |1 = Brake Function triggered by Core lockup detection Enabled.
+     * @var PWM_T::BRKCTL[3]
+     * Offset: 0xC8~0xD0  PWM Brake Edge Detect Control Register 0/1, 2/3, 4/5
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CPO0EBEN  |Enable ACMP0_O Digital Output As Edge-detect Brake Source (Write Protect)
+     * |        |          |0 = ACMP0_O as edge-detect brake source Disabled.
+     * |        |          |1 = ACMP0_O as edge-detect brake source Enabled.
+     * |        |          |Note: This register is write protected. Refer toSYS_REGLCTL register.
+     * |[1]     |CPO1EBEN  |Enable ACMP1_O Digital Output As Edge-detect Brake Source (Write Protect)
+     * |        |          |0 = ACMP1_O as edge-detect brake source Disabled.
+     * |        |          |1 = ACMP1_O as edge-detect brake source Enabled.
+     * |        |          |Note: This register is write protected. Refer toSYS_REGLCTL register.
+     * |[4]     |BRKP0EEN  |Enable PWMx_BRAKE0 Pin As Edge-detect Brake Source (Write Protect)
+     * |        |          |0 = BKP0 pin as edge-detect brake source Disabled.
+     * |        |          |1 = BKP0 pin as edge-detect brake source Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[5]     |BRKP1EEN  |Enable PWMx_BRAKE1 Pin As Edge-detect Brake Source (Write Protect)
+     * |        |          |0 = BKP1 pin as edge-detect brake source Disabled.
+     * |        |          |1 = BKP1 pin as edge-detect brake source Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[7]     |SYSEBEN   |Enable System Fail As Edge-detect Brake Source (Write Protect)
+     * |        |          |0 = System Fail condition as edge-detect brake source Disabled.
+     * |        |          |1 = System Fail condition as edge-detect brake source Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[8]     |CPO0LBEN  |Enable ACMP0_O Digital Output As Level-detect Brake Source (Write Protect)
+     * |        |          |0 = ACMP0_O as level-detect brake source Disabled.
+     * |        |          |1 = ACMP0_O as level-detect brake source Enabled.
+     * |        |          |Note: This register is write protected. Refer toSYS_REGLCTL register.
+     * |[9]     |CPO1LBEN  |Enable ACMP1_O Digital Output As Level-detect Brake Source (Write Protect)
+     * |        |          |0 = ACMP1_O as level-detect brake source Disabled.
+     * |        |          |1 = ACMP1_O as level-detect brake source Enabled.
+     * |        |          |Note: This register is write protected. Refer toSYS_REGLCTL register.
+     * |[12]    |BRKP0LEN  |Enable BKP0 Pin As Level-detect Brake Source (Write Protect)
+     * |        |          |0 = PWMx_BRAKE0 pin as level-detect brake source Disabled.
+     * |        |          |1 = PWMx_BRAKE0 pin as level-detect brake source Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[13]    |BRKP1LEN  |Enable BKP1 Pin As Level-detect Brake Source (Write Protect)
+     * |        |          |0 = PWMx_BRAKE1 pin as level-detect brake source Disabled.
+     * |        |          |1 = PWMx_BRAKE1 pin as level-detect brake source Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[15]    |SYSLBEN   |Enable System Fail As Level-detect Brake Source (Write Protect)
+     * |        |          |0 = System Fail condition as level-detect brake source Disabled.
+     * |        |          |1 = System Fail condition as level-detect brake source Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[17:16] |BRKAEVEN  |PWM Brake Action Select for Even Channel (Write Protect)
+     * |        |          |00 = PWM even channel level-detect brake function not affect channel output.
+     * |        |          |01 = PWM even channel output tri-state when level-detect brake happened.
+     * |        |          |10 = PWM even channel output low level when level-detect brake happened.
+     * |        |          |11 = PWM even channel output high level when level-detect brake happened.
+     * |        |          |Note: These bits are write protected. Refer to SYS_REGLCTL register.
+     * |[19:18] |BRKAODD   |PWM Brake Action Select for Odd Channel (Write Protect)
+     * |        |          |00 = PWM odd channel level-detect brake function not affect channel output.
+     * |        |          |01 = PWM odd channel output tri-state when level-detect brake happened.
+     * |        |          |10 = PWM odd channel output low level when level-detect brake happened.
+     * |        |          |11 = PWM odd channel output high level when level-detect brake happened.
+     * |        |          |Note: These bits are write protected. Refer to SYS_REGLCTL register.
+     * @var PWM_T::POLCTL
+     * Offset: 0xD4  PWM Pin Polar Inverse Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PINV0     |PWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of PWM output.
+     * |        |          |0 = PWM output polar inverse Disabled.
+     * |        |          |1 = PWM output polar inverse Enabled.
+     * |[1]     |PINV1     |PWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of PWM output.
+     * |        |          |0 = PWM output polar inverse Disabled.
+     * |        |          |1 = PWM output polar inverse Enabled.
+     * |[2]     |PINV2     |PWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of PWM output.
+     * |        |          |0 = PWM output polar inverse Disabled.
+     * |        |          |1 = PWM output polar inverse Enabled.
+     * |[3]     |PINV3     |PWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of PWM output.
+     * |        |          |0 = PWM output polar inverse Disabled.
+     * |        |          |1 = PWM output polar inverse Enabled.
+     * |[4]     |PINV4     |PWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of PWM output.
+     * |        |          |0 = PWM output polar inverse Disabled.
+     * |        |          |1 = PWM output polar inverse Enabled.
+     * |[5]     |PINV5     |PWM PIN Polar Inverse Control
+     * |        |          |The register controls polarity state of PWM output.
+     * |        |          |0 = PWM output polar inverse Disabled.
+     * |        |          |1 = PWM output polar inverse Enabled.
+     * @var PWM_T::POEN
+     * Offset: 0xD8  PWM Output Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |POEN0     |PWM Pin Output Enable Bits
+     * |        |          |0 = PWM pin at tri-state.
+     * |        |          |1 = PWM pin in output mode.
+     * |[1]     |POEN1     |PWM Pin Output Enable Bits
+     * |        |          |0 = PWM pin at tri-state.
+     * |        |          |1 = PWM pin in output mode.
+     * |[2]     |POEN2     |PWM Pin Output Enable Bits
+     * |        |          |0 = PWM pin at tri-state.
+     * |        |          |1 = PWM pin in output mode.
+     * |[3]     |POEN3     |PWM Pin Output Enable Bits
+     * |        |          |0 = PWM pin at tri-state.
+     * |        |          |1 = PWM pin in output mode.
+     * |[4]     |POEN4     |PWM Pin Output Enable Bits
+     * |        |          |0 = PWM pin at tri-state.
+     * |        |          |1 = PWM pin in output mode.
+     * |[5]     |POEN5     |PWM Pin Output Enable Bits
+     * |        |          |0 = PWM pin at tri-state.
+     * |        |          |1 = PWM pin in output mode.
+     * @var PWM_T::SWBRK
+     * Offset: 0xDC  PWM Software Brake Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BRKETRG0  |PWM Edge Brake Software Trigger (Write Only) (Write Protect)
+     * |        |          |Write 1 to this bit will trigger Edge brake, and set BRKEIFn to 1 in PWM_INTSTS1 register.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[1]     |BRKETRG2  |PWM Edge Brake Software Trigger (Write Only) (Write Protect)
+     * |        |          |Write 1 to this bit will trigger Edge brake, and set BRKEIFn to 1 in PWM_INTSTS1 register.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[2]     |BRKETRG4  |PWM Edge Brake Software Trigger (Write Only) (Write Protect)
+     * |        |          |Write 1 to this bit will trigger Edge brake, and set BRKEIFn to 1 in PWM_INTSTS1 register.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[8]     |BRKLTRG0  |PWM Level Brake Software Trigger (Write Only) (Write Protect)
+     * |        |          |Write 1 to this bit will trigger level brake, and set BRKLIFn to 1 in PWM_INTSTS1 register.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[9]     |BRKLTRG2  |PWM Level Brake Software Trigger (Write Only) (Write Protect)
+     * |        |          |Write 1 to this bit will trigger level brake, and set BRKLIFn to 1 in PWM_INTSTS1 register.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[10]    |BRKLTRG4  |PWM Level Brake Software Trigger (Write Only) (Write Protect)
+     * |        |          |Write 1 to this bit will trigger level brake, and set BRKLIFn to 1 in PWM_INTSTS1 register.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * @var PWM_T::INTEN0
+     * Offset: 0xE0  PWM Interrupt Enable Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ZIEN0     |PWM Zero Point Interrupt Enable Bit 0
+     * |        |          |0 = Zero point interrupt Disabled.
+     * |        |          |1 = Zero point interrupt Enabled.
+     * |        |          |Note: Odd channels will read always 0 at complementary mode.
+     * |[2]     |ZIEN2     |PWM Zero Point Interrupt Enable Bit 2
+     * |        |          |0 = Zero point interrupt Disabled.
+     * |        |          |1 = Zero point interrupt Enabled.
+     * |        |          |Note: Odd channels will read always 0 at complementary mode.
+     * |[4]     |ZIEN4     |PWM Zero Point Interrupt Enable Bit 4
+     * |        |          |0 = Zero point interrupt Disabled.
+     * |        |          |1 = Zero point interrupt Enabled.
+     * |        |          |Note: Odd channels will read always 0 at complementary mode.
+     * |[8]     |PIEN0     |PWM Period Point Interrupt Enable Bit 0
+     * |        |          |0 = Period point interrupt Disabled.
+     * |        |          |1 = Period point interrupt Enabled.
+     * |        |          |Note: When up-down counter type, period point means center point.
+     * |[10]    |PIEN2     |PWM Period Point Interrupt Enable Bit 2
+     * |        |          |0 = Period point interrupt Disabled.
+     * |        |          |1 = Period point interrupt Enabled.
+     * |        |          |Note: When up-down counter type, period point means center point.
+     * |[12]    |PIEN4     |PWM Period Point Interrupt Enable Bit 4
+     * |        |          |0 = Period point interrupt Disabled.
+     * |        |          |1 = Period point interrupt Enabled.
+     * |        |          |Note: When up-down counter type, period point means center point.
+     * |[16]    |CMPUIEN0  |PWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPUIEN1, 3, 5 is used as another CMPUIEN for channel 0, 2, 4.
+     * |[17]    |CMPUIEN1  |PWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPUIEN1, 3, 5 is used as another CMPUIEN for channel 0, 2, 4.
+     * |[18]    |CMPUIEN2  |PWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPUIEN1, 3, 5 is used as another CMPUIEN for channel 0, 2, 4.
+     * |[19]    |CMPUIEN3  |PWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPUIEN1, 3, 5 is used as another CMPUIEN for channel 0, 2, 4.
+     * |[20]    |CMPUIEN4  |PWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPUIEN1, 3, 5 is used as another CMPUIEN for channel 0, 2, 4.
+     * |[21]    |CMPUIEN5  |PWM Compare Up Count Interrupt Enable Bits
+     * |        |          |Each bit n controls the corresponding PWM channel n.
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPUIEN1, 3, 5 is used as another CMPUIEN for channel 0, 2, 4.
+     * |[24]    |CMPDIEN0  |PWM Compare Down Count Interrupt Enable Bits
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPDIEN1, 3, 5 is used as another CMPDIEN for channel 0, 2, 4.
+     * |[25]    |CMPDIEN1  |PWM Compare Down Count Interrupt Enable Bits
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPDIEN1, 3, 5 is used as another CMPDIEN for channel 0, 2, 4.
+     * |[26]    |CMPDIEN2  |PWM Compare Down Count Interrupt Enable Bits
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPDIEN1, 3, 5 is used as another CMPDIEN for channel 0, 2, 4.
+     * |[27]    |CMPDIEN3  |PWM Compare Down Count Interrupt Enable Bits
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPDIEN1, 3, 5 is used as another CMPDIEN for channel 0, 2, 4.
+     * |[28]    |CMPDIEN4  |PWM Compare Down Count Interrupt Enable Bits
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPDIEN1, 3, 5 is used as another CMPDIEN for channel 0, 2, 4.
+     * |[29]    |CMPDIEN5  |PWM Compare Down Count Interrupt Enable Bits
+     * |        |          |0 = Compare down count interrupt Disabled.
+     * |        |          |1 = Compare down count interrupt Enabled.
+     * |        |          |Note: In complementary mode, CMPDIEN1, 3, 5 is used as another CMPDIEN for channel 0, 2, 4.
+     * @var PWM_T::INTEN1
+     * Offset: 0xE4  PWM Interrupt Enable Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BRKEIEN0_1|PWM Edge-detect Brake Interrupt Enable for Channel0/1 (Write Protect)
+     * |        |          |0 = Edge-detect Brake interrupt for channel0/1 Disabled.
+     * |        |          |1 = Edge-detect Brake interrupt for channel0/1 Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[1]     |BRKEIEN2_3|PWM Edge-detect Brake Interrupt Enable for Channel2/3 (Write Protect)
+     * |        |          |0 = Edge-detect Brake interrupt for channel2/3 Disabled.
+     * |        |          |1 = Edge-detect Brake interrupt for channel2/3 Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[2]     |BRKEIEN4_5|PWM Edge-detect Brake Interrupt Enable for Channel4/5 (Write Protect)
+     * |        |          |0 = Edge-detect Brake interrupt for channel4/5 Disabled.
+     * |        |          |1 = Edge-detect Brake interrupt for channel4/5 Enabled.
+     * |        |          |Note: This bitr is write protected. Refer to SYS_REGLCTL register.
+     * |[8]     |BRKLIEN0_1|PWM Level-detect Brake Interrupt Enable for Channel0/1 (Write Protect)
+     * |        |          |0 = Level-detect Brake interrupt for channel0/1 Disabled.
+     * |        |          |1 = Level-detect Brake interrupt for channel0/1 Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[9]     |BRKLIEN2_3|PWM Level-detect Brake Interrupt Enable for Channel2/3 (Write Protect)
+     * |        |          |0 = Level-detect Brake interrupt for channel2/3 Disabled.
+     * |        |          |1 = Level-detect Brake interrupt for channel2/3 Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[10]    |BRKLIEN4_5|PWM Level-detect Brake Interrupt Enable for Channel4/5 (Write Protect)
+     * |        |          |0 = Level-detect Brake interrupt for channel4/5 Disabled.
+     * |        |          |1 = Level-detect Brake interrupt for channel4/5 Enabled.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * @var PWM_T::INTSTS0
+     * Offset: 0xE8  PWM Interrupt Flag Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ZIF0      |PWM Zero Point Interrupt Flag 0
+     * |        |          |This bit is set by hardware when PWM_CH0 counter reaches 0.
+     * |        |          |Note: This bit can be cleared to 0 by software writing 1.
+     * |[2]     |ZIF2      |PWM Zero Point Interrupt Flag 2
+     * |        |          |This bit is set by hardware when PWM_CH2 counter reaches 0.
+     * |        |          |Note: This bit can be cleared to 0 by software writing 1.
+     * |[4]     |ZIF4      |PWM Zero Point Interrupt Flag 4
+     * |        |          |This bit is set by hardware when PWM_CH4 counter reaches 0.
+     * |        |          |Note: This bit can be cleared to 0 by software writing 1.
+     * |[8]     |PIF0      |PWM Period Point Interrupt Flag 0
+     * |        |          |This bit is set by hardware when PWM_CH0 counter reaches PWM_PERIOD0.
+     * |        |          |Note: This bit can be cleared to 0 by software writing 1.
+     * |[10]    |PIF2      |PWM Period Point Interrupt Flag 2
+     * |        |          |This bit is set by hardware when PWM_CH2 counter reaches PWM_PERIOD2.
+     * |        |          |Note: This bit can be cleared to 0 by software writing 1.
+     * |[12]    |PIF4      |PWM Period Point Interrupt Flag 4
+     * |        |          |This bit is set by hardware when PWM_CH4 counter reaches PWM_PERIOD4.
+     * |        |          |Note: This bit can be cleared to 0 by software writing 1.
+     * |[21:16] |CMPUIFn   |PWM Compare Up Count Interrupt Flag
+     * |        |          |Flag is set by hardware when PWM counter up count and reaches PWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: In complementary mode, CMPUIF1, 3, 5 is used as another CMPUIF for channel 0, 2, 4.
+     * |[24]    |CMPDIF0   |PWM Compare Down Count Interrupt Flag
+     * |        |          |Flag is set by hardware when PWM counter down count and reaches PWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: In complementary mode, CMPDIF1, 3, 5 is used as another CMPDIF for channel 0, 2, 4.
+     * |[25]    |CMPDIF1   |PWM Compare Down Count Interrupt Flag
+     * |        |          |Flag is set by hardware when PWM counter down count and reaches PWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: In complementary mode, CMPDIF1, 3, 5 is used as another CMPDIF for channel 0, 2, 4.
+     * |[26]    |CMPDIF2   |PWM Compare Down Count Interrupt Flag
+     * |        |          |Flag is set by hardware when PWM counter down count and reaches PWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: In complementary mode, CMPDIF1, 3, 5 is used as another CMPDIF for channel 0, 2, 4.
+     * |[27]    |CMPDIF3   |PWM Compare Down Count Interrupt Flag
+     * |        |          |Flag is set by hardware when PWM counter down count and reaches PWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: In complementary mode, CMPDIF1, 3, 5 is used as another CMPDIF for channel 0, 2, 4.
+     * |[28]    |CMPDIF4   |PWM Compare Down Count Interrupt Flag
+     * |        |          |Flag is set by hardware when PWM counter down count and reaches PWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: In complementary mode, CMPDIF1, 3, 5 is used as another CMPDIF for channel 0, 2, 4.
+     * |[29]    |CMPDIF5   |PWM Compare Down Count Interrupt Flag
+     * |        |          |Flag is set by hardware when PWM counter down count and reaches PWM_CMPDATn, software can clear this bit by writing 1 to it.
+     * |        |          |Note: In complementary mode, CMPDIF1, 3, 5 is used as another CMPDIF for channel 0, 2, 4.
+     * @var PWM_T::INTSTS1
+     * Offset: 0xEC  PWM Interrupt Flag Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BRKEIF0   |PWM Channel0 Edge-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel0 edge-detect brake event do not happened.
+     * |        |          |1 = When PWM channel0 edge-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[1]     |BRKEIF1   |PWM Channel1 Edge-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel1 edge-detect brake event do not happened.
+     * |        |          |1 = When PWM channel1 edge-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[2]     |BRKEIF2   |PWM Channel2 Edge-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel2 edge-detect brake event do not happened.
+     * |        |          |1 = When PWM channel2 edge-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[3]     |BRKEIF3   |PWM Channel3 Edge-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel3 edge-detect brake event do not happened.
+     * |        |          |1 = When PWM channel3 edge-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[4]     |BRKEIF4   |PWM Channel4 Edge-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel4 edge-detect brake event do not happened.
+     * |        |          |1 = When PWM channel4 edge-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[5]     |BRKEIF5   |PWM Channel5 Edge-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel5 edge-detect brake event do not happened.
+     * |        |          |1 = When PWM channel5 edge-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[8]     |BRKLIF0   |PWM Channel0 Level-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel0 level-detect brake event do not happened.
+     * |        |          |1 = When PWM channel0 level-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[9]     |BRKLIF1   |PWM Channel1 Level-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel1 level-detect brake event do not happened.
+     * |        |          |1 = When PWM channel1 level-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[10]    |BRKLIF2   |PWM Channel2 Level-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel2 level-detect brake event do not happened.
+     * |        |          |1 = When PWM channel2 level-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[11]    |BRKLIF3   |PWM Channel3 Level-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel3 level-detect brake event do not happened.
+     * |        |          |1 = When PWM channel3 level-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[12]    |BRKLIF4   |PWM Channel4 Level-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel4 level-detect brake event do not happened.
+     * |        |          |1 = When PWM channel4 level-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[13]    |BRKLIF5   |PWM Channel5 Level-detect Brake Interrupt Flag (Write Protect)
+     * |        |          |0 = PWM channel5 level-detect brake event do not happened.
+     * |        |          |1 = When PWM channel5 level-detect brake event happened, this bit is set to 1, writing 1 to clear.
+     * |        |          |Note: This bit is write protected. Refer to SYS_REGLCTL register.
+     * |[16]    |BRKESTS0  |PWM Channel0 Edge-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel0 edge-detect brake state is released.
+     * |        |          |1 = When PWM channel0 edge-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel0 at brake state.
+     * |[17]    |BRKESTS1  |PWM Channel1 Edge-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel1 edge-detect brake state is released.
+     * |        |          |1 = When PWM channel1 edge-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel1 at brake state.
+     * |[18]    |BRKESTS2  |PWM Channel2 Edge-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel2 edge-detect brake state is released.
+     * |        |          |1 = When PWM channel2 edge-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel2 at brake state.
+     * |[19]    |BRKESTS3  |PWM Channel3 Edge-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel3 edge-detect brake state is released.
+     * |        |          |1 = When PWM channel3 edge-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel3 at brake state.
+     * |[20]    |BRKESTS4  |PWM Channel4 Edge-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel4 edge-detect brake state is released.
+     * |        |          |1 = When PWM channel4 edge-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel4 at brake state.
+     * |[21]    |BRKESTS5  |PWM Channel5 Edge-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel5 edge-detect brake state is released.
+     * |        |          |1 = When PWM channel5 edge-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel5 at brake state.
+     * |[24]    |BRKLSTS0  |PWM Channel0 Level-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel0 level-detect brake state is released.
+     * |        |          |1 = When PWM channel0 level-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel0 at brake state.
+     * |        |          |Note: This bit is read only and auto cleared by hardware
+     * |        |          |When enabled brake source return to high level, PWM will release brake state until current PWM period finished
+     * |        |          |The PWM waveform will start output from next full PWM period.
+     * |[25]    |BRKLSTS1  |PWM Channel1 Level-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel1 level-detect brake state is released.
+     * |        |          |1 = When PWM channel1 level-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel1 at brake state.
+     * |        |          |Note: This bit is read only and auto cleared by hardware
+     * |        |          |When enabled brake source return to high level, PWM will release brake state until current PWM period finished
+     * |        |          |The PWM waveform will start output from next full PWM period.
+     * |[26]    |BRKLSTS2  |PWM Channel2 Level-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel2 level-detect brake state is released.
+     * |        |          |1 = When PWM channel2 level-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel2 at brake state.
+     * |        |          |Note: This bit is read only and auto cleared by hardware
+     * |        |          |When enabled brake source return to high level, PWM will release brake state until current PWM period finished
+     * |        |          |The PWM waveform will start output from next full PWM period.
+     * |[27]    |BRKLSTS3  |PWM Channel3 Level-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel3 level-detect brake state is released.
+     * |        |          |1 = When PWM channel3 level-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel3 at brake state.
+     * |        |          |Note: This bit is read only and auto cleared by hardware
+     * |        |          |When enabled brake source return to high level, PWM will release brake state until current PWM period finished
+     * |        |          |The PWM waveform will start output from next full PWM period.
+     * |[28]    |BRKLSTS4  |PWM Channel4 Level-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel4 level-detect brake state is released.
+     * |        |          |1 = When PWM channel4 level-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel4 at brake state.
+     * |        |          |Note: This bit is read only and auto cleared by hardware
+     * |        |          |When enabled brake source return to high level, PWM will release brake state until current PWM period finished
+     * |        |          |The PWM waveform will start output from next full PWM period.
+     * |[29]    |BRKLSTS5  |PWM Channel5 Level-detect Brake Status (Read Only)
+     * |        |          |0 = PWM channel5 level-detect brake state is released.
+     * |        |          |1 = When PWM channel5 level-detect brake detects a falling edge of any enabled brake source; this flag will be set to indicate the PWM channel5 at brake state.
+     * |        |          |Note: This bit is read only and auto cleared by hardware
+     * |        |          |When enabled brake source return to high level, PWM will release brake state until current PWM period finished
+     * |        |          |The PWM waveform will start output from next full PWM period.
+     * @var PWM_T::EADCTS0
+     * Offset: 0xF8  PWM Trigger EADC Source Select Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |TRGSEL0   |PWM_CH0 Trigger EADC Source Select
+     * |        |          |0000 = PWM_CH0 zero point.
+     * |        |          |0001 = PWM_CH0 period point.
+     * |        |          |0010 = PWM_CH0 zero or period point.
+     * |        |          |0011 = PWM_CH0 up-count CMPDAT point.
+     * |        |          |0100 = PWM_CH0 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = PWM_CH1 up-count CMPDAT point.
+     * |        |          |1001 = PWM_CH1 down-count CMPDAT point.
+     * |        |          |Others = reserved.
+     * |[7]     |TRGEN0    |PWM_CH0 Trigger EADC Enable Bit
+     * |        |          |0 = PWM_CH0 Trigger EADC function Disabled.
+     * |        |          |1 = PWM_CH0 Trigger EADC function Enabled.
+     * |[11:8]  |TRGSEL1   |PWM_CH1 Trigger EADC Source Select
+     * |        |          |0000 = PWM_CH0 zero point.
+     * |        |          |0001 = PWM_CH0 period point.
+     * |        |          |0010 = PWM_CH0 zero or period point.
+     * |        |          |0011 = PWM_CH0 up-count CMPDAT point.
+     * |        |          |0100 = PWM_CH0 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = PWM_CH1 up-count CMPDAT point.
+     * |        |          |1001 = PWM_CH1 down-count CMPDAT point.
+     * |        |          |Others = reserved.
+     * |[15]    |TRGEN1    |PWM_CH1 Trigger EADC Enable Bit
+     * |        |          |0 = PWM_CH1 Trigger EADC function Disabled.
+     * |        |          |1 = PWM_CH1 Trigger EADC function Enabled.
+     * |[19:16] |TRGSEL2   |PWM_CH2 Trigger EADC Source Select
+     * |        |          |0000 = PWM_CH2 zero point.
+     * |        |          |0001 = PWM_CH2 period point.
+     * |        |          |0010 = PWM_CH2 zero or period point.
+     * |        |          |0011 = PWM_CH2 up-count CMPDAT point.
+     * |        |          |0100 = PWM_CH2 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = PWM_CH3 up-count CMPDAT point.
+     * |        |          |1001 = PWM_CH3 down-count CMPDAT point.
+     * |        |          |Others = reserved.
+     * |[23]    |TRGEN2    |PWM_CH2 Trigger EADC Enable Bit
+     * |        |          |0 = PWM_CH2 Trigger EADC function Disabled.
+     * |        |          |1 = PWM_CH2 Trigger EADC function Enabled.
+     * |[27:24] |TRGSEL3   |PWM_CH3 Trigger EADC Source Select
+     * |        |          |0000 = PWM_CH2 zero point.
+     * |        |          |0001 = PWM_CH2 period point.
+     * |        |          |0010 = PWM_CH2 zero or period point.
+     * |        |          |0011 = PWM_CH2 up-count CMPDAT point.
+     * |        |          |0100 = PWM_CH2 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = PWM_CH3 up-count CMPDAT point.
+     * |        |          |1001 = PWM_CH3 down-count CMPDAT point.
+     * |        |          |Others = reserved.
+     * |[31]    |TRGEN3    |PWM_CH3 Trigger EADC Enable Bit
+     * |        |          |0 = PWM_CH3 Trigger EADC function Disabled.
+     * |        |          |1 = PWM_CH3 Trigger EADC function Enabled.
+     * @var PWM_T::EADCTS1
+     * Offset: 0xFC  PWM Trigger EADC Source Select Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |TRGSEL4   |PWM_CH4 Trigger EADC Source Select
+     * |        |          |0000 = PWM_CH4 zero point.
+     * |        |          |0001 = PWM_CH4 period point.
+     * |        |          |0010 = PWM_CH4 zero or period point.
+     * |        |          |0011 = PWM_CH4 up-count CMPDAT point.
+     * |        |          |0100 = PWM_CH4 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = PWM_CH5 up-count CMPDAT point.
+     * |        |          |1001 = PWM_CH5 down-count CMPDAT point.
+     * |        |          |Others = reserved.
+     * |[7]     |TRGEN4    |PWM_CH4 Trigger EADC Enable Bit
+     * |        |          |0 = PWM_CH4 Trigger EADC function Disabled.
+     * |        |          |1 = PWM_CH4 Trigger EADC function Enabled.
+     * |[11:8]  |TRGSEL5   |PWM_CH5 Trigger EADC Source Select
+     * |        |          |0000 = PWM_CH4 zero point.
+     * |        |          |0001 = PWM_CH4 period point.
+     * |        |          |0010 = PWM_CH4 zero or period point.
+     * |        |          |0011 = PWM_CH4 up-count CMPDAT point.
+     * |        |          |0100 = PWM_CH4 down-count CMPDAT point.
+     * |        |          |0101 = Reserved.
+     * |        |          |0110 = Reserved.
+     * |        |          |0111 = Reserved.
+     * |        |          |1000 = PWM_CH5 up-count CMPDAT point.
+     * |        |          |1001 = PWM_CH5 down-count CMPDAT point.
+     * |        |          |Others = reserved.
+     * |[15]    |TRGEN5    |PWM_CH5 Trigger EADC Enable Bit
+     * |        |          |0 = PWM_CH5 Trigger EADC function Disabled.
+     * |        |          |1 = PWM_CH5 Trigger EADC function Enabled.
+     * @var PWM_T::SSCTL
+     * Offset: 0x110  PWM Synchronous Start Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SSEN0     |PWM Synchronous Start Function Enable Bit 0
+     * |        |          |When synchronous start function is enabled, the PWM_CH0 counter enable bit (CNTEN0) can be enabled by writing PWM synchronous start trigger bit (CNTSEN).
+     * |        |          |0 = PWM synchronous start function Disabled.
+     * |        |          |1 = PWM synchronous start function Enabled.
+     * |[2]     |SSEN2     |PWM Synchronous Start Function Enable Bit 2
+     * |        |          |When synchronous start function is enabled, the PWM_CH2 counter enable bit (CNTEN2) can be enabled by writing PWM synchronous start trigger bit (CNTSEN).
+     * |        |          |0 = PWM synchronous start function Disabled.
+     * |        |          |1 = PWM synchronous start function Enabled.
+     * |[4]     |SSEN4     |PWM Synchronous Start Function Enable Bit 4
+     * |        |          |When synchronous start function is enabled, the PWM_CH4 counter enable bit (CNTEN4) can be enabled by writing PWM synchronous start trigger bit (CNTSEN).
+     * |        |          |0 = PWM synchronous start function Disabled.
+     * |        |          |1 = PWM synchronous start function Enabled.
+     * |[9:8]   |SSRC      |PWM Synchronous Start Source Select Bits
+     * |        |          |00 = Synchronous start source come from PWM0.
+     * |        |          |01 = Synchronous start source come from PWM1.
+     * |        |          |10 = Synchronous start source come from BPWM0.
+     * |        |          |11 = Synchronous start source come from BPWM1.
+     * @var PWM_T::SSTRG
+     * Offset: 0x114  PWM Synchronous Start Trigger Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTSEN    |PWM Counter Synchronous Start Enable (Write Only)
+     * |        |          |PMW counter synchronous enable function is used to make selected PWM channels (include PWM0_CHx and PWM1_CHx) start counting at the same time.
+     * |        |          |Writing this bit to 1 will also set the counter enable bit (CNTENn, n denotes channel 0 to 5) if correlated PWM channel counter synchronous start function is enabled.
+     * @var PWM_T::STATUS
+     * Offset: 0x120  PWM Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTMAX0   |Time-base Counter 0 Equal to 0xFFFF Latched Flag
+     * |        |          |0 = indicates the time-base counter never reached its maximum value 0xFFFF.
+     * |        |          |1 = indicates the time-base counter reached its maximum value.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * |[2]     |CNTMAX2   |Time-base Counter 2 Equal to 0xFFFF Latched Flag
+     * |        |          |0 = indicates the time-base counter never reached its maximum value 0xFFFF.
+     * |        |          |1 = indicates the time-base counter reached its maximum value.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * |[4]     |CNTMAX4   |Time-base Counter 4 Equal to 0xFFFF Latched Flag
+     * |        |          |0 = The time-base counter never reached its maximum value 0xFFFF.
+     * |        |          |1 = The time-base counter reached its maximum value.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * |[16]    |EADCTRG0  |EADC Start of Conversion Status
+     * |        |          |0 = Indicates no EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * |[17]    |EADCTRG1  |EADC Start of Conversion Status
+     * |        |          |0 = Indicates no EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * |[18]    |EADCTRG2  |EADC Start of Conversion Status
+     * |        |          |0 = Indicates no EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * |[19]    |EADCTRG3  |EADC Start of Conversion Status
+     * |        |          |0 = Indicates no EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * |[20]    |EADCTRG4  |EADC Start of Conversion Status
+     * |        |          |0 = Indicates no EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * |[21]    |EADCTRG5  |EADC Start of Conversion Status
+     * |        |          |0 = Indicates no EADC start of conversion trigger event has occurred.
+     * |        |          |1 = An EADC start of conversion trigger event has occurred.
+     * |        |          |Note: This bit can be cleared by software writing 1.
+     * @var PWM_T::CAPINEN
+     * Offset: 0x200  PWM Capture Input Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CAPINEN0  |Capture Input Enable Bits
+     * |        |          |0 = PWM Channel capture input path Disabled
+     * |        |          |The input of PWM channel capture function is always regarded as 0.
+     * |        |          |1 = PWM Channel capture input path Enabled
+     * |        |          |The input of PWM channel capture function comes from correlative multifunction pin.
+     * |[1]     |CAPINEN1  |Capture Input Enable Bits
+     * |        |          |0 = PWM Channel capture input path Disabled
+     * |        |          |The input of PWM channel capture function is always regarded as 0.
+     * |        |          |1 = PWM Channel capture input path Enabled
+     * |        |          |The input of PWM channel capture function comes from correlative multifunction pin.
+     * |[2]     |CAPINEN2  |Capture Input Enable Bits
+     * |        |          |0 = PWM Channel capture input path Disabled
+     * |        |          |The input of PWM channel capture function is always regarded as 0.
+     * |        |          |1 = PWM Channel capture input path Enabled
+     * |        |          |The input of PWM channel capture function comes from correlative multifunction pin.
+     * |[3]     |CAPINEN3  |Capture Input Enable Bits
+     * |        |          |0 = PWM Channel capture input path Disabled
+     * |        |          |The input of PWM channel capture function is always regarded as 0.
+     * |        |          |1 = PWM Channel capture input path Enabled
+     * |        |          |The input of PWM channel capture function comes from correlative multifunction pin.
+     * |[4]     |CAPINEN4  |Capture Input Enable Bits
+     * |        |          |0 = PWM Channel capture input path Disabled
+     * |        |          |The input of PWM channel capture function is always regarded as 0.
+     * |        |          |1 = PWM Channel capture input path Enabled
+     * |        |          |The input of PWM channel capture function comes from correlative multifunction pin.
+     * |[5]     |CAPINEN5  |Capture Input Enable Bits
+     * |        |          |0 = PWM Channel capture input path Disabled
+     * |        |          |The input of PWM channel capture function is always regarded as 0.
+     * |        |          |1 = PWM Channel capture input path Enabled
+     * |        |          |The input of PWM channel capture function comes from correlative multifunction pin.
+     * @var PWM_T::CAPCTL
+     * Offset: 0x204  PWM Capture Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CAPEN0    |Capture Function Enable Bits
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the PWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[1]     |CAPEN1    |Capture Function Enable Bits
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the PWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[2]     |CAPEN2    |Capture Function Enable Bits
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the PWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[3]     |CAPEN3    |Capture Function Enable Bits
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the PWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[4]     |CAPEN4    |Capture Function Enable Bits
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the PWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[5]     |CAPEN5    |Capture Function Enable Bits
+     * |        |          |0 = Capture function Disabled. RCAPDAT/FCAPDAT register will not be updated.
+     * |        |          |1 = Capture function Enabled
+     * |        |          |Capture latched the PWM counter value when detected rising or falling edge of input signal and saved to RCAPDAT (Rising latch) and FCAPDAT (Falling latch).
+     * |[8]     |CAPINV0   |Capture Inverter Enable Bits
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[9]     |CAPINV1   |Capture Inverter Enable Bits
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[10]    |CAPINV2   |Capture Inverter Enable Bits
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[11]    |CAPINV3   |Capture Inverter Enable Bits
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[12]    |CAPINV4   |Capture Inverter Enable Bits
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[13]    |CAPINV5   |Capture Inverter Enable Bits
+     * |        |          |0 = Capture source inverter Disabled.
+     * |        |          |1 = Capture source inverter Enabled. Reverse the input signal from GPIO.
+     * |[16]    |RCRLDEN0  |Rising Capture Reload Enable Bits
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[17]    |RCRLDEN1  |Rising Capture Reload Enable Bits
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[18]    |RCRLDEN2  |Rising Capture Reload Enable Bits
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[19]    |RCRLDEN3  |Rising Capture Reload Enable Bits
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[20]    |RCRLDEN4  |Rising Capture Reload Enable Bits
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[21]    |RCRLDEN5  |Rising Capture Reload Enable Bits
+     * |        |          |0 = Rising capture reload counter Disabled.
+     * |        |          |1 = Rising capture reload counter Enabled.
+     * |[24]    |FCRLDEN0  |Falling Capture Reload Enable Bits
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[25]    |FCRLDEN1  |Falling Capture Reload Enable Bits
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[26]    |FCRLDEN2  |Falling Capture Reload Enable Bits
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[27]    |FCRLDEN3  |Falling Capture Reload Enable Bits
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[28]    |FCRLDEN4  |Falling Capture Reload Enable Bits
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * |[29]    |FCRLDEN5  |Falling Capture Reload Enable Bits
+     * |        |          |0 = Falling capture reload counter Disabled.
+     * |        |          |1 = Falling capture reload counter Enabled.
+     * @var PWM_T::CAPSTS
+     * Offset: 0x208  PWM Capture Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CRLIFOV0  |Capture Rising Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CRLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CRLIF.
+     * |[1]     |CRLIFOV1  |Capture Rising Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CRLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CRLIF.
+     * |[2]     |CRLIFOV2  |Capture Rising Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CRLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CRLIF.
+     * |[3]     |CRLIFOV3  |Capture Rising Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CRLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CRLIF.
+     * |[4]     |CRLIFOV4  |Capture Rising Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CRLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CRLIF.
+     * |[5]     |CRLIFOV5  |Capture Rising Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if rising latch happened when the corresponding CRLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CRLIF.
+     * |[8]     |CFLIFOV0  |Capture Falling Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CFLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CFLIF.
+     * |[9]     |CFLIFOV1  |Capture Falling Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CFLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CFLIF.
+     * |[10]    |CFLIFOV2  |Capture Falling Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CFLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CFLIF.
+     * |[11]    |CFLIFOV3  |Capture Falling Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CFLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CFLIF.
+     * |[12]    |CFLIFOV4  |Capture Falling Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CFLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CFLIF.
+     * |[13]    |CFLIFOV5  |Capture Falling Latch Interrupt Flag Overrun Status (Read Only)
+     * |        |          |This flag indicates if falling latch happened when the corresponding CFLIF is 1.
+     * |        |          |Note: This bit will be cleared automatically when user clear corresponding CFLIF.
+     * @var PWM_T::PDMACTL
+     * Offset: 0x23C  PWM PDMA Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CHEN0_1   |Channel 0/1 PDMA Enable Bit
+     * |        |          |0 = Channel 0/1 PDMA function Disabled.
+     * |        |          |1 = Channel 0/1 PDMA function Enabled for the channel 0/1 captured data and transfer to memory.
+     * |[2:1]   |CAPMOD0_1 |Select PWM_RCAPDAT0/1 or PWM_FCAPDAT0/1 to Do PDMA Transfer
+     * |        |          |00 = Reserved.
+     * |        |          |01 = PWM_RCAPDAT0/1.
+     * |        |          |10 = PWM_FCAPDAT0/1.
+     * |        |          |11 = Both PWM_RCAPDAT0/1 and PWM_FCAPDAT0/1.
+     * |[3]     |CAPORD0_1 |Capture Channel 0/1 Rising/Falling Order
+     * |        |          |Set this bit to determine whether the PWM_RCAPDAT0/1 or PWM_FCAPDAT0/1 is the first captured data transferred to memory through PDMA when CAPMOD0_1 =11.
+     * |        |          |0 = PWM_FCAPDAT0/1 is the first captured data to memory.
+     * |        |          |1 = PWM_RCAPDAT0/1 is the first captured data to memory.
+     * |[4]     |CHSEL0_1  |Select Channel 0/1 to Do PDMA Transfer
+     * |        |          |0 = Channel0.
+     * |        |          |1 = Channel1.
+     * |[8]     |CHEN2_3   |Channel 2/3 PDMA Enable Bit
+     * |        |          |0 = Channel 2/3 PDMA function Disabled.
+     * |        |          |1 = Channel 2/3 PDMA function Enabled for the channel 2/3 captured data and transfer to memory.
+     * |[10:9]  |CAPMOD2_3 |Select PWM_RCAPDAT2/3 or PWM_FCAODAT2/3 to Do PDMA Transfer
+     * |        |          |00 = Reserved.
+     * |        |          |01 = PWM_RCAPDAT2/3.
+     * |        |          |10 = PWM_FCAPDAT2/3.
+     * |        |          |11 = Both PWM_RCAPDAT2/3 and PWM_FCAPDAT2/3.
+     * |[11]    |CAPORD2_3 |Capture Channel 2/3 Rising/Falling Order
+     * |        |          |Set this bit to determine whether the PWM_RCAPDAT2/3 or PWM_FCAPDAT2/3 is the first captured data transferred to memory through PDMA when CAPMOD2_3 =11.
+     * |        |          |0 = PWM_FCAPDAT2/3 is the first captured data to memory.
+     * |        |          |1 = PWM_RCAPDAT2/3 is the first captured data to memory.
+     * |[12]    |CHSEL2_3  |Select Channel 2/3 to Do PDMA Transfer
+     * |        |          |0 = Channel2.
+     * |        |          |1 = Channel3.
+     * |[16]    |CHEN4_5   |Channel 4/5 PDMA Enable Bit
+     * |        |          |0 = Channel 4/5 PDMA function Disabled.
+     * |        |          |1 = Channel 4/5 PDMA function Enabled for the channel 4/5 captured data and transfer to memory.
+     * |[18:17] |CAPMOD4_5 |Select PWM_RCAPDAT4/5 or PWM_FCAPDAT4/5 to Do PDMA Transfer
+     * |        |          |00 = Reserved.
+     * |        |          |01 = PWM_RCAPDAT4/5.
+     * |        |          |10 = PWM_FCAPDAT4/5.
+     * |        |          |11 = Both PWM_RCAPDAT4/5 and PWM_FCAPDAT4/5.
+     * |[19]    |CAPORD4_5 |Capture Channel 4/5 Rising/Falling Order
+     * |        |          |Set this bit to determine whether the PWM_RCAPDAT4/5 or PWM_FCAPDAT4/5 is the first captured data transferred to memory through PDMA when CAPMOD4_5 =11.
+     * |        |          |0 = PWM_FCAPDAT4/5 is the first captured data to memory.
+     * |        |          |1 = PWM_RCAPDAT4/5 is the first captured data to memory.
+     * |[20]    |CHSEL4_5  |Select Channel 4/5 to Do PDMA Transfer
+     * |        |          |0 = Channel4.
+     * |        |          |1 = Channel5.
+     * @var PWM_T::PDMACAP[3]
+     * Offset: 0x240~0x248  PWM Capture Channel 01 23 45 PDMA Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CAPBUF    |PWM Capture PDMA Register (Read Only)
+     * |        |          |This register is used as a buffer to transfer PWM capture rising or falling data to memory by PDMA.
+     * @var PWM_T::CAPIEN
+     * Offset: 0x250  PWM Capture Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CAPRIEN0  |PWM Capture Rising Latch Interrupt Enable Bits
+     * |        |          |0 = Capture rising edge latch interrupt Disabled.
+     * |        |          |1 = Capture rising edge latch interrupt Enabled.
+     * |[1]     |CAPRIEN1  |PWM Capture Rising Latch Interrupt Enable Bits
+     * |        |          |0 = Capture rising edge latch interrupt Disabled.
+     * |        |          |1 = Capture rising edge latch interrupt Enabled.
+     * |[2]     |CAPRIEN2  |PWM Capture Rising Latch Interrupt Enable Bits
+     * |        |          |0 = Capture rising edge latch interrupt Disabled.
+     * |        |          |1 = Capture rising edge latch interrupt Enabled.
+     * |[3]     |CAPRIEN3  |PWM Capture Rising Latch Interrupt Enable Bits
+     * |        |          |0 = Capture rising edge latch interrupt Disabled.
+     * |        |          |1 = Capture rising edge latch interrupt Enabled.
+     * |[4]     |CAPRIEN4  |PWM Capture Rising Latch Interrupt Enable Bits
+     * |        |          |0 = Capture rising edge latch interrupt Disabled.
+     * |        |          |1 = Capture rising edge latch interrupt Enabled.
+     * |[5]     |CAPRIEN5  |PWM Capture Rising Latch Interrupt Enable Bits
+     * |        |          |0 = Capture rising edge latch interrupt Disabled.
+     * |        |          |1 = Capture rising edge latch interrupt Enabled.
+     * |[8]     |CAPFIEN0  |PWM Capture Falling Latch Interrupt Enable Bits
+     * |        |          |0 = Capture falling edge latch interrupt Disabled.
+     * |        |          |1 = Capture falling edge latch interrupt Enabled.
+     * |[9]     |CAPFIEN1  |PWM Capture Falling Latch Interrupt Enable Bits
+     * |        |          |0 = Capture falling edge latch interrupt Disabled.
+     * |        |          |1 = Capture falling edge latch interrupt Enabled.
+     * |[10]    |CAPFIEN2  |PWM Capture Falling Latch Interrupt Enable Bits
+     * |        |          |0 = Capture falling edge latch interrupt Disabled.
+     * |        |          |1 = Capture falling edge latch interrupt Enabled.
+     * |[11]    |CAPFIEN3  |PWM Capture Falling Latch Interrupt Enable Bits
+     * |        |          |0 = Capture falling edge latch interrupt Disabled.
+     * |        |          |1 = Capture falling edge latch interrupt Enabled.
+     * |[12]    |CAPFIEN4  |PWM Capture Falling Latch Interrupt Enable Bits
+     * |        |          |0 = Capture falling edge latch interrupt Disabled.
+     * |        |          |1 = Capture falling edge latch interrupt Enabled.
+     * |[13]    |CAPFIEN5  |PWM Capture Falling Latch Interrupt Enable Bits
+     * |        |          |0 = Capture falling edge latch interrupt Disabled.
+     * |        |          |1 = Capture falling edge latch interrupt Enabled.
+     * @var PWM_T::CAPIF
+     * Offset: 0x254  PWM Capture Interrupt Flag Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CRLIF0    |PWM Capture Rising Latch Interrupt Flag
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CRLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[1]     |CRLIF1    |PWM Capture Rising Latch Interrupt Flag
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CRLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[2]     |CRLIF2    |PWM Capture Rising Latch Interrupt Flag
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CRLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[3]     |CRLIF3    |PWM Capture Rising Latch Interrupt Flag
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CRLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[4]     |CRLIF4    |PWM Capture Rising Latch Interrupt Flag
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CRLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[5]     |CRLIF5    |PWM Capture Rising Latch Interrupt Flag
+     * |        |          |0 = No capture rising latch condition happened.
+     * |        |          |1 = Capture rising latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CRLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[8]     |CFLIF0    |PWM Capture Falling Latch Interrupt Flag
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CFLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[9]     |CFLIF1    |PWM Capture Falling Latch Interrupt Flag
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CFLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[10]    |CFLIF2    |PWM Capture Falling Latch Interrupt Flag
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CFLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[11]    |CFLIF3    |PWM Capture Falling Latch Interrupt Flag
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CFLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[12]    |CFLIF4    |PWM Capture Falling Latch Interrupt Flag
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CFLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[13]    |CFLIF5    |PWM Capture Falling Latch Interrupt Flag
+     * |        |          |0 = No capture falling latch condition happened.
+     * |        |          |1 = Capture falling latch condition happened, this flag will be set to high.
+     * |        |          |Note1: When Capture with PDMA operating, CAPIF corresponding channel CFLIF will be cleared by hardware after PDMA transfer data.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * @var PWM_T::PBUF[6]
+     * Offset: 0x304~0x318  PWM PERIOD0, 2, 4 Buffer
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |PBUF      |PWM Period Register Buffer (Read Only)
+     * |        |          |Used as PERIOD active register.
+     * @var PWM_T::CMPBUF[6]
+     * Offset: 0x31C~0x330  PWM CMPDAT0~5 Buffer
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CMPBUF    |PWM Comparator Register Buffer (Read Only)
+     * |        |          |Used as CMP active register.
+     */
+    __IO uint32_t CTL0;                  /*!< [0x0000] PWM Control Register 0                                           */
+    __IO uint32_t CTL1;                  /*!< [0x0004] PWM Control Register 1                                           */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CLKSRC;                /*!< [0x0010] PWM Clock Source Register                                        */
+    __IO uint32_t CLKPSC[3];             /*!< [0x0014 ~ 0x001c] PWM Clock Prescale Register                             */
+    __IO uint32_t CNTEN;                 /*!< [0x0020] PWM Counter Enable Register                                      */
+    __IO uint32_t CNTCLR;                /*!< [0x0024] PWM Clear Counter Register                                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PERIOD[6];            /*!< [0x0030 ~ 0x0044] PWM Period Register 0                                    */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE4[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CMPDAT[6];             /*!< [0x0050 ~ 0x0064] PWM Comparator Register 0 ~ 5                           */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE5[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t DTCTL[3];              /*!< [0x0070 ~ 0x0078] PWM Dead-time Control Register                          */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE6[5];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t CNT[6];                /*!< [0x0090] PWM Counter Register 0,2,4                                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE9[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t WGCTL0;                /*!< [0x00b0] PWM Generation Register 0                                        */
+    __IO uint32_t WGCTL1;                /*!< [0x00b4] PWM Generation Register 1                                        */
+    __IO uint32_t MSKEN;                 /*!< [0x00b8] PWM Mask Enable Register                                         */
+    __IO uint32_t MSK;                   /*!< [0x00bc] PWM Mask Data Register                                           */
+    __IO uint32_t BNF;                   /*!< [0x00c0] PWM Brake Noise Filter Register                                  */
+    __IO uint32_t FAILBRK;               /*!< [0x00c4] PWM System Fail Brake Control Register                           */
+    __IO uint32_t BRKCTL[3];             /*!< [0x00c8 ~ 0x00d0] PWM Brake Edge Detect Control Register                  */
+    __IO uint32_t POLCTL;                /*!< [0x00d4] PWM Pin Polar Inverse Register                                   */
+    __IO uint32_t POEN;                  /*!< [0x00d8] PWM Output Enable Register                                       */
+    __O  uint32_t SWBRK;                 /*!< [0x00dc] PWM Software Brake Control Register                              */
+    __IO uint32_t INTEN0;                /*!< [0x00e0] PWM Interrupt Enable Register 0                                  */
+    __IO uint32_t INTEN1;                /*!< [0x00e4] PWM Interrupt Enable Register 1                                  */
+    __IO uint32_t INTSTS0;               /*!< [0x00e8] PWM Interrupt Flag Register 0                                    */
+    __IO uint32_t INTSTS1;               /*!< [0x00ec] PWM Interrupt Flag Register 1                                    */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE10[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t EADCTS0;               /*!< [0x00f8] PWM Trigger EADC Source Select Register 0                        */
+    __IO uint32_t EADCTS1;               /*!< [0x00fc] PWM Trigger EADC Source Select Register 1                        */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE11[4];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t SSCTL;                 /*!< [0x0110] PWM Synchronous Start Control Register                           */
+    __O  uint32_t SSTRG;                 /*!< [0x0114] PWM Synchronous Start Trigger Register                           */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE12[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t STATUS;                /*!< [0x0120] PWM Status Register                                              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE13[55];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CAPINEN;               /*!< [0x0200] PWM Capture Input Enable Register                                */
+    __IO uint32_t CAPCTL;                /*!< [0x0204] PWM Capture Control Register                                     */
+    __I  uint32_t CAPSTS;                /*!< [0x0208] PWM Capture Status Register                                      */
+    CAPDAT_T CAPDAT[6];                 /*!< [0x020C] PWM Rising and Falling Capture Data Register 0~5                  */
+    __IO uint32_t PDMACTL;               /*!< [0x023c] PWM PDMA Control Register                                        */
+    __I  uint32_t PDMACAP[3];            /*!< [0x0240 ~ 0x0248] PWM Capture Channel 01, 23, 45 PDMA Register            */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE14[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CAPIEN;                /*!< [0x0250] PWM Capture Interrupt Enable Register                            */
+    __IO uint32_t CAPIF;                 /*!< [0x0254] PWM Capture Interrupt Flag Register                              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE15[43];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t PBUF[6];               /*!< [0x0304 ~ 0x0318] PWM PERIOD0 ~ 6 Buffer                                  */
+    __I  uint32_t CMPBUF[6];             /*!< [0x031c ~ 0x0330] PWM CMPDAT0 ~ 5 Buffer                                  */
+} PWM_T;
+
+/**
+    @addtogroup PWM_CONST PWM Bit Field Definition
+    Constant Definitions for PWM Controller
+@{ */
+
+#define PWM_CTL0_CTRLDn_Pos              (0)                                               /*!< PWM_T::CTL0: CTRLDn Position           */
+#define PWM_CTL0_CTRLDn_Msk              (0x3ful << PWM_CTL0_CTRLDn_Pos)                   /*!< PWM_T::CTL0: CTRLDn Mask               */
+
+#define PWM_CTL0_CTRLD0_Pos              (0)                                               /*!< PWM_T::CTL0: CTRLD0 Position           */
+#define PWM_CTL0_CTRLD0_Msk              (0x1ul << PWM_CTL0_CTRLD0_Pos)                    /*!< PWM_T::CTL0: CTRLD0 Mask               */
+
+#define PWM_CTL0_CTRLD1_Pos              (1)                                               /*!< PWM_T::CTL0: CTRLD1 Position           */
+#define PWM_CTL0_CTRLD1_Msk              (0x1ul << PWM_CTL0_CTRLD1_Pos)                    /*!< PWM_T::CTL0: CTRLD1 Mask               */
+
+#define PWM_CTL0_CTRLD2_Pos              (2)                                               /*!< PWM_T::CTL0: CTRLD2 Position           */
+#define PWM_CTL0_CTRLD2_Msk              (0x1ul << PWM_CTL0_CTRLD2_Pos)                    /*!< PWM_T::CTL0: CTRLD2 Mask               */
+
+#define PWM_CTL0_CTRLD3_Pos              (3)                                               /*!< PWM_T::CTL0: CTRLD3 Position           */
+#define PWM_CTL0_CTRLD3_Msk              (0x1ul << PWM_CTL0_CTRLD3_Pos)                    /*!< PWM_T::CTL0: CTRLD3 Mask               */
+
+#define PWM_CTL0_CTRLD4_Pos              (4)                                               /*!< PWM_T::CTL0: CTRLD4 Position           */
+#define PWM_CTL0_CTRLD4_Msk              (0x1ul << PWM_CTL0_CTRLD4_Pos)                    /*!< PWM_T::CTL0: CTRLD4 Mask               */
+
+#define PWM_CTL0_CTRLD5_Pos              (5)                                               /*!< PWM_T::CTL0: CTRLD5 Position           */
+#define PWM_CTL0_CTRLD5_Msk              (0x1ul << PWM_CTL0_CTRLD5_Pos)                    /*!< PWM_T::CTL0: CTRLD5 Mask               */
+
+#define PWM_CTL0_IMMLDENn_Pos            (16)                                              /*!< PWM_T::CTL0: IMMLDENn Position         */
+#define PWM_CTL0_IMMLDENn_Msk            (0x3ful << PWM_CTL0_IMMLDENn_Pos)                 /*!< PWM_T::CTL0: IMMLDENn Mask             */
+
+#define PWM_CTL0_IMMLDEN0_Pos            (16)                                              /*!< PWM_T::CTL0: IMMLDEN0 Position         */
+#define PWM_CTL0_IMMLDEN0_Msk            (0x1ul << PWM_CTL0_IMMLDEN0_Pos)                  /*!< PWM_T::CTL0: IMMLDEN0 Mask             */
+
+#define PWM_CTL0_IMMLDEN1_Pos            (17)                                              /*!< PWM_T::CTL0: IMMLDEN1 Position         */
+#define PWM_CTL0_IMMLDEN1_Msk            (0x1ul << PWM_CTL0_IMMLDEN1_Pos)                  /*!< PWM_T::CTL0: IMMLDEN1 Mask             */
+
+#define PWM_CTL0_IMMLDEN2_Pos            (18)                                              /*!< PWM_T::CTL0: IMMLDEN2 Position         */
+#define PWM_CTL0_IMMLDEN2_Msk            (0x1ul << PWM_CTL0_IMMLDEN2_Pos)                  /*!< PWM_T::CTL0: IMMLDEN2 Mask             */
+
+#define PWM_CTL0_IMMLDEN3_Pos            (19)                                              /*!< PWM_T::CTL0: IMMLDEN3 Position         */
+#define PWM_CTL0_IMMLDEN3_Msk            (0x1ul << PWM_CTL0_IMMLDEN3_Pos)                  /*!< PWM_T::CTL0: IMMLDEN3 Mask             */
+
+#define PWM_CTL0_IMMLDEN4_Pos            (20)                                              /*!< PWM_T::CTL0: IMMLDEN4 Position         */
+#define PWM_CTL0_IMMLDEN4_Msk            (0x1ul << PWM_CTL0_IMMLDEN4_Pos)                  /*!< PWM_T::CTL0: IMMLDEN4 Mask             */
+
+#define PWM_CTL0_IMMLDEN5_Pos            (21)                                              /*!< PWM_T::CTL0: IMMLDEN5 Position         */
+#define PWM_CTL0_IMMLDEN5_Msk            (0x1ul << PWM_CTL0_IMMLDEN5_Pos)                  /*!< PWM_T::CTL0: IMMLDEN5 Mask             */
+
+#define PWM_CTL0_DBGHALT_Pos             (30)                                              /*!< PWM_T::CTL0: DBGHALT Position          */
+#define PWM_CTL0_DBGHALT_Msk             (0x1ul << PWM_CTL0_DBGHALT_Pos)                   /*!< PWM_T::CTL0: DBGHALT Mask              */
+
+#define PWM_CTL0_DBGTRIOFF_Pos           (31)                                              /*!< PWM_T::CTL0: DBGTRIOFF Position        */
+#define PWM_CTL0_DBGTRIOFF_Msk           (0x1ul << PWM_CTL0_DBGTRIOFF_Pos)                 /*!< PWM_T::CTL0: DBGTRIOFF Mask            */
+
+#define PWM_CTL1_CNTTYPE0_Pos            (0)                                               /*!< PWM_T::CTL1: CNTTYPE0 Position         */
+#define PWM_CTL1_CNTTYPE0_Msk            (0x3ul << PWM_CTL1_CNTTYPE0_Pos)                  /*!< PWM_T::CTL1: CNTTYPE0 Mask             */
+
+#define PWM_CTL1_CNTTYPE2_Pos            (4)                                               /*!< PWM_T::CTL1: CNTTYPE2 Position         */
+#define PWM_CTL1_CNTTYPE2_Msk            (0x3ul << PWM_CTL1_CNTTYPE2_Pos)                  /*!< PWM_T::CTL1: CNTTYPE2 Mask             */
+
+#define PWM_CTL1_CNTTYPE4_Pos            (8)                                               /*!< PWM_T::CTL1: CNTTYPE4 Position         */
+#define PWM_CTL1_CNTTYPE4_Msk            (0x3ul << PWM_CTL1_CNTTYPE4_Pos)                  /*!< PWM_T::CTL1: CNTTYPE4 Mask             */
+
+#define PWM_CTL1_OUTMODEn_Pos            (24)                                              /*!< PWM_T::CTL1: OUTMODEn Position         */
+#define PWM_CTL1_OUTMODEn_Msk            (0x7ul << PWM_CTL1_OUTMODEn_Pos)                  /*!< PWM_T::CTL1: OUTMODEn Mask             */
+
+#define PWM_CTL1_OUTMODE0_Pos            (24)                                              /*!< PWM_T::CTL1: OUTMODE0 Position         */
+#define PWM_CTL1_OUTMODE0_Msk            (0x1ul << PWM_CTL1_OUTMODE0_Pos)                  /*!< PWM_T::CTL1: OUTMODE0 Mask             */
+
+#define PWM_CTL1_OUTMODE2_Pos            (25)                                              /*!< PWM_T::CTL1: OUTMODE2 Position         */
+#define PWM_CTL1_OUTMODE2_Msk            (0x1ul << PWM_CTL1_OUTMODE2_Pos)                  /*!< PWM_T::CTL1: OUTMODE2 Mask             */
+
+#define PWM_CTL1_OUTMODE4_Pos            (26)                                              /*!< PWM_T::CTL1: OUTMODE4 Position         */
+#define PWM_CTL1_OUTMODE4_Msk            (0x1ul << PWM_CTL1_OUTMODE4_Pos)                  /*!< PWM_T::CTL1: OUTMODE4 Mask             */
+
+#define PWM_CLKSRC_ECLKSRC0_Pos          (0)                                               /*!< PWM_T::CLKSRC: ECLKSRC0 Position       */
+#define PWM_CLKSRC_ECLKSRC0_Msk          (0x7ul << PWM_CLKSRC_ECLKSRC0_Pos)                /*!< PWM_T::CLKSRC: ECLKSRC0 Mask           */
+
+#define PWM_CLKSRC_ECLKSRC2_Pos          (8)                                               /*!< PWM_T::CLKSRC: ECLKSRC2 Position       */
+#define PWM_CLKSRC_ECLKSRC2_Msk          (0x7ul << PWM_CLKSRC_ECLKSRC2_Pos)                /*!< PWM_T::CLKSRC: ECLKSRC2 Mask           */
+
+#define PWM_CLKSRC_ECLKSRC4_Pos          (16)                                              /*!< PWM_T::CLKSRC: ECLKSRC4 Position       */
+#define PWM_CLKSRC_ECLKSRC4_Msk          (0x7ul << PWM_CLKSRC_ECLKSRC4_Pos)                /*!< PWM_T::CLKSRC: ECLKSRC4 Mask           */
+
+#define PWM_CLKPSC_CLKPSC_Pos            (0)                                               /*!< PWM_T::CLKPSC: CLKPSC Position         */
+#define PWM_CLKPSC_CLKPSC_Msk            (0xffful << PWM_CLKPSC_CLKPSC_Pos)                /*!< PWM_T::CLKPSC: CLKPSC Mask             */
+
+#define PWM_CLKPSC0_1_CLKPSC_Pos         (0)                                               /*!< PWM_T::CLKPSC0_1: CLKPSC Position      */
+#define PWM_CLKPSC0_1_CLKPSC_Msk         (0xffful << PWM_CLKPSC0_1_CLKPSC_Pos)             /*!< PWM_T::CLKPSC0_1: CLKPSC Mask          */
+
+#define PWM_CLKPSC2_3_CLKPSC_Pos         (0)                                               /*!< PWM_T::CLKPSC2_3: CLKPSC Position      */
+#define PWM_CLKPSC2_3_CLKPSC_Msk         (0xffful << PWM_CLKPSC2_3_CLKPSC_Pos)             /*!< PWM_T::CLKPSC2_3: CLKPSC Mask          */
+
+#define PWM_CLKPSC4_5_CLKPSC_Pos         (0)                                               /*!< PWM_T::CLKPSC4_5: CLKPSC Position      */
+#define PWM_CLKPSC4_5_CLKPSC_Msk         (0xffful << PWM_CLKPSC4_5_CLKPSC_Pos)             /*!< PWM_T::CLKPSC4_5: CLKPSC Mask          */
+
+#define PWM_CNTEN_CNTEN0_Pos             (0)                                               /*!< PWM_T::CNTEN: CNTEN0 Position          */
+#define PWM_CNTEN_CNTEN0_Msk             (0x1ul << PWM_CNTEN_CNTEN0_Pos)                   /*!< PWM_T::CNTEN: CNTEN0 Mask              */
+
+#define PWM_CNTEN_CNTEN2_Pos             (2)                                               /*!< PWM_T::CNTEN: CNTEN2 Position          */
+#define PWM_CNTEN_CNTEN2_Msk             (0x1ul << PWM_CNTEN_CNTEN2_Pos)                   /*!< PWM_T::CNTEN: CNTEN2 Mask              */
+
+#define PWM_CNTEN_CNTEN4_Pos             (4)                                               /*!< PWM_T::CNTEN: CNTEN4 Position          */
+#define PWM_CNTEN_CNTEN4_Msk             (0x1ul << PWM_CNTEN_CNTEN4_Pos)                   /*!< PWM_T::CNTEN: CNTEN4 Mask              */
+
+#define PWM_CNTCLR_CNTCLR0_Pos           (0)                                               /*!< PWM_T::CNTCLR: CNTCLR0 Position        */
+#define PWM_CNTCLR_CNTCLR0_Msk           (0x1ul << PWM_CNTCLR_CNTCLR0_Pos)                 /*!< PWM_T::CNTCLR: CNTCLR0 Mask            */
+
+#define PWM_CNTCLR_CNTCLR2_Pos           (2)                                               /*!< PWM_T::CNTCLR: CNTCLR2 Position        */
+#define PWM_CNTCLR_CNTCLR2_Msk           (0x1ul << PWM_CNTCLR_CNTCLR2_Pos)                 /*!< PWM_T::CNTCLR: CNTCLR2 Mask            */
+
+#define PWM_CNTCLR_CNTCLR4_Pos           (4)                                               /*!< PWM_T::CNTCLR: CNTCLR4 Position        */
+#define PWM_CNTCLR_CNTCLR4_Msk           (0x1ul << PWM_CNTCLR_CNTCLR4_Pos)                 /*!< PWM_T::CNTCLR: CNTCLR4 Mask            */
+
+#define PWM_PERIOD_PERIOD_Pos            (0)                                               /*!< PWM_T::PERIOD: PERIOD Position         */
+#define PWM_PERIOD_PERIOD_Msk            (0xfffful << PWM_PERIOD_PERIOD_Pos)               /*!< PWM_T::PERIOD: PERIOD Mask             */
+
+#define PWM_CMPDAT_CMP_Pos               (0)                                               /*!< PWM_T::CMPDAT: CMP Position            */
+#define PWM_CMPDAT_CMP_Msk               (0xfffful << PWM_CMPDAT_CMP_Pos)                  /*!< PWM_T::CMPDAT: CMP Mask                */
+
+#define PWM_DTCTL_DTCNT_Pos              (0)                                               /*!< PWM_T::DTCTL: DTCNT Position           */
+#define PWM_DTCTL_DTCNT_Msk              (0xffful << PWM_DTCTL_DTCNT_Pos)                  /*!< PWM_T::DTCTL: DTCNT Mask               */
+
+#define PWM_DTCTL_DTEN_Pos               (16)                                              /*!< PWM_T::DTCTL: DTEN Position            */
+#define PWM_DTCTL_DTEN_Msk               (0x1ul << PWM_DTCTL_DTEN_Pos)                     /*!< PWM_T::DTCTL: DTEN Mask                */
+
+#define PWM_DTCTL_DTCKSEL_Pos            (24)                                              /*!< PWM_T::DTCTL: DTCKSEL Position         */
+#define PWM_DTCTL_DTCKSEL_Msk            (0x1ul << PWM_DTCTL_DTCKSEL_Pos)                  /*!< PWM_T::DTCTL: DTCKSEL Mask             */
+
+#define PWM_DTCTL0_1_DTCNT_Pos           (0)                                               /*!< PWM_T::DTCTL0_1: DTCNT Position        */
+#define PWM_DTCTL0_1_DTCNT_Msk           (0xffful << PWM_DTCTL0_1_DTCNT_Pos)               /*!< PWM_T::DTCTL0_1: DTCNT Mask            */
+
+#define PWM_DTCTL0_1_DTEN_Pos            (16)                                              /*!< PWM_T::DTCTL0_1: DTEN Position         */
+#define PWM_DTCTL0_1_DTEN_Msk            (0x1ul << PWM_DTCTL0_1_DTEN_Pos)                  /*!< PWM_T::DTCTL0_1: DTEN Mask             */
+
+#define PWM_DTCTL0_1_DTCKSEL_Pos         (24)                                              /*!< PWM_T::DTCTL0_1: DTCKSEL Position      */
+#define PWM_DTCTL0_1_DTCKSEL_Msk         (0x1ul << PWM_DTCTL0_1_DTCKSEL_Pos)               /*!< PWM_T::DTCTL0_1: DTCKSEL Mask          */
+
+#define PWM_DTCTL2_3_DTCNT_Pos           (0)                                               /*!< PWM_T::DTCTL2_3: DTCNT Position        */
+#define PWM_DTCTL2_3_DTCNT_Msk           (0xffful << PWM_DTCTL2_3_DTCNT_Pos)               /*!< PWM_T::DTCTL2_3: DTCNT Mask            */
+
+#define PWM_DTCTL2_3_DTEN_Pos            (16)                                              /*!< PWM_T::DTCTL2_3: DTEN Position         */
+#define PWM_DTCTL2_3_DTEN_Msk            (0x1ul << PWM_DTCTL2_3_DTEN_Pos)                  /*!< PWM_T::DTCTL2_3: DTEN Mask             */
+
+#define PWM_DTCTL2_3_DTCKSEL_Pos         (24)                                              /*!< PWM_T::DTCTL2_3: DTCKSEL Position      */
+#define PWM_DTCTL2_3_DTCKSEL_Msk         (0x1ul << PWM_DTCTL2_3_DTCKSEL_Pos)               /*!< PWM_T::DTCTL2_3: DTCKSEL Mask          */
+
+#define PWM_DTCTL4_5_DTCNT_Pos           (0)                                               /*!< PWM_T::DTCTL4_5: DTCNT Position        */
+#define PWM_DTCTL4_5_DTCNT_Msk           (0xffful << PWM_DTCTL4_5_DTCNT_Pos)               /*!< PWM_T::DTCTL4_5: DTCNT Mask            */
+
+#define PWM_DTCTL4_5_DTEN_Pos            (16)                                              /*!< PWM_T::DTCTL4_5: DTEN Position         */
+#define PWM_DTCTL4_5_DTEN_Msk            (0x1ul << PWM_DTCTL4_5_DTEN_Pos)                  /*!< PWM_T::DTCTL4_5: DTEN Mask             */
+
+#define PWM_DTCTL4_5_DTCKSEL_Pos         (24)                                              /*!< PWM_T::DTCTL4_5: DTCKSEL Position      */
+#define PWM_DTCTL4_5_DTCKSEL_Msk         (0x1ul << PWM_DTCTL4_5_DTCKSEL_Pos)               /*!< PWM_T::DTCTL4_5: DTCKSEL Mask          */
+
+#define PWM_CNT_CNT_Pos                  (0)                                               /*!< PWM_T::CNT: CNT Position               */
+#define PWM_CNT_CNT_Msk                  (0xfffful << PWM_CNT_CNT_Pos)                     /*!< PWM_T::CNT: CNT Mask                   */
+
+#define PWM_CNT_DIRF_Pos                 (16)                                              /*!< PWM_T::CNT: DIRF Position              */
+#define PWM_CNT_DIRF_Msk                 (0x1ul << PWM_CNT_DIRF_Pos)                       /*!< PWM_T::CNT: DIRF Mask                  */
+
+#define PWM_WGCTL0_ZPCTL0_Pos            (0)                                               /*!< PWM_T::WGCTL0: ZPCTL0 Position         */
+#define PWM_WGCTL0_ZPCTL0_Msk            (0x3ul << PWM_WGCTL0_ZPCTL0_Pos)                  /*!< PWM_T::WGCTL0: ZPCTL0 Mask             */
+
+#define PWM_WGCTL0_ZPCTL1_Pos            (2)                                               /*!< PWM_T::WGCTL0: ZPCTL1 Position         */
+#define PWM_WGCTL0_ZPCTL1_Msk            (0x3ul << PWM_WGCTL0_ZPCTL1_Pos)                  /*!< PWM_T::WGCTL0: ZPCTL1 Mask             */
+
+#define PWM_WGCTL0_ZPCTL2_Pos            (4)                                               /*!< PWM_T::WGCTL0: ZPCTL2 Position         */
+#define PWM_WGCTL0_ZPCTL2_Msk            (0x3ul << PWM_WGCTL0_ZPCTL2_Pos)                  /*!< PWM_T::WGCTL0: ZPCTL2 Mask             */
+
+#define PWM_WGCTL0_ZPCTL3_Pos            (6)                                               /*!< PWM_T::WGCTL0: ZPCTL3 Position         */
+#define PWM_WGCTL0_ZPCTL3_Msk            (0x3ul << PWM_WGCTL0_ZPCTL3_Pos)                  /*!< PWM_T::WGCTL0: ZPCTL3 Mask             */
+
+#define PWM_WGCTL0_ZPCTL4_Pos            (8)                                               /*!< PWM_T::WGCTL0: ZPCTL4 Position         */
+#define PWM_WGCTL0_ZPCTL4_Msk            (0x3ul << PWM_WGCTL0_ZPCTL4_Pos)                  /*!< PWM_T::WGCTL0: ZPCTL4 Mask             */
+
+#define PWM_WGCTL0_ZPCTL5_Pos            (10)                                              /*!< PWM_T::WGCTL0: ZPCTL5 Position         */
+#define PWM_WGCTL0_ZPCTL5_Msk            (0x3ul << PWM_WGCTL0_ZPCTL5_Pos)                  /*!< PWM_T::WGCTL0: ZPCTL5 Mask             */
+
+#define PWM_WGCTL0_PRDPCTL0_Pos          (16)                                              /*!< PWM_T::WGCTL0: PRDPCTL0 Position       */
+#define PWM_WGCTL0_PRDPCTL0_Msk          (0x3ul << PWM_WGCTL0_PRDPCTL0_Pos)                /*!< PWM_T::WGCTL0: PRDPCTL0 Mask           */
+
+#define PWM_WGCTL0_PRDPCTL1_Pos          (18)                                              /*!< PWM_T::WGCTL0: PRDPCTL1 Position       */
+#define PWM_WGCTL0_PRDPCTL1_Msk          (0x3ul << PWM_WGCTL0_PRDPCTL1_Pos)                /*!< PWM_T::WGCTL0: PRDPCTL1 Mask           */
+
+#define PWM_WGCTL0_PRDPCTL2_Pos          (20)                                              /*!< PWM_T::WGCTL0: PRDPCTL2 Position       */
+#define PWM_WGCTL0_PRDPCTL2_Msk          (0x3ul << PWM_WGCTL0_PRDPCTL2_Pos)                /*!< PWM_T::WGCTL0: PRDPCTL2 Mask           */
+
+#define PWM_WGCTL0_PRDPCTL3_Pos          (22)                                              /*!< PWM_T::WGCTL0: PRDPCTL3 Position       */
+#define PWM_WGCTL0_PRDPCTL3_Msk          (0x3ul << PWM_WGCTL0_PRDPCTL3_Pos)                /*!< PWM_T::WGCTL0: PRDPCTL3 Mask           */
+
+#define PWM_WGCTL0_PRDPCTL4_Pos          (24)                                              /*!< PWM_T::WGCTL0: PRDPCTL4 Position       */
+#define PWM_WGCTL0_PRDPCTL4_Msk          (0x3ul << PWM_WGCTL0_PRDPCTL4_Pos)                /*!< PWM_T::WGCTL0: PRDPCTL4 Mask           */
+
+#define PWM_WGCTL0_PRDPCTL5_Pos          (26)                                              /*!< PWM_T::WGCTL0: PRDPCTL5 Position       */
+#define PWM_WGCTL0_PRDPCTL5_Msk          (0x3ul << PWM_WGCTL0_PRDPCTL5_Pos)                /*!< PWM_T::WGCTL0: PRDPCTL5 Mask           */
+
+#define PWM_WGCTL1_CMPUCTLn_Pos          (0)                                               /*!< PWM_T::WGCTL1: CMPUCTLn Position       */
+#define PWM_WGCTL1_CMPUCTLn_Msk          (0xffful << PWM_WGCTL1_CMPUCTLn_Pos)              /*!< PWM_T::WGCTL1: CMPUCTLn Mask           */
+
+#define PWM_WGCTL1_CMPUCTL0_Pos          (0)                                               /*!< PWM_T::WGCTL1: CMPUCTL0 Position       */
+#define PWM_WGCTL1_CMPUCTL0_Msk          (0x3ul << PWM_WGCTL1_CMPUCTL0_Pos)                /*!< PWM_T::WGCTL1: CMPUCTL0 Mask           */
+
+#define PWM_WGCTL1_CMPUCTL1_Pos          (2)                                               /*!< PWM_T::WGCTL1: CMPUCTL1 Position       */
+#define PWM_WGCTL1_CMPUCTL1_Msk          (0x3ul << PWM_WGCTL1_CMPUCTL1_Pos)                /*!< PWM_T::WGCTL1: CMPUCTL1 Mask           */
+
+#define PWM_WGCTL1_CMPUCTL2_Pos          (4)                                               /*!< PWM_T::WGCTL1: CMPUCTL2 Position       */
+#define PWM_WGCTL1_CMPUCTL2_Msk          (0x3ul << PWM_WGCTL1_CMPUCTL2_Pos)                /*!< PWM_T::WGCTL1: CMPUCTL2 Mask           */
+
+#define PWM_WGCTL1_CMPUCTL3_Pos          (6)                                               /*!< PWM_T::WGCTL1: CMPUCTL3 Position       */
+#define PWM_WGCTL1_CMPUCTL3_Msk          (0x3ul << PWM_WGCTL1_CMPUCTL3_Pos)                /*!< PWM_T::WGCTL1: CMPUCTL3 Mask           */
+
+#define PWM_WGCTL1_CMPUCTL4_Pos          (8)                                               /*!< PWM_T::WGCTL1: CMPUCTL4 Position       */
+#define PWM_WGCTL1_CMPUCTL4_Msk          (0x3ul << PWM_WGCTL1_CMPUCTL4_Pos)                /*!< PWM_T::WGCTL1: CMPUCTL4 Mask           */
+
+#define PWM_WGCTL1_CMPUCTL5_Pos          (10)                                              /*!< PWM_T::WGCTL1: CMPUCTL5 Position       */
+#define PWM_WGCTL1_CMPUCTL5_Msk          (0x3ul << PWM_WGCTL1_CMPUCTL5_Pos)                /*!< PWM_T::WGCTL1: CMPUCTL5 Mask           */
+
+#define PWM_WGCTL1_CMPDCTL0_Pos          (16)                                              /*!< PWM_T::WGCTL1: CMPDCTL0 Position       */
+#define PWM_WGCTL1_CMPDCTL0_Msk          (0x3ul << PWM_WGCTL1_CMPDCTL0_Pos)                /*!< PWM_T::WGCTL1: CMPDCTL0 Mask           */
+
+#define PWM_WGCTL1_CMPDCTL1_Pos          (18)                                              /*!< PWM_T::WGCTL1: CMPDCTL1 Position       */
+#define PWM_WGCTL1_CMPDCTL1_Msk          (0x3ul << PWM_WGCTL1_CMPDCTL1_Pos)                /*!< PWM_T::WGCTL1: CMPDCTL1 Mask           */
+
+#define PWM_WGCTL1_CMPDCTL2_Pos          (20)                                              /*!< PWM_T::WGCTL1: CMPDCTL2 Position       */
+#define PWM_WGCTL1_CMPDCTL2_Msk          (0x3ul << PWM_WGCTL1_CMPDCTL2_Pos)                /*!< PWM_T::WGCTL1: CMPDCTL2 Mask           */
+
+#define PWM_WGCTL1_CMPDCTL3_Pos          (22)                                              /*!< PWM_T::WGCTL1: CMPDCTL3 Position       */
+#define PWM_WGCTL1_CMPDCTL3_Msk          (0x3ul << PWM_WGCTL1_CMPDCTL3_Pos)                /*!< PWM_T::WGCTL1: CMPDCTL3 Mask           */
+
+#define PWM_WGCTL1_CMPDCTL4_Pos          (24)                                              /*!< PWM_T::WGCTL1: CMPDCTL4 Position       */
+#define PWM_WGCTL1_CMPDCTL4_Msk          (0x3ul << PWM_WGCTL1_CMPDCTL4_Pos)                /*!< PWM_T::WGCTL1: CMPDCTL4 Mask           */
+
+#define PWM_WGCTL1_CMPDCTL5_Pos          (26)                                              /*!< PWM_T::WGCTL1: CMPDCTL5 Position       */
+#define PWM_WGCTL1_CMPDCTL5_Msk          (0x3ul << PWM_WGCTL1_CMPDCTL5_Pos)                /*!< PWM_T::WGCTL1: CMPDCTL5 Mask           */
+
+#define PWM_MSKEN_MSKEN0_Pos             (0)                                               /*!< PWM_T::MSKEN: MSKEN0 Position          */
+#define PWM_MSKEN_MSKEN0_Msk             (0x1ul << PWM_MSKEN_MSKEN0_Pos)                   /*!< PWM_T::MSKEN: MSKEN0 Mask              */
+
+#define PWM_MSKEN_MSKEN1_Pos             (1)                                               /*!< PWM_T::MSKEN: MSKEN1 Position          */
+#define PWM_MSKEN_MSKEN1_Msk             (0x1ul << PWM_MSKEN_MSKEN1_Pos)                   /*!< PWM_T::MSKEN: MSKEN1 Mask              */
+
+#define PWM_MSKEN_MSKEN2_Pos             (2)                                               /*!< PWM_T::MSKEN: MSKEN2 Position          */
+#define PWM_MSKEN_MSKEN2_Msk             (0x1ul << PWM_MSKEN_MSKEN2_Pos)                   /*!< PWM_T::MSKEN: MSKEN2 Mask              */
+
+#define PWM_MSKEN_MSKEN3_Pos             (3)                                               /*!< PWM_T::MSKEN: MSKEN3 Position          */
+#define PWM_MSKEN_MSKEN3_Msk             (0x1ul << PWM_MSKEN_MSKEN3_Pos)                   /*!< PWM_T::MSKEN: MSKEN3 Mask              */
+
+#define PWM_MSKEN_MSKEN4_Pos             (4)                                               /*!< PWM_T::MSKEN: MSKEN4 Position          */
+#define PWM_MSKEN_MSKEN4_Msk             (0x1ul << PWM_MSKEN_MSKEN4_Pos)                   /*!< PWM_T::MSKEN: MSKEN4 Mask              */
+
+#define PWM_MSKEN_MSKEN5_Pos             (5)                                               /*!< PWM_T::MSKEN: MSKEN5 Position          */
+#define PWM_MSKEN_MSKEN5_Msk             (0x1ul << PWM_MSKEN_MSKEN5_Pos)                   /*!< PWM_T::MSKEN: MSKEN5 Mask              */
+
+#define PWM_MSK_MSKDAT0_Pos              (0)                                               /*!< PWM_T::MSK: MSKDAT0 Position           */
+#define PWM_MSK_MSKDAT0_Msk              (0x1ul << PWM_MSK_MSKDAT0_Pos)                    /*!< PWM_T::MSK: MSKDAT0 Mask               */
+
+#define PWM_MSK_MSKDAT1_Pos              (1)                                               /*!< PWM_T::MSK: MSKDAT1 Position           */
+#define PWM_MSK_MSKDAT1_Msk              (0x1ul << PWM_MSK_MSKDAT1_Pos)                    /*!< PWM_T::MSK: MSKDAT1 Mask               */
+
+#define PWM_MSK_MSKDAT2_Pos              (2)                                               /*!< PWM_T::MSK: MSKDAT2 Position           */
+#define PWM_MSK_MSKDAT2_Msk              (0x1ul << PWM_MSK_MSKDAT2_Pos)                    /*!< PWM_T::MSK: MSKDAT2 Mask               */
+
+#define PWM_MSK_MSKDAT3_Pos              (3)                                               /*!< PWM_T::MSK: MSKDAT3 Position           */
+#define PWM_MSK_MSKDAT3_Msk              (0x1ul << PWM_MSK_MSKDAT3_Pos)                    /*!< PWM_T::MSK: MSKDAT3 Mask               */
+
+#define PWM_MSK_MSKDAT4_Pos              (4)                                               /*!< PWM_T::MSK: MSKDAT4 Position           */
+#define PWM_MSK_MSKDAT4_Msk              (0x1ul << PWM_MSK_MSKDAT4_Pos)                    /*!< PWM_T::MSK: MSKDAT4 Mask               */
+
+#define PWM_MSK_MSKDAT5_Pos              (5)                                               /*!< PWM_T::MSK: MSKDAT5 Position           */
+#define PWM_MSK_MSKDAT5_Msk              (0x1ul << PWM_MSK_MSKDAT5_Pos)                    /*!< PWM_T::MSK: MSKDAT5 Mask               */
+
+#define PWM_BNF_BRK0FEN_Pos              (0)                                               /*!< PWM_T::BNF: BRK0NFEN Position          */
+#define PWM_BNF_BRK0FEN_Msk              (0x1ul << PWM_BNF_BRK0FEN_Pos)                   /*!< PWM_T::BNF: BRK0NFEN Mask              */
+
+#define PWM_BNF_BRK0NFSEL_Pos            (1)                                               /*!< PWM_T::BNF: BRK0NFSEL Position         */
+#define PWM_BNF_BRK0NFSEL_Msk            (0x7ul << PWM_BNF_BRK0NFSEL_Pos)                  /*!< PWM_T::BNF: BRK0NFSEL Mask             */
+
+#define PWM_BNF_BRK0NFCNT_Pos            (4)                                               /*!< PWM_T::BNF: BRK0NFCNT Position         */
+#define PWM_BNF_BRK0NFCNT_Msk            (0x7ul << PWM_BNF_BRK0NFCNT_Pos)                  /*!< PWM_T::BNF: BRK0NFCNT Mask             */
+
+#define PWM_BNF_BRK0PINV_Pos             (7)                                               /*!< PWM_T::BNF: BRK0PINV Position          */
+#define PWM_BNF_BRK0PINV_Msk             (0x1ul << PWM_BNF_BRK0PINV_Pos)                   /*!< PWM_T::BNF: BRK0PINV Mask              */
+
+#define PWM_BNF_BRK1FEN_Pos              (8)                                               /*!< PWM_T::BNF: BRK1FEN Position           */
+#define PWM_BNF_BRK1FEN_Msk              (0x1ul << PWM_BNF_BRK1FEN_Pos)                    /*!< PWM_T::BNF: BRK1FEN Mask               */
+
+#define PWM_BNF_BRK1NFSEL_Pos            (9)                                               /*!< PWM_T::BNF: BRK1NFSEL Position         */
+#define PWM_BNF_BRK1NFSEL_Msk            (0x7ul << PWM_BNF_BRK1NFSEL_Pos)                  /*!< PWM_T::BNF: BRK1NFSEL Mask             */
+
+#define PWM_BNF_BRK1FCNT_Pos             (12)                                              /*!< PWM_T::BNF: BRK1FCNT Position          */
+#define PWM_BNF_BRK1FCNT_Msk             (0x7ul << PWM_BNF_BRK1FCNT_Pos)                   /*!< PWM_T::BNF: BRK1FCNT Mask              */
+
+#define PWM_BNF_BRK1PINV_Pos             (15)                                              /*!< PWM_T::BNF: BRK1PINV Position          */
+#define PWM_BNF_BRK1PINV_Msk             (0x1ul << PWM_BNF_BRK1PINV_Pos)                   /*!< PWM_T::BNF: BRK1PINV Mask              */
+
+#define PWM_BNF_BK0SRC_Pos               (16)                                              /*!< PWM_T::BNF: BK0SRC Position            */
+#define PWM_BNF_BK0SRC_Msk               (0x1ul << PWM_BNF_BK0SRC_Pos)                     /*!< PWM_T::BNF: BK0SRC Mask                */
+
+#define PWM_BNF_BK1SRC_Pos               (24)                                              /*!< PWM_T::BNF: BK1SRC Position            */
+#define PWM_BNF_BK1SRC_Msk               (0x1ul << PWM_BNF_BK1SRC_Pos)                     /*!< PWM_T::BNF: BK1SRC Mask                */
+
+#define PWM_FAILBRK_CSSBRKEN_Pos         (0)                                               /*!< PWM_T::FAILBRK: CSSBRKEN Position      */
+#define PWM_FAILBRK_CSSBRKEN_Msk         (0x1ul << PWM_FAILBRK_CSSBRKEN_Pos)               /*!< PWM_T::FAILBRK: CSSBRKEN Mask          */
+
+#define PWM_FAILBRK_BODBRKEN_Pos         (1)                                               /*!< PWM_T::FAILBRK: BODBRKEN Position      */
+#define PWM_FAILBRK_BODBRKEN_Msk         (0x1ul << PWM_FAILBRK_BODBRKEN_Pos)               /*!< PWM_T::FAILBRK: BODBRKEN Mask          */
+
+#define PWM_FAILBRK_CORBRKEN_Pos         (3)                                               /*!< PWM_T::FAILBRK: CORBRKEN Position      */
+#define PWM_FAILBRK_CORBRKEN_Msk         (0x1ul << PWM_FAILBRK_CORBRKEN_Pos)               /*!< PWM_T::FAILBRK: CORBRKEN Mask          */
+
+#define PWM_BRKCTL_CPO0EBEN_Pos          (0)                                               /*!< PWM_T::BRKCTL: CPO0EBEN Position    */
+#define PWM_BRKCTL_CPO0EBEN_Msk          (0x1ul << PWM_BRKCTL_CPO0EBEN_Pos)             /*!< PWM_T::BRKCTL: CPO0EBEN Mask        */
+
+#define PWM_BRKCTL_CPO1EBEN_Pos          (1)                                               /*!< PWM_T::BRKCTL: CPO1EBEN Position    */
+#define PWM_BRKCTL_CPO1EBEN_Msk          (0x1ul << PWM_BRKCTL_CPO1EBEN_Pos)             /*!< PWM_T::BRKCTL: CPO1EBEN Mask        */
+
+#define PWM_BRKCTL_BRKP0EEN_Pos          (4)                                               /*!< PWM_T::BRKCTL: BRKP0EEN Position    */
+#define PWM_BRKCTL_BRKP0EEN_Msk          (0x1ul << PWM_BRKCTL_BRKP0EEN_Pos)             /*!< PWM_T::BRKCTL: BRKP0EEN Mask        */
+
+#define PWM_BRKCTL_BRKP1EEN_Pos          (5)                                               /*!< PWM_T::BRKCTL: BRKP1EEN Position    */
+#define PWM_BRKCTL_BRKP1EEN_Msk          (0x1ul << PWM_BRKCTL_BRKP1EEN_Pos)             /*!< PWM_T::BRKCTL: BRKP1EEN Mask        */
+
+#define PWM_BRKCTL_SYSEBEN_Pos           (7)                                               /*!< PWM_T::BRKCTL: SYSEBEN Position     */
+#define PWM_BRKCTL_SYSEBEN_Msk           (0x1ul << PWM_BRKCTL_SYSEBEN_Pos)              /*!< PWM_T::BRKCTL: SYSEBEN Mask         */
+
+#define PWM_BRKCTL_CPO0LBEN_Pos          (8)                                               /*!< PWM_T::BRKCTL: CPO0LBEN Position    */
+#define PWM_BRKCTL_CPO0LBEN_Msk          (0x1ul << PWM_BRKCTL_CPO0LBEN_Pos)             /*!< PWM_T::BRKCTL: CPO0LBEN Mask        */
+
+#define PWM_BRKCTL_CPO1LBEN_Pos          (9)                                               /*!< PWM_T::BRKCTL: CPO1LBEN Position    */
+#define PWM_BRKCTL_CPO1LBEN_Msk          (0x1ul << PWM_BRKCTL_CPO1LBEN_Pos)             /*!< PWM_T::BRKCTL: CPO1LBEN Mask        */
+
+#define PWM_BRKCTL_BRKP0LEN_Pos          (12)                                              /*!< PWM_T::BRKCTL: BRKP0LEN Position    */
+#define PWM_BRKCTL_BRKP0LEN_Msk          (0x1ul << PWM_BRKCTL_BRKP0LEN_Pos)             /*!< PWM_T::BRKCTL: BRKP0LEN Mask        */
+
+#define PWM_BRKCTL_BRKP1LEN_Pos          (13)                                              /*!< PWM_T::BRKCTL: BRKP1LEN Position    */
+#define PWM_BRKCTL_BRKP1LEN_Msk          (0x1ul << PWM_BRKCTL_BRKP1LEN_Pos)             /*!< PWM_T::BRKCTL: BRKP1LEN Mask        */
+
+#define PWM_BRKCTL_SYSLBEN_Pos           (15)                                              /*!< PWM_T::BRKCTL: SYSLBEN Position     */
+#define PWM_BRKCTL_SYSLBEN_Msk           (0x1ul << PWM_BRKCTL_SYSLBEN_Pos)              /*!< PWM_T::BRKCTL: SYSLBEN Mask         */
+
+#define PWM_BRKCTL_BRKAEVEN_Pos          (16)                                              /*!< PWM_T::BRKCTL: BRKAEVEN Position    */
+#define PWM_BRKCTL_BRKAEVEN_Msk          (0x3ul << PWM_BRKCTL_BRKAEVEN_Pos)             /*!< PWM_T::BRKCTL: BRKAEVEN Mask        */
+
+#define PWM_BRKCTL_BRKAODD_Pos           (18)                                              /*!< PWM_T::BRKCTL: BRKAODD Position     */
+#define PWM_BRKCTL_BRKAODD_Msk           (0x3ul << PWM_BRKCTL_BRKAODD_Pos)              /*!< PWM_T::BRKCTL: BRKAODD Mask         */
+
+#define PWM_BRKCTL0_1_CPO0EBEN_Pos       (0)                                               /*!< PWM_T::BRKCTL0_1: CPO0EBEN Position    */
+#define PWM_BRKCTL0_1_CPO0EBEN_Msk       (0x1ul << PWM_BRKCTL0_1_CPO0EBEN_Pos)             /*!< PWM_T::BRKCTL0_1: CPO0EBEN Mask        */
+
+#define PWM_BRKCTL0_1_CPO1EBEN_Pos       (1)                                               /*!< PWM_T::BRKCTL0_1: CPO1EBEN Position    */
+#define PWM_BRKCTL0_1_CPO1EBEN_Msk       (0x1ul << PWM_BRKCTL0_1_CPO1EBEN_Pos)             /*!< PWM_T::BRKCTL0_1: CPO1EBEN Mask        */
+
+#define PWM_BRKCTL0_1_BRKP0EEN_Pos       (4)                                               /*!< PWM_T::BRKCTL0_1: BRKP0EEN Position    */
+#define PWM_BRKCTL0_1_BRKP0EEN_Msk       (0x1ul << PWM_BRKCTL0_1_BRKP0EEN_Pos)             /*!< PWM_T::BRKCTL0_1: BRKP0EEN Mask        */
+
+#define PWM_BRKCTL0_1_BRKP1EEN_Pos       (5)                                               /*!< PWM_T::BRKCTL0_1: BRKP1EEN Position    */
+#define PWM_BRKCTL0_1_BRKP1EEN_Msk       (0x1ul << PWM_BRKCTL0_1_BRKP1EEN_Pos)             /*!< PWM_T::BRKCTL0_1: BRKP1EEN Mask        */
+
+#define PWM_BRKCTL0_1_SYSEBEN_Pos        (7)                                               /*!< PWM_T::BRKCTL0_1: SYSEBEN Position     */
+#define PWM_BRKCTL0_1_SYSEBEN_Msk        (0x1ul << PWM_BRKCTL0_1_SYSEBEN_Pos)              /*!< PWM_T::BRKCTL0_1: SYSEBEN Mask         */
+
+#define PWM_BRKCTL0_1_CPO0LBEN_Pos       (8)                                               /*!< PWM_T::BRKCTL0_1: CPO0LBEN Position    */
+#define PWM_BRKCTL0_1_CPO0LBEN_Msk       (0x1ul << PWM_BRKCTL0_1_CPO0LBEN_Pos)             /*!< PWM_T::BRKCTL0_1: CPO0LBEN Mask        */
+
+#define PWM_BRKCTL0_1_CPO1LBEN_Pos       (9)                                               /*!< PWM_T::BRKCTL0_1: CPO1LBEN Position    */
+#define PWM_BRKCTL0_1_CPO1LBEN_Msk       (0x1ul << PWM_BRKCTL0_1_CPO1LBEN_Pos)             /*!< PWM_T::BRKCTL0_1: CPO1LBEN Mask        */
+
+#define PWM_BRKCTL0_1_BRKP0LEN_Pos       (12)                                              /*!< PWM_T::BRKCTL0_1: BRKP0LEN Position    */
+#define PWM_BRKCTL0_1_BRKP0LEN_Msk       (0x1ul << PWM_BRKCTL0_1_BRKP0LEN_Pos)             /*!< PWM_T::BRKCTL0_1: BRKP0LEN Mask        */
+
+#define PWM_BRKCTL0_1_BRKP1LEN_Pos       (13)                                              /*!< PWM_T::BRKCTL0_1: BRKP1LEN Position    */
+#define PWM_BRKCTL0_1_BRKP1LEN_Msk       (0x1ul << PWM_BRKCTL0_1_BRKP1LEN_Pos)             /*!< PWM_T::BRKCTL0_1: BRKP1LEN Mask        */
+
+#define PWM_BRKCTL0_1_SYSLBEN_Pos        (15)                                              /*!< PWM_T::BRKCTL0_1: SYSLBEN Position     */
+#define PWM_BRKCTL0_1_SYSLBEN_Msk        (0x1ul << PWM_BRKCTL0_1_SYSLBEN_Pos)              /*!< PWM_T::BRKCTL0_1: SYSLBEN Mask         */
+
+#define PWM_BRKCTL0_1_BRKAEVEN_Pos       (16)                                              /*!< PWM_T::BRKCTL0_1: BRKAEVEN Position    */
+#define PWM_BRKCTL0_1_BRKAEVEN_Msk       (0x3ul << PWM_BRKCTL0_1_BRKAEVEN_Pos)             /*!< PWM_T::BRKCTL0_1: BRKAEVEN Mask        */
+
+#define PWM_BRKCTL0_1_BRKAODD_Pos        (18)                                              /*!< PWM_T::BRKCTL0_1: BRKAODD Position     */
+#define PWM_BRKCTL0_1_BRKAODD_Msk        (0x3ul << PWM_BRKCTL0_1_BRKAODD_Pos)              /*!< PWM_T::BRKCTL0_1: BRKAODD Mask         */
+
+#define PWM_BRKCTL2_3_CPO0EBEN_Pos       (0)                                               /*!< PWM_T::BRKCTL2_3: CPO0EBEN Position    */
+#define PWM_BRKCTL2_3_CPO0EBEN_Msk       (0x1ul << PWM_BRKCTL2_3_CPO0EBEN_Pos)             /*!< PWM_T::BRKCTL2_3: CPO0EBEN Mask        */
+
+#define PWM_BRKCTL2_3_CPO1EBEN_Pos       (1)                                               /*!< PWM_T::BRKCTL2_3: CPO1EBEN Position    */
+#define PWM_BRKCTL2_3_CPO1EBEN_Msk       (0x1ul << PWM_BRKCTL2_3_CPO1EBEN_Pos)             /*!< PWM_T::BRKCTL2_3: CPO1EBEN Mask        */
+
+#define PWM_BRKCTL2_3_BRKP0EEN_Pos       (4)                                               /*!< PWM_T::BRKCTL2_3: BRKP0EEN Position    */
+#define PWM_BRKCTL2_3_BRKP0EEN_Msk       (0x1ul << PWM_BRKCTL2_3_BRKP0EEN_Pos)             /*!< PWM_T::BRKCTL2_3: BRKP0EEN Mask        */
+
+#define PWM_BRKCTL2_3_BRKP1EEN_Pos       (5)                                               /*!< PWM_T::BRKCTL2_3: BRKP1EEN Position    */
+#define PWM_BRKCTL2_3_BRKP1EEN_Msk       (0x1ul << PWM_BRKCTL2_3_BRKP1EEN_Pos)             /*!< PWM_T::BRKCTL2_3: BRKP1EEN Mask        */
+
+#define PWM_BRKCTL2_3_SYSEBEN_Pos        (7)                                               /*!< PWM_T::BRKCTL2_3: SYSEBEN Position     */
+#define PWM_BRKCTL2_3_SYSEBEN_Msk        (0x1ul << PWM_BRKCTL2_3_SYSEBEN_Pos)              /*!< PWM_T::BRKCTL2_3: SYSEBEN Mask         */
+
+#define PWM_BRKCTL2_3_CPO0LBEN_Pos       (8)                                               /*!< PWM_T::BRKCTL2_3: CPO0LBEN Position    */
+#define PWM_BRKCTL2_3_CPO0LBEN_Msk       (0x1ul << PWM_BRKCTL2_3_CPO0LBEN_Pos)             /*!< PWM_T::BRKCTL2_3: CPO0LBEN Mask        */
+
+#define PWM_BRKCTL2_3_CPO1LBEN_Pos       (9)                                               /*!< PWM_T::BRKCTL2_3: CPO1LBEN Position    */
+#define PWM_BRKCTL2_3_CPO1LBEN_Msk       (0x1ul << PWM_BRKCTL2_3_CPO1LBEN_Pos)             /*!< PWM_T::BRKCTL2_3: CPO1LBEN Mask        */
+
+#define PWM_BRKCTL2_3_BRKP0LEN_Pos       (12)                                              /*!< PWM_T::BRKCTL2_3: BRKP0LEN Position    */
+#define PWM_BRKCTL2_3_BRKP0LEN_Msk       (0x1ul << PWM_BRKCTL2_3_BRKP0LEN_Pos)             /*!< PWM_T::BRKCTL2_3: BRKP0LEN Mask        */
+
+#define PWM_BRKCTL2_3_BRKP1LEN_Pos       (13)                                              /*!< PWM_T::BRKCTL2_3: BRKP1LEN Position    */
+#define PWM_BRKCTL2_3_BRKP1LEN_Msk       (0x1ul << PWM_BRKCTL2_3_BRKP1LEN_Pos)             /*!< PWM_T::BRKCTL2_3: BRKP1LEN Mask        */
+
+#define PWM_BRKCTL2_3_SYSLBEN_Pos        (15)                                              /*!< PWM_T::BRKCTL2_3: SYSLBEN Position     */
+#define PWM_BRKCTL2_3_SYSLBEN_Msk        (0x1ul << PWM_BRKCTL2_3_SYSLBEN_Pos)              /*!< PWM_T::BRKCTL2_3: SYSLBEN Mask         */
+
+#define PWM_BRKCTL2_3_BRKAEVEN_Pos       (16)                                              /*!< PWM_T::BRKCTL2_3: BRKAEVEN Position    */
+#define PWM_BRKCTL2_3_BRKAEVEN_Msk       (0x3ul << PWM_BRKCTL2_3_BRKAEVEN_Pos)             /*!< PWM_T::BRKCTL2_3: BRKAEVEN Mask        */
+
+#define PWM_BRKCTL2_3_BRKAODD_Pos        (18)                                              /*!< PWM_T::BRKCTL2_3: BRKAODD Position     */
+#define PWM_BRKCTL2_3_BRKAODD_Msk        (0x3ul << PWM_BRKCTL2_3_BRKAODD_Pos)              /*!< PWM_T::BRKCTL2_3: BRKAODD Mask         */
+
+#define PWM_BRKCTL4_5_CPO0EBEN_Pos       (0)                                               /*!< PWM_T::BRKCTL4_5: CPO0EBEN Position    */
+#define PWM_BRKCTL4_5_CPO0EBEN_Msk       (0x1ul << PWM_BRKCTL4_5_CPO0EBEN_Pos)             /*!< PWM_T::BRKCTL4_5: CPO0EBEN Mask        */
+
+#define PWM_BRKCTL4_5_CPO1EBEN_Pos       (1)                                               /*!< PWM_T::BRKCTL4_5: CPO1EBEN Position    */
+#define PWM_BRKCTL4_5_CPO1EBEN_Msk       (0x1ul << PWM_BRKCTL4_5_CPO1EBEN_Pos)             /*!< PWM_T::BRKCTL4_5: CPO1EBEN Mask        */
+
+#define PWM_BRKCTL4_5_BRKP0EEN_Pos       (4)                                               /*!< PWM_T::BRKCTL4_5: BRKP0EEN Position    */
+#define PWM_BRKCTL4_5_BRKP0EEN_Msk       (0x1ul << PWM_BRKCTL4_5_BRKP0EEN_Pos)             /*!< PWM_T::BRKCTL4_5: BRKP0EEN Mask        */
+
+#define PWM_BRKCTL4_5_BRKP1EEN_Pos       (5)                                               /*!< PWM_T::BRKCTL4_5: BRKP1EEN Position    */
+#define PWM_BRKCTL4_5_BRKP1EEN_Msk       (0x1ul << PWM_BRKCTL4_5_BRKP1EEN_Pos)             /*!< PWM_T::BRKCTL4_5: BRKP1EEN Mask        */
+
+#define PWM_BRKCTL4_5_SYSEBEN_Pos        (7)                                               /*!< PWM_T::BRKCTL4_5: SYSEBEN Position     */
+#define PWM_BRKCTL4_5_SYSEBEN_Msk        (0x1ul << PWM_BRKCTL4_5_SYSEBEN_Pos)              /*!< PWM_T::BRKCTL4_5: SYSEBEN Mask         */
+
+#define PWM_BRKCTL4_5_CPO0LBEN_Pos       (8)                                               /*!< PWM_T::BRKCTL4_5: CPO0LBEN Position    */
+#define PWM_BRKCTL4_5_CPO0LBEN_Msk       (0x1ul << PWM_BRKCTL4_5_CPO0LBEN_Pos)             /*!< PWM_T::BRKCTL4_5: CPO0LBEN Mask        */
+
+#define PWM_BRKCTL4_5_CPO1LBEN_Pos       (9)                                               /*!< PWM_T::BRKCTL4_5: CPO1LBEN Position    */
+#define PWM_BRKCTL4_5_CPO1LBEN_Msk       (0x1ul << PWM_BRKCTL4_5_CPO1LBEN_Pos)             /*!< PWM_T::BRKCTL4_5: CPO1LBEN Mask        */
+
+#define PWM_BRKCTL4_5_BRKP0LEN_Pos       (12)                                              /*!< PWM_T::BRKCTL4_5: BRKP0LEN Position    */
+#define PWM_BRKCTL4_5_BRKP0LEN_Msk       (0x1ul << PWM_BRKCTL4_5_BRKP0LEN_Pos)             /*!< PWM_T::BRKCTL4_5: BRKP0LEN Mask        */
+
+#define PWM_BRKCTL4_5_BRKP1LEN_Pos       (13)                                              /*!< PWM_T::BRKCTL4_5: BRKP1LEN Position    */
+#define PWM_BRKCTL4_5_BRKP1LEN_Msk       (0x1ul << PWM_BRKCTL4_5_BRKP1LEN_Pos)             /*!< PWM_T::BRKCTL4_5: BRKP1LEN Mask        */
+
+#define PWM_BRKCTL4_5_SYSLBEN_Pos        (15)                                              /*!< PWM_T::BRKCTL4_5: SYSLBEN Position     */
+#define PWM_BRKCTL4_5_SYSLBEN_Msk        (0x1ul << PWM_BRKCTL4_5_SYSLBEN_Pos)              /*!< PWM_T::BRKCTL4_5: SYSLBEN Mask         */
+
+#define PWM_BRKCTL4_5_BRKAEVEN_Pos       (16)                                              /*!< PWM_T::BRKCTL4_5: BRKAEVEN Position    */
+#define PWM_BRKCTL4_5_BRKAEVEN_Msk       (0x3ul << PWM_BRKCTL4_5_BRKAEVEN_Pos)             /*!< PWM_T::BRKCTL4_5: BRKAEVEN Mask        */
+
+#define PWM_BRKCTL4_5_BRKAODD_Pos        (18)                                              /*!< PWM_T::BRKCTL4_5: BRKAODD Position     */
+#define PWM_BRKCTL4_5_BRKAODD_Msk        (0x3ul << PWM_BRKCTL4_5_BRKAODD_Pos)              /*!< PWM_T::BRKCTL4_5: BRKAODD Mask         */
+
+#define PWM_POLCTL_PINVn_Pos             (0)                                               /*!< PWM_T::POLCTL: PINVn Position          */
+#define PWM_POLCTL_PINVn_Msk             (0x3ful << PWM_POLCTL_PINVn_Pos)                  /*!< PWM_T::POLCTL: PINVn Mask              */
+
+#define PWM_POLCTL_PINV0_Pos             (0)                                               /*!< PWM_T::POLCTL: PINV0 Position          */
+#define PWM_POLCTL_PINV0_Msk             (0x1ul << PWM_POLCTL_PINV0_Pos)                   /*!< PWM_T::POLCTL: PINV0 Mask              */
+
+#define PWM_POLCTL_PINV1_Pos             (1)                                               /*!< PWM_T::POLCTL: PINV1 Position          */
+#define PWM_POLCTL_PINV1_Msk             (0x1ul << PWM_POLCTL_PINV1_Pos)                   /*!< PWM_T::POLCTL: PINV1 Mask              */
+
+#define PWM_POLCTL_PINV2_Pos             (2)                                               /*!< PWM_T::POLCTL: PINV2 Position          */
+#define PWM_POLCTL_PINV2_Msk             (0x1ul << PWM_POLCTL_PINV2_Pos)                   /*!< PWM_T::POLCTL: PINV2 Mask              */
+
+#define PWM_POLCTL_PINV3_Pos             (3)                                               /*!< PWM_T::POLCTL: PINV3 Position          */
+#define PWM_POLCTL_PINV3_Msk             (0x1ul << PWM_POLCTL_PINV3_Pos)                   /*!< PWM_T::POLCTL: PINV3 Mask              */
+
+#define PWM_POLCTL_PINV4_Pos             (4)                                               /*!< PWM_T::POLCTL: PINV4 Position          */
+#define PWM_POLCTL_PINV4_Msk             (0x1ul << PWM_POLCTL_PINV4_Pos)                   /*!< PWM_T::POLCTL: PINV4 Mask              */
+
+#define PWM_POLCTL_PINV5_Pos             (5)                                               /*!< PWM_T::POLCTL: PINV5 Position          */
+#define PWM_POLCTL_PINV5_Msk             (0x1ul << PWM_POLCTL_PINV5_Pos)                   /*!< PWM_T::POLCTL: PINV5 Mask              */
+
+#define PWM_POEN_POENn_Pos               (0)                                               /*!< PWM_T::POEN: POENn Position            */
+#define PWM_POEN_POENn_Msk               (0x3ful << PWM_POEN_POENn_Pos)                    /*!< PWM_T::POEN: POENn Mask                */
+
+#define PWM_POEN_POEN0_Pos               (0)                                               /*!< PWM_T::POEN: POEN0 Position            */
+#define PWM_POEN_POEN0_Msk               (0x1ul << PWM_POEN_POEN0_Pos)                     /*!< PWM_T::POEN: POEN0 Mask                */
+
+#define PWM_POEN_POEN1_Pos               (1)                                               /*!< PWM_T::POEN: POEN1 Position            */
+#define PWM_POEN_POEN1_Msk               (0x1ul << PWM_POEN_POEN1_Pos)                     /*!< PWM_T::POEN: POEN1 Mask                */
+
+#define PWM_POEN_POEN2_Pos               (2)                                               /*!< PWM_T::POEN: POEN2 Position            */
+#define PWM_POEN_POEN2_Msk               (0x1ul << PWM_POEN_POEN2_Pos)                     /*!< PWM_T::POEN: POEN2 Mask                */
+
+#define PWM_POEN_POEN3_Pos               (3)                                               /*!< PWM_T::POEN: POEN3 Position            */
+#define PWM_POEN_POEN3_Msk               (0x1ul << PWM_POEN_POEN3_Pos)                     /*!< PWM_T::POEN: POEN3 Mask                */
+
+#define PWM_POEN_POEN4_Pos               (4)                                               /*!< PWM_T::POEN: POEN4 Position            */
+#define PWM_POEN_POEN4_Msk               (0x1ul << PWM_POEN_POEN4_Pos)                     /*!< PWM_T::POEN: POEN4 Mask                */
+
+#define PWM_POEN_POEN5_Pos               (5)                                               /*!< PWM_T::POEN: POEN5 Position            */
+#define PWM_POEN_POEN5_Msk               (0x1ul << PWM_POEN_POEN5_Pos)                     /*!< PWM_T::POEN: POEN5 Mask                */
+
+#define PWM_SWBRK_BRKETRGn_Pos           (0)                                               /*!< PWM_T::SWBRK: BRKETRGn Position        */
+#define PWM_SWBRK_BRKETRGn_Msk           (0x7ul << PWM_SWBRK_BRKETRGn_Pos)                 /*!< PWM_T::SWBRK: BRKETRGn Mask            */
+
+#define PWM_SWBRK_BRKETRG0_Pos           (0)                                               /*!< PWM_T::SWBRK: BRKETRG0 Position        */
+#define PWM_SWBRK_BRKETRG0_Msk           (0x1ul << PWM_SWBRK_BRKETRG0_Pos)                 /*!< PWM_T::SWBRK: BRKETRG0 Mask            */
+
+#define PWM_SWBRK_BRKETRG2_Pos           (1)                                               /*!< PWM_T::SWBRK: BRKETRG2 Position        */
+#define PWM_SWBRK_BRKETRG2_Msk           (0x1ul << PWM_SWBRK_BRKETRG2_Pos)                 /*!< PWM_T::SWBRK: BRKETRG2 Mask            */
+
+#define PWM_SWBRK_BRKETRG4_Pos           (2)                                               /*!< PWM_T::SWBRK: BRKETRG4 Position        */
+#define PWM_SWBRK_BRKETRG4_Msk           (0x1ul << PWM_SWBRK_BRKETRG4_Pos)                 /*!< PWM_T::SWBRK: BRKETRG4 Mask            */
+
+#define PWM_SWBRK_BRKLTRGn_Pos           (8)                                               /*!< PWM_T::SWBRK: BRKLTRGn Position        */
+#define PWM_SWBRK_BRKLTRGn_Msk           (0x7ul << PWM_SWBRK_BRKLTRGn_Pos)                 /*!< PWM_T::SWBRK: BRKLTRGn Mask            */
+
+#define PWM_SWBRK_BRKLTRG0_Pos           (8)                                               /*!< PWM_T::SWBRK: BRKLTRG0 Position        */
+#define PWM_SWBRK_BRKLTRG0_Msk           (0x1ul << PWM_SWBRK_BRKLTRG0_Pos)                 /*!< PWM_T::SWBRK: BRKLTRG0 Mask            */
+
+#define PWM_SWBRK_BRKLTRG2_Pos           (9)                                               /*!< PWM_T::SWBRK: BRKLTRG2 Position        */
+#define PWM_SWBRK_BRKLTRG2_Msk           (0x1ul << PWM_SWBRK_BRKLTRG2_Pos)                 /*!< PWM_T::SWBRK: BRKLTRG2 Mask            */
+
+#define PWM_SWBRK_BRKLTRG4_Pos           (10)                                              /*!< PWM_T::SWBRK: BRKLTRG4 Position        */
+#define PWM_SWBRK_BRKLTRG4_Msk           (0x1ul << PWM_SWBRK_BRKLTRG4_Pos)                 /*!< PWM_T::SWBRK: BRKLTRG4 Mask            */
+
+#define PWM_INTEN0_ZIEN0_Pos             (0)                                               /*!< PWM_T::INTEN0: ZIEN0 Position          */
+#define PWM_INTEN0_ZIEN0_Msk             (0x1ul << PWM_INTEN0_ZIEN0_Pos)                   /*!< PWM_T::INTEN0: ZIEN0 Mask              */
+
+#define PWM_INTEN0_ZIEN2_Pos             (2)                                               /*!< PWM_T::INTEN0: ZIEN2 Position          */
+#define PWM_INTEN0_ZIEN2_Msk             (0x1ul << PWM_INTEN0_ZIEN2_Pos)                   /*!< PWM_T::INTEN0: ZIEN2 Mask              */
+
+#define PWM_INTEN0_ZIEN4_Pos             (4)                                               /*!< PWM_T::INTEN0: ZIEN4 Position          */
+#define PWM_INTEN0_ZIEN4_Msk             (0x1ul << PWM_INTEN0_ZIEN4_Pos)                   /*!< PWM_T::INTEN0: ZIEN4 Mask              */
+
+#define PWM_INTEN0_PIEN0_Pos             (8)                                               /*!< PWM_T::INTEN0: PIEN0 Position          */
+#define PWM_INTEN0_PIEN0_Msk             (0x1ul << PWM_INTEN0_PIEN0_Pos)                   /*!< PWM_T::INTEN0: PIEN0 Mask              */
+
+#define PWM_INTEN0_PIEN2_Pos             (10)                                              /*!< PWM_T::INTEN0: PIEN2 Position          */
+#define PWM_INTEN0_PIEN2_Msk             (0x1ul << PWM_INTEN0_PIEN2_Pos)                   /*!< PWM_T::INTEN0: PIEN2 Mask              */
+
+#define PWM_INTEN0_PIEN4_Pos             (12)                                              /*!< PWM_T::INTEN0: PIEN4 Position          */
+#define PWM_INTEN0_PIEN4_Msk             (0x1ul << PWM_INTEN0_PIEN4_Pos)                   /*!< PWM_T::INTEN0: PIEN4 Mask              */
+
+#define PWM_INTEN0_CMPUIENn_Pos          (16)                                              /*!< PWM_T::INTEN0: CMPUIENn Position       */
+#define PWM_INTEN0_CMPUIENn_Msk          (0x3ful << PWM_INTEN0_CMPUIENn_Pos)               /*!< PWM_T::INTEN0: CMPUIENn Mask           */
+
+#define PWM_INTEN0_CMPUIEN0_Pos          (16)                                              /*!< PWM_T::INTEN0: CMPUIEN0 Position       */
+#define PWM_INTEN0_CMPUIEN0_Msk          (0x1ul << PWM_INTEN0_CMPUIEN0_Pos)                /*!< PWM_T::INTEN0: CMPUIEN0 Mask           */
+
+#define PWM_INTEN0_CMPUIEN1_Pos          (17)                                              /*!< PWM_T::INTEN0: CMPUIEN1 Position       */
+#define PWM_INTEN0_CMPUIEN1_Msk          (0x1ul << PWM_INTEN0_CMPUIEN1_Pos)                /*!< PWM_T::INTEN0: CMPUIEN1 Mask           */
+
+#define PWM_INTEN0_CMPUIEN2_Pos          (18)                                              /*!< PWM_T::INTEN0: CMPUIEN2 Position       */
+#define PWM_INTEN0_CMPUIEN2_Msk          (0x1ul << PWM_INTEN0_CMPUIEN2_Pos)                /*!< PWM_T::INTEN0: CMPUIEN2 Mask           */
+
+#define PWM_INTEN0_CMPUIEN3_Pos          (19)                                              /*!< PWM_T::INTEN0: CMPUIEN3 Position       */
+#define PWM_INTEN0_CMPUIEN3_Msk          (0x1ul << PWM_INTEN0_CMPUIEN3_Pos)                /*!< PWM_T::INTEN0: CMPUIEN3 Mask           */
+
+#define PWM_INTEN0_CMPUIEN4_Pos          (20)                                              /*!< PWM_T::INTEN0: CMPUIEN4 Position       */
+#define PWM_INTEN0_CMPUIEN4_Msk          (0x1ul << PWM_INTEN0_CMPUIEN4_Pos)                /*!< PWM_T::INTEN0: CMPUIEN4 Mask           */
+
+#define PWM_INTEN0_CMPUIEN5_Pos          (21)                                              /*!< PWM_T::INTEN0: CMPUIEN5 Position       */
+#define PWM_INTEN0_CMPUIEN5_Msk          (0x1ul << PWM_INTEN0_CMPUIEN5_Pos)                /*!< PWM_T::INTEN0: CMPUIEN5 Mask           */
+
+#define PWM_INTEN0_CMPDIENn_Pos          (24)                                              /*!< PWM_T::INTEN0: CMPDIENn Position       */
+#define PWM_INTEN0_CMPDIENn_Msk          (0x3ful << PWM_INTEN0_CMPDIENn_Pos)               /*!< PWM_T::INTEN0: CMPDIENn Mask           */
+
+#define PWM_INTEN0_CMPDIEN0_Pos          (24)                                              /*!< PWM_T::INTEN0: CMPDIEN0 Position       */
+#define PWM_INTEN0_CMPDIEN0_Msk          (0x1ul << PWM_INTEN0_CMPDIEN0_Pos)                /*!< PWM_T::INTEN0: CMPDIEN0 Mask           */
+
+#define PWM_INTEN0_CMPDIEN1_Pos          (25)                                              /*!< PWM_T::INTEN0: CMPDIEN1 Position       */
+#define PWM_INTEN0_CMPDIEN1_Msk          (0x1ul << PWM_INTEN0_CMPDIEN1_Pos)                /*!< PWM_T::INTEN0: CMPDIEN1 Mask           */
+
+#define PWM_INTEN0_CMPDIEN2_Pos          (26)                                              /*!< PWM_T::INTEN0: CMPDIEN2 Position       */
+#define PWM_INTEN0_CMPDIEN2_Msk          (0x1ul << PWM_INTEN0_CMPDIEN2_Pos)                /*!< PWM_T::INTEN0: CMPDIEN2 Mask           */
+
+#define PWM_INTEN0_CMPDIEN3_Pos          (27)                                              /*!< PWM_T::INTEN0: CMPDIEN3 Position       */
+#define PWM_INTEN0_CMPDIEN3_Msk          (0x1ul << PWM_INTEN0_CMPDIEN3_Pos)                /*!< PWM_T::INTEN0: CMPDIEN3 Mask           */
+
+#define PWM_INTEN0_CMPDIEN4_Pos          (28)                                              /*!< PWM_T::INTEN0: CMPDIEN4 Position       */
+#define PWM_INTEN0_CMPDIEN4_Msk          (0x1ul << PWM_INTEN0_CMPDIEN4_Pos)                /*!< PWM_T::INTEN0: CMPDIEN4 Mask           */
+
+#define PWM_INTEN0_CMPDIEN5_Pos          (29)                                              /*!< PWM_T::INTEN0: CMPDIEN5 Position       */
+#define PWM_INTEN0_CMPDIEN5_Msk          (0x1ul << PWM_INTEN0_CMPDIEN5_Pos)                /*!< PWM_T::INTEN0: CMPDIEN5 Mask           */
+
+#define PWM_INTEN1_BRKEIEN0_1_Pos        (0)                                               /*!< PWM_T::INTEN1: BRKEIEN0_1 Position     */
+#define PWM_INTEN1_BRKEIEN0_1_Msk        (0x1ul << PWM_INTEN1_BRKEIEN0_1_Pos)              /*!< PWM_T::INTEN1: BRKEIEN0_1 Mask         */
+
+#define PWM_INTEN1_BRKEIEN2_3_Pos        (1)                                               /*!< PWM_T::INTEN1: BRKEIEN2_3 Position     */
+#define PWM_INTEN1_BRKEIEN2_3_Msk        (0x1ul << PWM_INTEN1_BRKEIEN2_3_Pos)              /*!< PWM_T::INTEN1: BRKEIEN2_3 Mask         */
+
+#define PWM_INTEN1_BRKEIEN4_5_Pos        (2)                                               /*!< PWM_T::INTEN1: BRKEIEN4_5 Position     */
+#define PWM_INTEN1_BRKEIEN4_5_Msk        (0x1ul << PWM_INTEN1_BRKEIEN4_5_Pos)              /*!< PWM_T::INTEN1: BRKEIEN4_5 Mask         */
+
+#define PWM_INTEN1_BRKLIEN0_1_Pos        (8)                                               /*!< PWM_T::INTEN1: BRKLIEN0_1 Position     */
+#define PWM_INTEN1_BRKLIEN0_1_Msk        (0x1ul << PWM_INTEN1_BRKLIEN0_1_Pos)              /*!< PWM_T::INTEN1: BRKLIEN0_1 Mask         */
+
+#define PWM_INTEN1_BRKLIEN2_3_Pos        (9)                                               /*!< PWM_T::INTEN1: BRKLIEN2_3 Position     */
+#define PWM_INTEN1_BRKLIEN2_3_Msk        (0x1ul << PWM_INTEN1_BRKLIEN2_3_Pos)              /*!< PWM_T::INTEN1: BRKLIEN2_3 Mask         */
+
+#define PWM_INTEN1_BRKLIEN4_5_Pos        (10)                                              /*!< PWM_T::INTEN1: BRKLIEN4_5 Position     */
+#define PWM_INTEN1_BRKLIEN4_5_Msk        (0x1ul << PWM_INTEN1_BRKLIEN4_5_Pos)              /*!< PWM_T::INTEN1: BRKLIEN4_5 Mask         */
+
+#define PWM_INTSTS0_ZIF0_Pos             (0)                                               /*!< PWM_T::INTSTS0: ZIF0 Position          */
+#define PWM_INTSTS0_ZIF0_Msk             (0x1ul << PWM_INTSTS0_ZIF0_Pos)                   /*!< PWM_T::INTSTS0: ZIF0 Mask              */
+
+#define PWM_INTSTS0_ZIF2_Pos             (2)                                               /*!< PWM_T::INTSTS0: ZIF2 Position          */
+#define PWM_INTSTS0_ZIF2_Msk             (0x1ul << PWM_INTSTS0_ZIF2_Pos)                   /*!< PWM_T::INTSTS0: ZIF2 Mask              */
+
+#define PWM_INTSTS0_ZIF4_Pos             (4)                                               /*!< PWM_T::INTSTS0: ZIF4 Position          */
+#define PWM_INTSTS0_ZIF4_Msk             (0x1ul << PWM_INTSTS0_ZIF4_Pos)                   /*!< PWM_T::INTSTS0: ZIF4 Mask              */
+
+#define PWM_INTSTS0_PIF0_Pos             (8)                                               /*!< PWM_T::INTSTS0: PIF0 Position          */
+#define PWM_INTSTS0_PIF0_Msk             (0x1ul << PWM_INTSTS0_PIF0_Pos)                   /*!< PWM_T::INTSTS0: PIF0 Mask              */
+
+#define PWM_INTSTS0_PIF2_Pos             (10)                                              /*!< PWM_T::INTSTS0: PIF2 Position          */
+#define PWM_INTSTS0_PIF2_Msk             (0x1ul << PWM_INTSTS0_PIF2_Pos)                   /*!< PWM_T::INTSTS0: PIF2 Mask              */
+
+#define PWM_INTSTS0_PIF4_Pos             (12)                                              /*!< PWM_T::INTSTS0: PIF4 Position          */
+#define PWM_INTSTS0_PIF4_Msk             (0x1ul << PWM_INTSTS0_PIF4_Pos)                   /*!< PWM_T::INTSTS0: PIF4 Mask              */
+
+#define PWM_INTSTS0_CMPUIFn_Pos          (16)                                              /*!< PWM_T::INTSTS0: CMPUIFn Position       */
+#define PWM_INTSTS0_CMPUIFn_Msk          (0x3ful << PWM_INTSTS0_CMPUIFn_Pos)               /*!< PWM_T::INTSTS0: CMPUIFn Mask           */
+
+#define PWM_INTSTS0_CMPUIF0_Pos          (16)                                              /*!< PWM_T::INTSTS0: CMPUIF0 Position       */
+#define PWM_INTSTS0_CMPUIF0_Msk          (0x1ul << PWM_INTSTS0_CMPUIF0_Pos)               /*!< PWM_T::INTSTS0: CMPUIF0 Mask           */
+
+#define PWM_INTSTS0_CMPUIF1_Pos          (17)                                              /*!< PWM_T::INTSTS0: CMPUIF1 Position       */
+#define PWM_INTSTS0_CMPUIF1_Msk          (0x1ul << PWM_INTSTS0_CMPUIF1_Pos)               /*!< PWM_T::INTSTS0: CMPUIF1 Mask           */
+
+#define PWM_INTSTS0_CMPUIF2_Pos          (18)                                              /*!< PWM_T::INTSTS0: CMPUIF2 Position       */
+#define PWM_INTSTS0_CMPUIF2_Msk          (0x1ul << PWM_INTSTS0_CMPUIF2_Pos)               /*!< PWM_T::INTSTS0: CMPUIF2 Mask           */
+
+#define PWM_INTSTS0_CMPUIF3_Pos          (19)                                              /*!< PWM_T::INTSTS0: CMPUIF3 Position       */
+#define PWM_INTSTS0_CMPUIF3_Msk          (0x1ul << PWM_INTSTS0_CMPUIF3_Pos)               /*!< PWM_T::INTSTS0: CMPUIF3 Mask           */
+
+#define PWM_INTSTS0_CMPUIF4_Pos          (20)                                              /*!< PWM_T::INTSTS0: CMPUIF4 Position       */
+#define PWM_INTSTS0_CMPUIF4_Msk          (0x1ul << PWM_INTSTS0_CMPUIF4_Pos)               /*!< PWM_T::INTSTS0: CMPUIF4 Mask           */
+
+#define PWM_INTSTS0_CMPUIF5_Pos          (21)                                              /*!< PWM_T::INTSTS0: CMPUIF5 Position       */
+#define PWM_INTSTS0_CMPUIF5_Msk          (0x1ul << PWM_INTSTS0_CMPUIF5_Pos)               /*!< PWM_T::INTSTS0: CMPUIF5 Mask           */
+
+#define PWM_INTSTS0_CMPDIFn_Pos          (24)                                              /*!< PWM_T::INTSTS0: CMPDIFn Position       */
+#define PWM_INTSTS0_CMPDIFn_Msk          (0x3ful << PWM_INTSTS0_CMPDIFn_Pos)               /*!< PWM_T::INTSTS0: CMPDIFn Mask           */
+
+#define PWM_INTSTS0_CMPDIF0_Pos          (24)                                              /*!< PWM_T::INTSTS0: CMPDIF0 Position       */
+#define PWM_INTSTS0_CMPDIF0_Msk          (0x1ul << PWM_INTSTS0_CMPDIF0_Pos)                /*!< PWM_T::INTSTS0: CMPDIF0 Mask           */
+
+#define PWM_INTSTS0_CMPDIF1_Pos          (25)                                              /*!< PWM_T::INTSTS0: CMPDIF1 Position       */
+#define PWM_INTSTS0_CMPDIF1_Msk          (0x1ul << PWM_INTSTS0_CMPDIF1_Pos)                /*!< PWM_T::INTSTS0: CMPDIF1 Mask           */
+
+#define PWM_INTSTS0_CMPDIF2_Pos          (26)                                              /*!< PWM_T::INTSTS0: CMPDIF2 Position       */
+#define PWM_INTSTS0_CMPDIF2_Msk          (0x1ul << PWM_INTSTS0_CMPDIF2_Pos)                /*!< PWM_T::INTSTS0: CMPDIF2 Mask           */
+
+#define PWM_INTSTS0_CMPDIF3_Pos          (27)                                              /*!< PWM_T::INTSTS0: CMPDIF3 Position       */
+#define PWM_INTSTS0_CMPDIF3_Msk          (0x1ul << PWM_INTSTS0_CMPDIF3_Pos)                /*!< PWM_T::INTSTS0: CMPDIF3 Mask           */
+
+#define PWM_INTSTS0_CMPDIF4_Pos          (28)                                              /*!< PWM_T::INTSTS0: CMPDIF4 Position       */
+#define PWM_INTSTS0_CMPDIF4_Msk          (0x1ul << PWM_INTSTS0_CMPDIF4_Pos)                /*!< PWM_T::INTSTS0: CMPDIF4 Mask           */
+
+#define PWM_INTSTS0_CMPDIF5_Pos          (29)                                              /*!< PWM_T::INTSTS0: CMPDIF5 Position       */
+#define PWM_INTSTS0_CMPDIF5_Msk          (0x1ul << PWM_INTSTS0_CMPDIF5_Pos)                /*!< PWM_T::INTSTS0: CMPDIF5 Mask           */
+
+#define PWM_INTSTS1_BRKEIF0_Pos          (0)                                               /*!< PWM_T::INTSTS1: BRKEIF0 Position       */
+#define PWM_INTSTS1_BRKEIF0_Msk          (0x1ul << PWM_INTSTS1_BRKEIF0_Pos)                /*!< PWM_T::INTSTS1: BRKEIF0 Mask           */
+
+#define PWM_INTSTS1_BRKEIF1_Pos          (1)                                               /*!< PWM_T::INTSTS1: BRKEIF1 Position       */
+#define PWM_INTSTS1_BRKEIF1_Msk          (0x1ul << PWM_INTSTS1_BRKEIF1_Pos)                /*!< PWM_T::INTSTS1: BRKEIF1 Mask           */
+
+#define PWM_INTSTS1_BRKEIF2_Pos          (2)                                               /*!< PWM_T::INTSTS1: BRKEIF2 Position       */
+#define PWM_INTSTS1_BRKEIF2_Msk          (0x1ul << PWM_INTSTS1_BRKEIF2_Pos)                /*!< PWM_T::INTSTS1: BRKEIF2 Mask           */
+
+#define PWM_INTSTS1_BRKEIF3_Pos          (3)                                               /*!< PWM_T::INTSTS1: BRKEIF3 Position       */
+#define PWM_INTSTS1_BRKEIF3_Msk          (0x1ul << PWM_INTSTS1_BRKEIF3_Pos)                /*!< PWM_T::INTSTS1: BRKEIF3 Mask           */
+
+#define PWM_INTSTS1_BRKEIF4_Pos          (4)                                               /*!< PWM_T::INTSTS1: BRKEIF4 Position       */
+#define PWM_INTSTS1_BRKEIF4_Msk          (0x1ul << PWM_INTSTS1_BRKEIF4_Pos)                /*!< PWM_T::INTSTS1: BRKEIF4 Mask           */
+
+#define PWM_INTSTS1_BRKEIF5_Pos          (5)                                               /*!< PWM_T::INTSTS1: BRKEIF5 Position       */
+#define PWM_INTSTS1_BRKEIF5_Msk          (0x1ul << PWM_INTSTS1_BRKEIF5_Pos)                /*!< PWM_T::INTSTS1: BRKEIF5 Mask           */
+
+#define PWM_INTSTS1_BRKLIF0_Pos          (8)                                               /*!< PWM_T::INTSTS1: BRKLIF0 Position       */
+#define PWM_INTSTS1_BRKLIF0_Msk          (0x1ul << PWM_INTSTS1_BRKLIF0_Pos)                /*!< PWM_T::INTSTS1: BRKLIF0 Mask           */
+
+#define PWM_INTSTS1_BRKLIF1_Pos          (9)                                               /*!< PWM_T::INTSTS1: BRKLIF1 Position       */
+#define PWM_INTSTS1_BRKLIF1_Msk          (0x1ul << PWM_INTSTS1_BRKLIF1_Pos)                /*!< PWM_T::INTSTS1: BRKLIF1 Mask           */
+
+#define PWM_INTSTS1_BRKLIF2_Pos          (10)                                              /*!< PWM_T::INTSTS1: BRKLIF2 Position       */
+#define PWM_INTSTS1_BRKLIF2_Msk          (0x1ul << PWM_INTSTS1_BRKLIF2_Pos)                /*!< PWM_T::INTSTS1: BRKLIF2 Mask           */
+
+#define PWM_INTSTS1_BRKLIF3_Pos          (11)                                              /*!< PWM_T::INTSTS1: BRKLIF3 Position       */
+#define PWM_INTSTS1_BRKLIF3_Msk          (0x1ul << PWM_INTSTS1_BRKLIF3_Pos)                /*!< PWM_T::INTSTS1: BRKLIF3 Mask           */
+
+#define PWM_INTSTS1_BRKLIF4_Pos          (12)                                              /*!< PWM_T::INTSTS1: BRKLIF4 Position       */
+#define PWM_INTSTS1_BRKLIF4_Msk          (0x1ul << PWM_INTSTS1_BRKLIF4_Pos)                /*!< PWM_T::INTSTS1: BRKLIF4 Mask           */
+
+#define PWM_INTSTS1_BRKLIF5_Pos          (13)                                              /*!< PWM_T::INTSTS1: BRKLIF5 Position       */
+#define PWM_INTSTS1_BRKLIF5_Msk          (0x1ul << PWM_INTSTS1_BRKLIF5_Pos)                /*!< PWM_T::INTSTS1: BRKLIF5 Mask           */
+
+#define PWM_INTSTS1_BRKESTS0_Pos         (16)                                              /*!< PWM_T::INTSTS1: BRKESTS0 Position      */
+#define PWM_INTSTS1_BRKESTS0_Msk         (0x1ul << PWM_INTSTS1_BRKESTS0_Pos)               /*!< PWM_T::INTSTS1: BRKESTS0 Mask          */
+
+#define PWM_INTSTS1_BRKESTS1_Pos         (17)                                              /*!< PWM_T::INTSTS1: BRKESTS1 Position      */
+#define PWM_INTSTS1_BRKESTS1_Msk         (0x1ul << PWM_INTSTS1_BRKESTS1_Pos)               /*!< PWM_T::INTSTS1: BRKESTS1 Mask          */
+
+#define PWM_INTSTS1_BRKESTS2_Pos         (18)                                              /*!< PWM_T::INTSTS1: BRKESTS2 Position      */
+#define PWM_INTSTS1_BRKESTS2_Msk         (0x1ul << PWM_INTSTS1_BRKESTS2_Pos)               /*!< PWM_T::INTSTS1: BRKESTS2 Mask          */
+
+#define PWM_INTSTS1_BRKESTS3_Pos         (19)                                              /*!< PWM_T::INTSTS1: BRKESTS3 Position      */
+#define PWM_INTSTS1_BRKESTS3_Msk         (0x1ul << PWM_INTSTS1_BRKESTS3_Pos)               /*!< PWM_T::INTSTS1: BRKESTS3 Mask          */
+
+#define PWM_INTSTS1_BRKESTS4_Pos         (20)                                              /*!< PWM_T::INTSTS1: BRKESTS4 Position      */
+#define PWM_INTSTS1_BRKESTS4_Msk         (0x1ul << PWM_INTSTS1_BRKESTS4_Pos)               /*!< PWM_T::INTSTS1: BRKESTS4 Mask          */
+
+#define PWM_INTSTS1_BRKESTS5_Pos         (21)                                              /*!< PWM_T::INTSTS1: BRKESTS5 Position      */
+#define PWM_INTSTS1_BRKESTS5_Msk         (0x1ul << PWM_INTSTS1_BRKESTS5_Pos)               /*!< PWM_T::INTSTS1: BRKESTS5 Mask          */
+
+#define PWM_INTSTS1_BRKLSTS0_Pos         (24)                                              /*!< PWM_T::INTSTS1: BRKLSTS0 Position      */
+#define PWM_INTSTS1_BRKLSTS0_Msk         (0x1ul << PWM_INTSTS1_BRKLSTS0_Pos)               /*!< PWM_T::INTSTS1: BRKLSTS0 Mask          */
+
+#define PWM_INTSTS1_BRKLSTS1_Pos         (25)                                              /*!< PWM_T::INTSTS1: BRKLSTS1 Position      */
+#define PWM_INTSTS1_BRKLSTS1_Msk         (0x1ul << PWM_INTSTS1_BRKLSTS1_Pos)               /*!< PWM_T::INTSTS1: BRKLSTS1 Mask          */
+
+#define PWM_INTSTS1_BRKLSTS2_Pos         (26)                                              /*!< PWM_T::INTSTS1: BRKLSTS2 Position      */
+#define PWM_INTSTS1_BRKLSTS2_Msk         (0x1ul << PWM_INTSTS1_BRKLSTS2_Pos)               /*!< PWM_T::INTSTS1: BRKLSTS2 Mask          */
+
+#define PWM_INTSTS1_BRKLSTS3_Pos         (27)                                              /*!< PWM_T::INTSTS1: BRKLSTS3 Position      */
+#define PWM_INTSTS1_BRKLSTS3_Msk         (0x1ul << PWM_INTSTS1_BRKLSTS3_Pos)               /*!< PWM_T::INTSTS1: BRKLSTS3 Mask          */
+
+#define PWM_INTSTS1_BRKLSTS4_Pos         (28)                                              /*!< PWM_T::INTSTS1: BRKLSTS4 Position      */
+#define PWM_INTSTS1_BRKLSTS4_Msk         (0x1ul << PWM_INTSTS1_BRKLSTS4_Pos)               /*!< PWM_T::INTSTS1: BRKLSTS4 Mask          */
+
+#define PWM_INTSTS1_BRKLSTS5_Pos         (29)                                              /*!< PWM_T::INTSTS1: BRKLSTS5 Position      */
+#define PWM_INTSTS1_BRKLSTS5_Msk         (0x1ul << PWM_INTSTS1_BRKLSTS5_Pos)               /*!< PWM_T::INTSTS1: BRKLSTS5 Mask          */
+
+#define PWM_EADCTS0_TRGSEL0_Pos          (0)                                               /*!< PWM_T::EADCTS0: TRGSEL0 Position       */
+#define PWM_EADCTS0_TRGSEL0_Msk          (0xful << PWM_EADCTS0_TRGSEL0_Pos)                /*!< PWM_T::EADCTS0: TRGSEL0 Mask           */
+
+#define PWM_EADCTS0_TRGEN0_Pos           (7)                                               /*!< PWM_T::EADCTS0: TRGEN0 Position        */
+#define PWM_EADCTS0_TRGEN0_Msk           (0x1ul << PWM_EADCTS0_TRGEN0_Pos)                 /*!< PWM_T::EADCTS0: TRGEN0 Mask            */
+
+#define PWM_EADCTS0_TRGSEL1_Pos          (8)                                               /*!< PWM_T::EADCTS0: TRGSEL1 Position       */
+#define PWM_EADCTS0_TRGSEL1_Msk          (0xful << PWM_EADCTS0_TRGSEL1_Pos)                /*!< PWM_T::EADCTS0: TRGSEL1 Mask           */
+
+#define PWM_EADCTS0_TRGEN1_Pos           (15)                                              /*!< PWM_T::EADCTS0: TRGEN1 Position        */
+#define PWM_EADCTS0_TRGEN1_Msk           (0x1ul << PWM_EADCTS0_TRGEN1_Pos)                 /*!< PWM_T::EADCTS0: TRGEN1 Mask            */
+
+#define PWM_EADCTS0_TRGSEL2_Pos          (16)                                              /*!< PWM_T::EADCTS0: TRGSEL2 Position       */
+#define PWM_EADCTS0_TRGSEL2_Msk          (0xful << PWM_EADCTS0_TRGSEL2_Pos)                /*!< PWM_T::EADCTS0: TRGSEL2 Mask           */
+
+#define PWM_EADCTS0_TRGEN2_Pos           (23)                                              /*!< PWM_T::EADCTS0: TRGEN2 Position        */
+#define PWM_EADCTS0_TRGEN2_Msk           (0x1ul << PWM_EADCTS0_TRGEN2_Pos)                 /*!< PWM_T::EADCTS0: TRGEN2 Mask            */
+
+#define PWM_EADCTS0_TRGSEL3_Pos          (24)                                              /*!< PWM_T::EADCTS0: TRGSEL3 Position       */
+#define PWM_EADCTS0_TRGSEL3_Msk          (0xful << PWM_EADCTS0_TRGSEL3_Pos)                /*!< PWM_T::EADCTS0: TRGSEL3 Mask           */
+
+#define PWM_EADCTS0_TRGEN3_Pos           (31)                                              /*!< PWM_T::EADCTS0: TRGEN3 Position        */
+#define PWM_EADCTS0_TRGEN3_Msk           (0x1ul << PWM_EADCTS0_TRGEN3_Pos)                 /*!< PWM_T::EADCTS0: TRGEN3 Mask            */
+
+#define PWM_EADCTS1_TRGSEL4_Pos          (0)                                               /*!< PWM_T::EADCTS1: TRGSEL4 Position       */
+#define PWM_EADCTS1_TRGSEL4_Msk          (0xful << PWM_EADCTS1_TRGSEL4_Pos)                /*!< PWM_T::EADCTS1: TRGSEL4 Mask           */
+
+#define PWM_EADCTS1_TRGEN4_Pos           (7)                                               /*!< PWM_T::EADCTS1: TRGEN4 Position        */
+#define PWM_EADCTS1_TRGEN4_Msk           (0x1ul << PWM_EADCTS1_TRGEN4_Pos)                 /*!< PWM_T::EADCTS1: TRGEN4 Mask            */
+
+#define PWM_EADCTS1_TRGSEL5_Pos          (8)                                               /*!< PWM_T::EADCTS1: TRGSEL5 Position       */
+#define PWM_EADCTS1_TRGSEL5_Msk          (0xful << PWM_EADCTS1_TRGSEL5_Pos)                /*!< PWM_T::EADCTS1: TRGSEL5 Mask           */
+
+#define PWM_EADCTS1_TRGEN5_Pos           (15)                                              /*!< PWM_T::EADCTS1: TRGEN5 Position        */
+#define PWM_EADCTS1_TRGEN5_Msk           (0x1ul << PWM_EADCTS1_TRGEN5_Pos)                 /*!< PWM_T::EADCTS1: TRGEN5 Mask            */
+
+#define PWM_SSCTL_SSEN0_Pos              (0)                                               /*!< PWM_T::SSCTL: SSEN0 Position           */
+#define PWM_SSCTL_SSEN0_Msk              (0x1ul << PWM_SSCTL_SSEN0_Pos)                    /*!< PWM_T::SSCTL: SSEN0 Mask               */
+
+#define PWM_SSCTL_SSEN2_Pos              (2)                                               /*!< PWM_T::SSCTL: SSEN2 Position           */
+#define PWM_SSCTL_SSEN2_Msk              (0x1ul << PWM_SSCTL_SSEN2_Pos)                    /*!< PWM_T::SSCTL: SSEN2 Mask               */
+
+#define PWM_SSCTL_SSEN4_Pos              (4)                                               /*!< PWM_T::SSCTL: SSEN4 Position           */
+#define PWM_SSCTL_SSEN4_Msk              (0x1ul << PWM_SSCTL_SSEN4_Pos)                    /*!< PWM_T::SSCTL: SSEN4 Mask               */
+
+#define PWM_SSCTL_SSRC_Pos               (8)                                               /*!< PWM_T::SSCTL: SSRC Position            */
+#define PWM_SSCTL_SSRC_Msk               (0x3ul << PWM_SSCTL_SSRC_Pos)                     /*!< PWM_T::SSCTL: SSRC Mask                */
+
+#define PWM_SSTRG_CNTSEN_Pos             (0)                                               /*!< PWM_T::SSTRG: CNTSEN Position          */
+#define PWM_SSTRG_CNTSEN_Msk             (0x1ul << PWM_SSTRG_CNTSEN_Pos)                   /*!< PWM_T::SSTRG: CNTSEN Mask              */
+
+#define PWM_STATUS_CNTMAX0_Pos           (0)                                               /*!< PWM_T::STATUS: CNTMAX0 Position        */
+#define PWM_STATUS_CNTMAX0_Msk           (0x1ul << PWM_STATUS_CNTMAX0_Pos)                 /*!< PWM_T::STATUS: CNTMAX0 Mask            */
+
+#define PWM_STATUS_CNTMAX2_Pos           (2)                                               /*!< PWM_T::STATUS: CNTMAX2 Position        */
+#define PWM_STATUS_CNTMAX2_Msk           (0x1ul << PWM_STATUS_CNTMAX2_Pos)                 /*!< PWM_T::STATUS: CNTMAX2 Mask            */
+
+#define PWM_STATUS_CNTMAX4_Pos           (4)                                               /*!< PWM_T::STATUS: CNTMAX4 Position        */
+#define PWM_STATUS_CNTMAX4_Msk           (0x1ul << PWM_STATUS_CNTMAX4_Pos)                 /*!< PWM_T::STATUS: CNTMAX4 Mask            */
+
+#define PWM_STATUS_EADCTRGn_Pos          (16)                                              /*!< PWM_T::STATUS: EADCTRGn Position       */
+#define PWM_STATUS_EADCTRGn_Msk          (0x3ful << PWM_STATUS_EADCTRGn_Pos)               /*!< PWM_T::STATUS: EADCTRGn Mask           */
+
+#define PWM_STATUS_EADCTRG0_Pos          (16)                                              /*!< PWM_T::STATUS: EADCTRG0 Position       */
+#define PWM_STATUS_EADCTRG0_Msk          (0x1ul << PWM_STATUS_EADCTRG0_Pos)                /*!< PWM_T::STATUS: EADCTRG0 Mask           */
+
+#define PWM_STATUS_EADCTRG1_Pos          (17)                                              /*!< PWM_T::STATUS: EADCTRG1 Position       */
+#define PWM_STATUS_EADCTRG1_Msk          (0x1ul << PWM_STATUS_EADCTRG1_Pos)                /*!< PWM_T::STATUS: EADCTRG1 Mask           */
+
+#define PWM_STATUS_EADCTRG2_Pos          (18)                                              /*!< PWM_T::STATUS: EADCTRG2 Position       */
+#define PWM_STATUS_EADCTRG2_Msk          (0x1ul << PWM_STATUS_EADCTRG2_Pos)                /*!< PWM_T::STATUS: EADCTRG2 Mask           */
+
+#define PWM_STATUS_EADCTRG3_Pos          (19)                                              /*!< PWM_T::STATUS: EADCTRG3 Position       */
+#define PWM_STATUS_EADCTRG3_Msk          (0x1ul << PWM_STATUS_EADCTRG3_Pos)                /*!< PWM_T::STATUS: EADCTRG3 Mask           */
+
+#define PWM_STATUS_EADCTRG4_Pos          (20)                                              /*!< PWM_T::STATUS: EADCTRG4 Position       */
+#define PWM_STATUS_EADCTRG4_Msk          (0x1ul << PWM_STATUS_EADCTRG4_Pos)                /*!< PWM_T::STATUS: EADCTRG4 Mask           */
+
+#define PWM_STATUS_EADCTRG5_Pos          (21)                                              /*!< PWM_T::STATUS: EADCTRG5 Position       */
+#define PWM_STATUS_EADCTRG5_Msk          (0x1ul << PWM_STATUS_EADCTRG5_Pos)                /*!< PWM_T::STATUS: EADCTRG5 Mask           */
+
+#define PWM_CAPINEN_CAPINENn_Pos         (0)                                               /*!< PWM_T::CAPINEN: CAPINENn Position      */
+#define PWM_CAPINEN_CAPINENn_Msk         (0x3ful << PWM_CAPINEN_CAPINENn_Pos)              /*!< PWM_T::CAPINEN: CAPINENn Mask          */
+
+#define PWM_CAPINEN_CAPINEN0_Pos         (0)                                               /*!< PWM_T::CAPINEN: CAPINEN0 Position      */
+#define PWM_CAPINEN_CAPINEN0_Msk         (0x1ul << PWM_CAPINEN_CAPINEN0_Pos)               /*!< PWM_T::CAPINEN: CAPINEN0 Mask          */
+
+#define PWM_CAPINEN_CAPINEN1_Pos         (1)                                               /*!< PWM_T::CAPINEN: CAPINEN1 Position      */
+#define PWM_CAPINEN_CAPINEN1_Msk         (0x1ul << PWM_CAPINEN_CAPINEN1_Pos)               /*!< PWM_T::CAPINEN: CAPINEN1 Mask          */
+
+#define PWM_CAPINEN_CAPINEN2_Pos         (2)                                               /*!< PWM_T::CAPINEN: CAPINEN2 Position      */
+#define PWM_CAPINEN_CAPINEN2_Msk         (0x1ul << PWM_CAPINEN_CAPINEN2_Pos)               /*!< PWM_T::CAPINEN: CAPINEN2 Mask          */
+
+#define PWM_CAPINEN_CAPINEN3_Pos         (3)                                               /*!< PWM_T::CAPINEN: CAPINEN3 Position      */
+#define PWM_CAPINEN_CAPINEN3_Msk         (0x1ul << PWM_CAPINEN_CAPINEN3_Pos)               /*!< PWM_T::CAPINEN: CAPINEN3 Mask          */
+
+#define PWM_CAPINEN_CAPINEN4_Pos         (4)                                               /*!< PWM_T::CAPINEN: CAPINEN4 Position      */
+#define PWM_CAPINEN_CAPINEN4_Msk         (0x1ul << PWM_CAPINEN_CAPINEN4_Pos)               /*!< PWM_T::CAPINEN: CAPINEN4 Mask          */
+
+#define PWM_CAPINEN_CAPINEN5_Pos         (5)                                               /*!< PWM_T::CAPINEN: CAPINEN5 Position      */
+#define PWM_CAPINEN_CAPINEN5_Msk         (0x1ul << PWM_CAPINEN_CAPINEN5_Pos)               /*!< PWM_T::CAPINEN: CAPINEN5 Mask          */
+
+#define PWM_CAPCTL_CAPENn_Pos            (0)                                               /*!< PWM_T::CAPCTL: CAPENn Position         */
+#define PWM_CAPCTL_CAPENn_Msk            (0x3ful << PWM_CAPCTL_CAPENn_Pos)                 /*!< PWM_T::CAPCTL: CAPENn Mask             */
+
+#define PWM_CAPCTL_CAPEN0_Pos            (0)                                               /*!< PWM_T::CAPCTL: CAPEN0 Position         */
+#define PWM_CAPCTL_CAPEN0_Msk            (0x1ul << PWM_CAPCTL_CAPEN0_Pos)                  /*!< PWM_T::CAPCTL: CAPEN0 Mask             */
+
+#define PWM_CAPCTL_CAPEN1_Pos            (1)                                               /*!< PWM_T::CAPCTL: CAPEN1 Position         */
+#define PWM_CAPCTL_CAPEN1_Msk            (0x1ul << PWM_CAPCTL_CAPEN1_Pos)                  /*!< PWM_T::CAPCTL: CAPEN1 Mask             */
+
+#define PWM_CAPCTL_CAPEN2_Pos            (2)                                               /*!< PWM_T::CAPCTL: CAPEN2 Position         */
+#define PWM_CAPCTL_CAPEN2_Msk            (0x1ul << PWM_CAPCTL_CAPEN2_Pos)                  /*!< PWM_T::CAPCTL: CAPEN2 Mask             */
+
+#define PWM_CAPCTL_CAPEN3_Pos            (3)                                               /*!< PWM_T::CAPCTL: CAPEN3 Position         */
+#define PWM_CAPCTL_CAPEN3_Msk            (0x1ul << PWM_CAPCTL_CAPEN3_Pos)                  /*!< PWM_T::CAPCTL: CAPEN3 Mask             */
+
+#define PWM_CAPCTL_CAPEN4_Pos            (4)                                               /*!< PWM_T::CAPCTL: CAPEN4 Position         */
+#define PWM_CAPCTL_CAPEN4_Msk            (0x1ul << PWM_CAPCTL_CAPEN4_Pos)                  /*!< PWM_T::CAPCTL: CAPEN4 Mask             */
+
+#define PWM_CAPCTL_CAPEN5_Pos            (5)                                               /*!< PWM_T::CAPCTL: CAPEN5 Position         */
+#define PWM_CAPCTL_CAPEN5_Msk            (0x1ul << PWM_CAPCTL_CAPEN5_Pos)                  /*!< PWM_T::CAPCTL: CAPEN5 Mask             */
+
+#define PWM_CAPCTL_CAPINVn_Pos           (8)                                               /*!< PWM_T::CAPCTL: CAPINVn Position        */
+#define PWM_CAPCTL_CAPINVn_Msk           (0x3ful << PWM_CAPCTL_CAPINVn_Pos)                /*!< PWM_T::CAPCTL: CAPINVn Mask            */
+
+#define PWM_CAPCTL_CAPINV0_Pos           (8)                                               /*!< PWM_T::CAPCTL: CAPINV0 Position        */
+#define PWM_CAPCTL_CAPINV0_Msk           (0x1ul << PWM_CAPCTL_CAPINV0_Pos)                 /*!< PWM_T::CAPCTL: CAPINV0 Mask            */
+
+#define PWM_CAPCTL_CAPINV1_Pos           (9)                                               /*!< PWM_T::CAPCTL: CAPINV1 Position        */
+#define PWM_CAPCTL_CAPINV1_Msk           (0x1ul << PWM_CAPCTL_CAPINV1_Pos)                 /*!< PWM_T::CAPCTL: CAPINV1 Mask            */
+
+#define PWM_CAPCTL_CAPINV2_Pos           (10)                                              /*!< PWM_T::CAPCTL: CAPINV2 Position        */
+#define PWM_CAPCTL_CAPINV2_Msk           (0x1ul << PWM_CAPCTL_CAPINV2_Pos)                 /*!< PWM_T::CAPCTL: CAPINV2 Mask            */
+
+#define PWM_CAPCTL_CAPINV3_Pos           (11)                                              /*!< PWM_T::CAPCTL: CAPINV3 Position        */
+#define PWM_CAPCTL_CAPINV3_Msk           (0x1ul << PWM_CAPCTL_CAPINV3_Pos)                 /*!< PWM_T::CAPCTL: CAPINV3 Mask            */
+
+#define PWM_CAPCTL_CAPINV4_Pos           (12)                                              /*!< PWM_T::CAPCTL: CAPINV4 Position        */
+#define PWM_CAPCTL_CAPINV4_Msk           (0x1ul << PWM_CAPCTL_CAPINV4_Pos)                 /*!< PWM_T::CAPCTL: CAPINV4 Mask            */
+
+#define PWM_CAPCTL_CAPINV5_Pos           (13)                                              /*!< PWM_T::CAPCTL: CAPINV5 Position        */
+#define PWM_CAPCTL_CAPINV5_Msk           (0x1ul << PWM_CAPCTL_CAPINV5_Pos)                 /*!< PWM_T::CAPCTL: CAPINV5 Mask            */
+
+#define PWM_CAPCTL_RCRLDENn_Pos          (16)                                              /*!< PWM_T::CAPCTL: RCRLDENn Position       */
+#define PWM_CAPCTL_RCRLDENn_Msk          (0x3ful << PWM_CAPCTL_RCRLDENn_Pos)               /*!< PWM_T::CAPCTL: RCRLDENn Mask           */
+
+#define PWM_CAPCTL_RCRLDEN0_Pos          (16)                                              /*!< PWM_T::CAPCTL: RCRLDEN0 Position       */
+#define PWM_CAPCTL_RCRLDEN0_Msk          (0x1ul << PWM_CAPCTL_RCRLDEN0_Pos)                /*!< PWM_T::CAPCTL: RCRLDEN0 Mask           */
+
+#define PWM_CAPCTL_RCRLDEN1_Pos          (17)                                              /*!< PWM_T::CAPCTL: RCRLDEN1 Position       */
+#define PWM_CAPCTL_RCRLDEN1_Msk          (0x1ul << PWM_CAPCTL_RCRLDEN1_Pos)                /*!< PWM_T::CAPCTL: RCRLDEN1 Mask           */
+
+#define PWM_CAPCTL_RCRLDEN2_Pos          (18)                                              /*!< PWM_T::CAPCTL: RCRLDEN2 Position       */
+#define PWM_CAPCTL_RCRLDEN2_Msk          (0x1ul << PWM_CAPCTL_RCRLDEN2_Pos)                /*!< PWM_T::CAPCTL: RCRLDEN2 Mask           */
+
+#define PWM_CAPCTL_RCRLDEN3_Pos          (19)                                              /*!< PWM_T::CAPCTL: RCRLDEN3 Position       */
+#define PWM_CAPCTL_RCRLDEN3_Msk          (0x1ul << PWM_CAPCTL_RCRLDEN3_Pos)                /*!< PWM_T::CAPCTL: RCRLDEN3 Mask           */
+
+#define PWM_CAPCTL_RCRLDEN4_Pos          (20)                                              /*!< PWM_T::CAPCTL: RCRLDEN4 Position       */
+#define PWM_CAPCTL_RCRLDEN4_Msk          (0x1ul << PWM_CAPCTL_RCRLDEN4_Pos)                /*!< PWM_T::CAPCTL: RCRLDEN4 Mask           */
+
+#define PWM_CAPCTL_RCRLDEN5_Pos          (21)                                              /*!< PWM_T::CAPCTL: RCRLDEN5 Position       */
+#define PWM_CAPCTL_RCRLDEN5_Msk          (0x1ul << PWM_CAPCTL_RCRLDEN5_Pos)                /*!< PWM_T::CAPCTL: RCRLDEN5 Mask           */
+
+#define PWM_CAPCTL_FCRLDENn_Pos          (24)                                              /*!< PWM_T::CAPCTL: FCRLDENn Position       */
+#define PWM_CAPCTL_FCRLDENn_Msk          (0x3ful << PWM_CAPCTL_FCRLDENn_Pos)               /*!< PWM_T::CAPCTL: FCRLDENn Mask           */
+
+#define PWM_CAPCTL_FCRLDEN0_Pos          (24)                                              /*!< PWM_T::CAPCTL: FCRLDEN0 Position       */
+#define PWM_CAPCTL_FCRLDEN0_Msk          (0x1ul << PWM_CAPCTL_FCRLDEN0_Pos)                /*!< PWM_T::CAPCTL: FCRLDEN0 Mask           */
+
+#define PWM_CAPCTL_FCRLDEN1_Pos          (25)                                              /*!< PWM_T::CAPCTL: FCRLDEN1 Position       */
+#define PWM_CAPCTL_FCRLDEN1_Msk          (0x1ul << PWM_CAPCTL_FCRLDEN1_Pos)                /*!< PWM_T::CAPCTL: FCRLDEN1 Mask           */
+
+#define PWM_CAPCTL_FCRLDEN2_Pos          (26)                                              /*!< PWM_T::CAPCTL: FCRLDEN2 Position       */
+#define PWM_CAPCTL_FCRLDEN2_Msk          (0x1ul << PWM_CAPCTL_FCRLDEN2_Pos)                /*!< PWM_T::CAPCTL: FCRLDEN2 Mask           */
+
+#define PWM_CAPCTL_FCRLDEN3_Pos          (27)                                              /*!< PWM_T::CAPCTL: FCRLDEN3 Position       */
+#define PWM_CAPCTL_FCRLDEN3_Msk          (0x1ul << PWM_CAPCTL_FCRLDEN3_Pos)                /*!< PWM_T::CAPCTL: FCRLDEN3 Mask           */
+
+#define PWM_CAPCTL_FCRLDEN4_Pos          (28)                                              /*!< PWM_T::CAPCTL: FCRLDEN4 Position       */
+#define PWM_CAPCTL_FCRLDEN4_Msk          (0x1ul << PWM_CAPCTL_FCRLDEN4_Pos)                /*!< PWM_T::CAPCTL: FCRLDEN4 Mask           */
+
+#define PWM_CAPCTL_FCRLDEN5_Pos          (29)                                              /*!< PWM_T::CAPCTL: FCRLDEN5 Position       */
+#define PWM_CAPCTL_FCRLDEN5_Msk          (0x1ul << PWM_CAPCTL_FCRLDEN5_Pos)                /*!< PWM_T::CAPCTL: FCRLDEN5 Mask           */
+
+#define PWM_CAPSTS_CRLIFOVn_Pos          (0)                                               /*!< PWM_T::CAPSTS: CRLIFOVn Position       */
+#define PWM_CAPSTS_CRLIFOVn_Msk          (0x3ful << PWM_CAPSTS_CRLIFOVn_Pos)               /*!< PWM_T::CAPSTS: CRLIFOVn Mask           */
+
+#define PWM_CAPSTS_CRLIFOV0_Pos          (0)                                               /*!< PWM_T::CAPSTS: CRLIFOV0 Position       */
+#define PWM_CAPSTS_CRLIFOV0_Msk          (0x1ul << PWM_CAPSTS_CRLIFOV0_Pos)                /*!< PWM_T::CAPSTS: CRLIFOV0 Mask           */
+
+#define PWM_CAPSTS_CRLIFOV1_Pos          (1)                                               /*!< PWM_T::CAPSTS: CRLIFOV1 Position       */
+#define PWM_CAPSTS_CRLIFOV1_Msk          (0x1ul << PWM_CAPSTS_CRLIFOV1_Pos)                /*!< PWM_T::CAPSTS: CRLIFOV1 Mask           */
+
+#define PWM_CAPSTS_CRLIFOV2_Pos          (2)                                               /*!< PWM_T::CAPSTS: CRLIFOV2 Position       */
+#define PWM_CAPSTS_CRLIFOV2_Msk          (0x1ul << PWM_CAPSTS_CRLIFOV2_Pos)                /*!< PWM_T::CAPSTS: CRLIFOV2 Mask           */
+
+#define PWM_CAPSTS_CRLIFOV3_Pos          (3)                                               /*!< PWM_T::CAPSTS: CRLIFOV3 Position       */
+#define PWM_CAPSTS_CRLIFOV3_Msk          (0x1ul << PWM_CAPSTS_CRLIFOV3_Pos)                /*!< PWM_T::CAPSTS: CRLIFOV3 Mask           */
+
+#define PWM_CAPSTS_CRLIFOV4_Pos          (4)                                               /*!< PWM_T::CAPSTS: CRLIFOV4 Position       */
+#define PWM_CAPSTS_CRLIFOV4_Msk          (0x1ul << PWM_CAPSTS_CRLIFOV4_Pos)                /*!< PWM_T::CAPSTS: CRLIFOV4 Mask           */
+
+#define PWM_CAPSTS_CRLIFOV5_Pos          (5)                                               /*!< PWM_T::CAPSTS: CRLIFOV5 Position       */
+#define PWM_CAPSTS_CRLIFOV5_Msk          (0x1ul << PWM_CAPSTS_CRLIFOV5_Pos)                /*!< PWM_T::CAPSTS: CRLIFOV5 Mask           */
+
+#define PWM_CAPSTS_CFLIFOVn_Pos          (8)                                               /*!< PWM_T::CAPSTS: CFLIFOVn Position       */
+#define PWM_CAPSTS_CFLIFOVn_Msk          (0x3ful << PWM_CAPSTS_CFLIFOVn_Pos)               /*!< PWM_T::CAPSTS: CFLIFOVn Mask           */
+
+#define PWM_CAPSTS_CFLIFOV0_Pos          (8)                                               /*!< PWM_T::CAPSTS: CFLIFOV0 Position       */
+#define PWM_CAPSTS_CFLIFOV0_Msk          (0x1ul << PWM_CAPSTS_CFLIFOV0_Pos)                /*!< PWM_T::CAPSTS: CFLIFOV0 Mask           */
+
+#define PWM_CAPSTS_CFLIFOV1_Pos          (9)                                               /*!< PWM_T::CAPSTS: CFLIFOV1 Position       */
+#define PWM_CAPSTS_CFLIFOV1_Msk          (0x1ul << PWM_CAPSTS_CFLIFOV1_Pos)                /*!< PWM_T::CAPSTS: CFLIFOV1 Mask           */
+
+#define PWM_CAPSTS_CFLIFOV2_Pos          (10)                                              /*!< PWM_T::CAPSTS: CFLIFOV2 Position       */
+#define PWM_CAPSTS_CFLIFOV2_Msk          (0x1ul << PWM_CAPSTS_CFLIFOV2_Pos)                /*!< PWM_T::CAPSTS: CFLIFOV2 Mask           */
+
+#define PWM_CAPSTS_CFLIFOV3_Pos          (11)                                              /*!< PWM_T::CAPSTS: CFLIFOV3 Position       */
+#define PWM_CAPSTS_CFLIFOV3_Msk          (0x1ul << PWM_CAPSTS_CFLIFOV3_Pos)                /*!< PWM_T::CAPSTS: CFLIFOV3 Mask           */
+
+#define PWM_CAPSTS_CFLIFOV4_Pos          (12)                                              /*!< PWM_T::CAPSTS: CFLIFOV4 Position       */
+#define PWM_CAPSTS_CFLIFOV4_Msk          (0x1ul << PWM_CAPSTS_CFLIFOV4_Pos)                /*!< PWM_T::CAPSTS: CFLIFOV4 Mask           */
+
+#define PWM_CAPSTS_CFLIFOV5_Pos          (13)                                              /*!< PWM_T::CAPSTS: CFLIFOV5 Position       */
+#define PWM_CAPSTS_CFLIFOV5_Msk          (0x1ul << PWM_CAPSTS_CFLIFOV5_Pos)                /*!< PWM_T::CAPSTS: CFLIFOV5 Mask           */
+
+#define PWM_RCAPDAT_RCAPDAT_Pos          (0)                                               /*!< PWM_T::RCAPDAT0: RCAPDAT Position      */
+#define PWM_RCAPDAT_RCAPDAT_Msk          (0xfffful << PWM_RCAPDAT_RCAPDAT_Pos)             /*!< PWM_T::RCAPDAT0: RCAPDAT Mask          */
+
+#define PWM_FCAPDAT_FCAPDAT_Pos          (0)                                               /*!< PWM_T::FCAPDAT0: FCAPDAT Position      */
+#define PWM_FCAPDAT_FCAPDAT_Msk          (0xfffful << PWM_FCAPDAT_FCAPDAT_Pos)             /*!< PWM_T::FCAPDAT0: FCAPDAT Mask          */
+
+#define PWM_RCAPDAT0_RCAPDAT_Pos         (0)                                               /*!< PWM_T::RCAPDAT0: RCAPDAT Position      */
+#define PWM_RCAPDAT0_RCAPDAT_Msk         (0xfffful << PWM_RCAPDAT0_RCAPDAT_Pos)            /*!< PWM_T::RCAPDAT0: RCAPDAT Mask          */
+
+#define PWM_FCAPDAT0_FCAPDAT_Pos         (0)                                               /*!< PWM_T::FCAPDAT0: FCAPDAT Position      */
+#define PWM_FCAPDAT0_FCAPDAT_Msk         (0xfffful << PWM_FCAPDAT0_FCAPDAT_Pos)            /*!< PWM_T::FCAPDAT0: FCAPDAT Mask          */
+
+#define PWM_RCAPDAT1_RCAPDAT_Pos         (0)                                               /*!< PWM_T::RCAPDAT1: RCAPDAT Position      */
+#define PWM_RCAPDAT1_RCAPDAT_Msk         (0xfffful << PWM_RCAPDAT1_RCAPDAT_Pos)            /*!< PWM_T::RCAPDAT1: RCAPDAT Mask          */
+
+#define PWM_FCAPDAT1_FCAPDAT_Pos         (0)                                               /*!< PWM_T::FCAPDAT1: FCAPDAT Position      */
+#define PWM_FCAPDAT1_FCAPDAT_Msk         (0xfffful << PWM_FCAPDAT1_FCAPDAT_Pos)            /*!< PWM_T::FCAPDAT1: FCAPDAT Mask          */
+
+#define PWM_RCAPDAT2_RCAPDAT_Pos         (0)                                               /*!< PWM_T::RCAPDAT2: RCAPDAT Position      */
+#define PWM_RCAPDAT2_RCAPDAT_Msk         (0xfffful << PWM_RCAPDAT2_RCAPDAT_Pos)            /*!< PWM_T::RCAPDAT2: RCAPDAT Mask          */
+
+#define PWM_FCAPDAT2_FCAPDAT_Pos         (0)                                               /*!< PWM_T::FCAPDAT2: FCAPDAT Position      */
+#define PWM_FCAPDAT2_FCAPDAT_Msk         (0xfffful << PWM_FCAPDAT2_FCAPDAT_Pos)            /*!< PWM_T::FCAPDAT2: FCAPDAT Mask          */
+
+#define PWM_RCAPDAT3_RCAPDAT_Pos         (0)                                               /*!< PWM_T::RCAPDAT3: RCAPDAT Position      */
+#define PWM_RCAPDAT3_RCAPDAT_Msk         (0xfffful << PWM_RCAPDAT3_RCAPDAT_Pos)            /*!< PWM_T::RCAPDAT3: RCAPDAT Mask          */
+
+#define PWM_FCAPDAT3_FCAPDAT_Pos         (0)                                               /*!< PWM_T::FCAPDAT3: FCAPDAT Position      */
+#define PWM_FCAPDAT3_FCAPDAT_Msk         (0xfffful << PWM_FCAPDAT3_FCAPDAT_Pos)            /*!< PWM_T::FCAPDAT3: FCAPDAT Mask          */
+
+#define PWM_RCAPDAT4_RCAPDAT_Pos         (0)                                               /*!< PWM_T::RCAPDAT4: RCAPDAT Position      */
+#define PWM_RCAPDAT4_RCAPDAT_Msk         (0xfffful << PWM_RCAPDAT4_RCAPDAT_Pos)            /*!< PWM_T::RCAPDAT4: RCAPDAT Mask          */
+
+#define PWM_FCAPDAT4_FCAPDAT_Pos         (0)                                               /*!< PWM_T::FCAPDAT4: FCAPDAT Position      */
+#define PWM_FCAPDAT4_FCAPDAT_Msk         (0xfffful << PWM_FCAPDAT4_FCAPDAT_Pos)            /*!< PWM_T::FCAPDAT4: FCAPDAT Mask          */
+
+#define PWM_RCAPDAT5_RCAPDAT_Pos         (0)                                               /*!< PWM_T::RCAPDAT5: RCAPDAT Position      */
+#define PWM_RCAPDAT5_RCAPDAT_Msk         (0xfffful << PWM_RCAPDAT5_RCAPDAT_Pos)            /*!< PWM_T::RCAPDAT5: RCAPDAT Mask          */
+
+#define PWM_FCAPDAT5_FCAPDAT_Pos         (0)                                               /*!< PWM_T::FCAPDAT5: FCAPDAT Position      */
+#define PWM_FCAPDAT5_FCAPDAT_Msk         (0xfffful << PWM_FCAPDAT5_FCAPDAT_Pos)            /*!< PWM_T::FCAPDAT5: FCAPDAT Mask          */
+
+#define PWM_PDMACTL_CHEN0_1_Pos          (0)                                               /*!< PWM_T::PDMACTL: CHEN0_1 Position       */
+#define PWM_PDMACTL_CHEN0_1_Msk          (0x1ul << PWM_PDMACTL_CHEN0_1_Pos)                /*!< PWM_T::PDMACTL: CHEN0_1 Mask           */
+
+#define PWM_PDMACTL_CAPMOD0_1_Pos        (1)                                               /*!< PWM_T::PDMACTL: CAPMOD0_1 Position     */
+#define PWM_PDMACTL_CAPMOD0_1_Msk        (0x3ul << PWM_PDMACTL_CAPMOD0_1_Pos)              /*!< PWM_T::PDMACTL: CAPMOD0_1 Mask         */
+
+#define PWM_PDMACTL_CAPORD0_1_Pos        (3)                                               /*!< PWM_T::PDMACTL: CAPORD0_1 Position     */
+#define PWM_PDMACTL_CAPORD0_1_Msk        (0x1ul << PWM_PDMACTL_CAPORD0_1_Pos)              /*!< PWM_T::PDMACTL: CAPORD0_1 Mask         */
+
+#define PWM_PDMACTL_CHSEL0_1_Pos         (4)                                               /*!< PWM_T::PDMACTL: CHSEL0_1 Position      */
+#define PWM_PDMACTL_CHSEL0_1_Msk         (0x1ul << PWM_PDMACTL_CHSEL0_1_Pos)               /*!< PWM_T::PDMACTL: CHSEL0_1 Mask          */
+
+#define PWM_PDMACTL_CHEN2_3_Pos          (8)                                               /*!< PWM_T::PDMACTL: CHEN2_3 Position       */
+#define PWM_PDMACTL_CHEN2_3_Msk          (0x1ul << PWM_PDMACTL_CHEN2_3_Pos)                /*!< PWM_T::PDMACTL: CHEN2_3 Mask           */
+
+#define PWM_PDMACTL_CAPMOD2_3_Pos        (9)                                               /*!< PWM_T::PDMACTL: CAPMOD2_3 Position     */
+#define PWM_PDMACTL_CAPMOD2_3_Msk        (0x3ul << PWM_PDMACTL_CAPMOD2_3_Pos)              /*!< PWM_T::PDMACTL: CAPMOD2_3 Mask         */
+
+#define PWM_PDMACTL_CAPORD2_3_Pos        (11)                                              /*!< PWM_T::PDMACTL: CAPORD2_3 Position     */
+#define PWM_PDMACTL_CAPORD2_3_Msk        (0x1ul << PWM_PDMACTL_CAPORD2_3_Pos)              /*!< PWM_T::PDMACTL: CAPORD2_3 Mask         */
+
+#define PWM_PDMACTL_CHSEL2_3_Pos         (12)                                              /*!< PWM_T::PDMACTL: CHSEL2_3 Position      */
+#define PWM_PDMACTL_CHSEL2_3_Msk         (0x1ul << PWM_PDMACTL_CHSEL2_3_Pos)               /*!< PWM_T::PDMACTL: CHSEL2_3 Mask          */
+
+#define PWM_PDMACTL_CHEN4_5_Pos          (16)                                              /*!< PWM_T::PDMACTL: CHEN4_5 Position       */
+#define PWM_PDMACTL_CHEN4_5_Msk          (0x1ul << PWM_PDMACTL_CHEN4_5_Pos)                /*!< PWM_T::PDMACTL: CHEN4_5 Mask           */
+
+#define PWM_PDMACTL_CAPMOD4_5_Pos        (17)                                              /*!< PWM_T::PDMACTL: CAPMOD4_5 Position     */
+#define PWM_PDMACTL_CAPMOD4_5_Msk        (0x3ul << PWM_PDMACTL_CAPMOD4_5_Pos)              /*!< PWM_T::PDMACTL: CAPMOD4_5 Mask         */
+
+#define PWM_PDMACTL_CAPORD4_5_Pos        (19)                                              /*!< PWM_T::PDMACTL: CAPORD4_5 Position     */
+#define PWM_PDMACTL_CAPORD4_5_Msk        (0x1ul << PWM_PDMACTL_CAPORD4_5_Pos)              /*!< PWM_T::PDMACTL: CAPORD4_5 Mask         */
+
+#define PWM_PDMACTL_CHSEL4_5_Pos         (20)                                              /*!< PWM_T::PDMACTL: CHSEL4_5 Position      */
+#define PWM_PDMACTL_CHSEL4_5_Msk         (0x1ul << PWM_PDMACTL_CHSEL4_5_Pos)               /*!< PWM_T::PDMACTL: CHSEL4_5 Mask          */
+
+#define PWM_PDMACAP0_1_CAPBUF_Pos        (0)                                               /*!< PWM_T::PDMACAP0_1: CAPBUF Position     */
+#define PWM_PDMACAP0_1_CAPBUF_Msk        (0xfffful << PWM_PDMACAP0_1_CAPBUF_Pos)           /*!< PWM_T::PDMACAP0_1: CAPBUF Mask         */
+
+#define PWM_PDMACAP2_3_CAPBUF_Pos        (0)                                               /*!< PWM_T::PDMACAP2_3: CAPBUF Position     */
+#define PWM_PDMACAP2_3_CAPBUF_Msk        (0xfffful << PWM_PDMACAP2_3_CAPBUF_Pos)           /*!< PWM_T::PDMACAP2_3: CAPBUF Mask         */
+
+#define PWM_PDMACAP4_5_CAPBUF_Pos        (0)                                               /*!< PWM_T::PDMACAP4_5: CAPBUF Position     */
+#define PWM_PDMACAP4_5_CAPBUF_Msk        (0xfffful << PWM_PDMACAP4_5_CAPBUF_Pos)           /*!< PWM_T::PDMACAP4_5: CAPBUF Mask         */
+
+#define PWM_CAPIEN_CAPRIENn_Pos          (0)                                               /*!< PWM_T::CAPIEN: CAPRIENn Position       */
+#define PWM_CAPIEN_CAPRIENn_Msk          (0x3ful << PWM_CAPIEN_CAPRIENn_Pos)               /*!< PWM_T::CAPIEN: CAPRIENn Mask           */
+
+#define PWM_CAPIEN_CAPRIEN0_Pos          (0)                                               /*!< PWM_T::CAPIEN: CAPRIEN0 Position       */
+#define PWM_CAPIEN_CAPRIEN0_Msk          (0x1ul << PWM_CAPIEN_CAPRIEN0_Pos)                /*!< PWM_T::CAPIEN: CAPRIEN0 Mask           */
+
+#define PWM_CAPIEN_CAPRIEN1_Pos          (1)                                               /*!< PWM_T::CAPIEN: CAPRIEN1 Position       */
+#define PWM_CAPIEN_CAPRIEN1_Msk          (0x1ul << PWM_CAPIEN_CAPRIEN1_Pos)                /*!< PWM_T::CAPIEN: CAPRIEN1 Mask           */
+
+#define PWM_CAPIEN_CAPRIEN2_Pos          (2)                                               /*!< PWM_T::CAPIEN: CAPRIEN2 Position       */
+#define PWM_CAPIEN_CAPRIEN2_Msk          (0x1ul << PWM_CAPIEN_CAPRIEN2_Pos)                /*!< PWM_T::CAPIEN: CAPRIEN2 Mask           */
+
+#define PWM_CAPIEN_CAPRIEN3_Pos          (3)                                               /*!< PWM_T::CAPIEN: CAPRIEN3 Position       */
+#define PWM_CAPIEN_CAPRIEN3_Msk          (0x1ul << PWM_CAPIEN_CAPRIEN3_Pos)                /*!< PWM_T::CAPIEN: CAPRIEN3 Mask           */
+
+#define PWM_CAPIEN_CAPRIEN4_Pos          (4)                                               /*!< PWM_T::CAPIEN: CAPRIEN4 Position       */
+#define PWM_CAPIEN_CAPRIEN4_Msk          (0x1ul << PWM_CAPIEN_CAPRIEN4_Pos)                /*!< PWM_T::CAPIEN: CAPRIEN4 Mask           */
+
+#define PWM_CAPIEN_CAPRIEN5_Pos          (5)                                               /*!< PWM_T::CAPIEN: CAPRIEN5 Position       */
+#define PWM_CAPIEN_CAPRIEN5_Msk          (0x1ul << PWM_CAPIEN_CAPRIEN5_Pos)                /*!< PWM_T::CAPIEN: CAPRIEN5 Mask           */
+
+#define PWM_CAPIEN_CAPFIENn_Pos          (8)                                               /*!< PWM_T::CAPIEN: CAPFIENn Position       */
+#define PWM_CAPIEN_CAPFIENn_Msk          (0x3ful << PWM_CAPIEN_CAPFIENn_Pos)               /*!< PWM_T::CAPIEN: CAPFIENn Mask           */
+
+#define PWM_CAPIEN_CAPFIEN0_Pos          (8)                                               /*!< PWM_T::CAPIEN: CAPFIEN0 Position       */
+#define PWM_CAPIEN_CAPFIEN0_Msk          (0x1ul << PWM_CAPIEN_CAPFIEN0_Pos)                /*!< PWM_T::CAPIEN: CAPFIEN0 Mask           */
+
+#define PWM_CAPIEN_CAPFIEN1_Pos          (9)                                               /*!< PWM_T::CAPIEN: CAPFIEN1 Position       */
+#define PWM_CAPIEN_CAPFIEN1_Msk          (0x1ul << PWM_CAPIEN_CAPFIEN1_Pos)                /*!< PWM_T::CAPIEN: CAPFIEN1 Mask           */
+
+#define PWM_CAPIEN_CAPFIEN2_Pos          (10)                                              /*!< PWM_T::CAPIEN: CAPFIEN2 Position       */
+#define PWM_CAPIEN_CAPFIEN2_Msk          (0x1ul << PWM_CAPIEN_CAPFIEN2_Pos)                /*!< PWM_T::CAPIEN: CAPFIEN2 Mask           */
+
+#define PWM_CAPIEN_CAPFIEN3_Pos          (11)                                              /*!< PWM_T::CAPIEN: CAPFIEN3 Position       */
+#define PWM_CAPIEN_CAPFIEN3_Msk          (0x1ul << PWM_CAPIEN_CAPFIEN3_Pos)                /*!< PWM_T::CAPIEN: CAPFIEN3 Mask           */
+
+#define PWM_CAPIEN_CAPFIEN4_Pos          (12)                                              /*!< PWM_T::CAPIEN: CAPFIEN4 Position       */
+#define PWM_CAPIEN_CAPFIEN4_Msk          (0x1ul << PWM_CAPIEN_CAPFIEN4_Pos)                /*!< PWM_T::CAPIEN: CAPFIEN4 Mask           */
+
+#define PWM_CAPIEN_CAPFIEN5_Pos          (13)                                              /*!< PWM_T::CAPIEN: CAPFIEN5 Position       */
+#define PWM_CAPIEN_CAPFIEN5_Msk          (0x1ul << PWM_CAPIEN_CAPFIEN5_Pos)                /*!< PWM_T::CAPIEN: CAPFIEN5 Mask           */
+
+#define PWM_CAPIF_CRLIFn_Pos             (0)                                               /*!< PWM_T::CAPIF: CRLIFn Position          */
+#define PWM_CAPIF_CRLIFn_Msk             (0x3ful << PWM_CAPIF_CRLIFn_Pos)                  /*!< PWM_T::CAPIF: CRLIFn Mask              */
+
+#define PWM_CAPIF_CRLIF0_Pos             (0)                                               /*!< PWM_T::CAPIF: CRLIF0 Position          */
+#define PWM_CAPIF_CRLIF0_Msk             (0x1ul << PWM_CAPIF_CRLIF0_Pos)                   /*!< PWM_T::CAPIF: CRLIF0 Mask              */
+
+#define PWM_CAPIF_CRLIF1_Pos             (1)                                               /*!< PWM_T::CAPIF: CRLIF1 Position          */
+#define PWM_CAPIF_CRLIF1_Msk             (0x1ul << PWM_CAPIF_CRLIF1_Pos)                   /*!< PWM_T::CAPIF: CRLIF1 Mask              */
+
+#define PWM_CAPIF_CRLIF2_Pos             (2)                                               /*!< PWM_T::CAPIF: CRLIF2 Position          */
+#define PWM_CAPIF_CRLIF2_Msk             (0x1ul << PWM_CAPIF_CRLIF2_Pos)                   /*!< PWM_T::CAPIF: CRLIF2 Mask              */
+
+#define PWM_CAPIF_CRLIF3_Pos             (3)                                               /*!< PWM_T::CAPIF: CRLIF3 Position          */
+#define PWM_CAPIF_CRLIF3_Msk             (0x1ul << PWM_CAPIF_CRLIF3_Pos)                   /*!< PWM_T::CAPIF: CRLIF3 Mask              */
+
+#define PWM_CAPIF_CRLIF4_Pos             (4)                                               /*!< PWM_T::CAPIF: CRLIF4 Position          */
+#define PWM_CAPIF_CRLIF4_Msk             (0x1ul << PWM_CAPIF_CRLIF4_Pos)                   /*!< PWM_T::CAPIF: CRLIF4 Mask              */
+
+#define PWM_CAPIF_CRLIF5_Pos             (5)                                               /*!< PWM_T::CAPIF: CRLIF5 Position          */
+#define PWM_CAPIF_CRLIF5_Msk             (0x1ul << PWM_CAPIF_CRLIF5_Pos)                   /*!< PWM_T::CAPIF: CRLIF5 Mask              */
+
+#define PWM_CAPIF_CFLIFn_Pos             (8)                                               /*!< PWM_T::CAPIF: CFLIFn Position          */
+#define PWM_CAPIF_CFLIFn_Msk             (0x3ful << PWM_CAPIF_CFLIFn_Pos)                  /*!< PWM_T::CAPIF: CFLIFn Mask              */
+
+#define PWM_CAPIF_CFLIF0_Pos             (8)                                               /*!< PWM_T::CAPIF: CFLIF0 Position          */
+#define PWM_CAPIF_CFLIF0_Msk             (0x1ul << PWM_CAPIF_CFLIF0_Pos)                   /*!< PWM_T::CAPIF: CFLIF0 Mask              */
+
+#define PWM_CAPIF_CFLIF1_Pos             (9)                                               /*!< PWM_T::CAPIF: CFLIF1 Position          */
+#define PWM_CAPIF_CFLIF1_Msk             (0x1ul << PWM_CAPIF_CFLIF1_Pos)                   /*!< PWM_T::CAPIF: CFLIF1 Mask              */
+
+#define PWM_CAPIF_CFLIF2_Pos             (10)                                              /*!< PWM_T::CAPIF: CFLIF2 Position          */
+#define PWM_CAPIF_CFLIF2_Msk             (0x1ul << PWM_CAPIF_CFLIF2_Pos)                   /*!< PWM_T::CAPIF: CFLIF2 Mask              */
+
+#define PWM_CAPIF_CFLIF3_Pos             (11)                                              /*!< PWM_T::CAPIF: CFLIF3 Position          */
+#define PWM_CAPIF_CFLIF3_Msk             (0x1ul << PWM_CAPIF_CFLIF3_Pos)                   /*!< PWM_T::CAPIF: CFLIF3 Mask              */
+
+#define PWM_CAPIF_CFLIF4_Pos             (12)                                              /*!< PWM_T::CAPIF: CFLIF4 Position          */
+#define PWM_CAPIF_CFLIF4_Msk             (0x1ul << PWM_CAPIF_CFLIF4_Pos)                   /*!< PWM_T::CAPIF: CFLIF4 Mask              */
+
+#define PWM_CAPIF_CFLIF5_Pos             (13)                                              /*!< PWM_T::CAPIF: CFLIF5 Position          */
+#define PWM_CAPIF_CFLIF5_Msk             (0x1ul << PWM_CAPIF_CFLIF5_Pos)                   /*!< PWM_T::CAPIF: CFLIF5 Mask              */
+
+#define PWM_PBUF_PBUF_Pos                (0)                                               /*!< PWM_T::PBUF0: PBUF Position            */
+#define PWM_PBUF_PBUF_Msk                (0xfffful << PWM_PBUF_PBUF_Pos)                   /*!< PWM_T::PBUF0: PBUF Mask                */
+
+#define PWM_PBUF0_PBUF_Pos               (0)                                               /*!< PWM_T::PBUF0: PBUF Position            */
+#define PWM_PBUF0_PBUF_Msk               (0xfffful << PWM_PBUF0_PBUF_Pos)                  /*!< PWM_T::PBUF0: PBUF Mask                */
+
+#define PWM_PBUF2_PBUF_Pos               (0)                                               /*!< PWM_T::PBUF2: PBUF Position            */
+#define PWM_PBUF2_PBUF_Msk               (0xfffful << PWM_PBUF2_PBUF_Pos)                  /*!< PWM_T::PBUF2: PBUF Mask                */
+
+#define PWM_PBUF4_PBUF_Pos               (0)                                               /*!< PWM_T::PBUF4: PBUF Position            */
+#define PWM_PBUF4_PBUF_Msk               (0xfffful << PWM_PBUF4_PBUF_Pos)                  /*!< PWM_T::PBUF4: PBUF Mask                */
+
+#define PWM_CMPBUF_CMPBUF_Pos            (0)                                               /*!< PWM_T::CMPBUF0: CMPBUF Position        */
+#define PWM_CMPBUF_CMPBUF_Msk            (0xfffful << PWM_CMPBUF_CMPBUF_Pos)               /*!< PWM_T::CMPBUF0: CMPBUF Mask            */
+
+#define PWM_CMPBUF0_CMPBUF_Pos           (0)                                               /*!< PWM_T::CMPBUF0: CMPBUF Position        */
+#define PWM_CMPBUF0_CMPBUF_Msk           (0xfffful << PWM_CMPBUF0_CMPBUF_Pos)              /*!< PWM_T::CMPBUF0: CMPBUF Mask            */
+
+#define PWM_CMPBUF1_CMPBUF_Pos           (0)                                               /*!< PWM_T::CMPBUF1: CMPBUF Position        */
+#define PWM_CMPBUF1_CMPBUF_Msk           (0xfffful << PWM_CMPBUF1_CMPBUF_Pos)              /*!< PWM_T::CMPBUF1: CMPBUF Mask            */
+
+#define PWM_CMPBUF2_CMPBUF_Pos           (0)                                               /*!< PWM_T::CMPBUF2: CMPBUF Position        */
+#define PWM_CMPBUF2_CMPBUF_Msk           (0xfffful << PWM_CMPBUF2_CMPBUF_Pos)              /*!< PWM_T::CMPBUF2: CMPBUF Mask            */
+
+#define PWM_CMPBUF3_CMPBUF_Pos           (0)                                               /*!< PWM_T::CMPBUF3: CMPBUF Position        */
+#define PWM_CMPBUF3_CMPBUF_Msk           (0xfffful << PWM_CMPBUF3_CMPBUF_Pos)              /*!< PWM_T::CMPBUF3: CMPBUF Mask            */
+
+#define PWM_CMPBUF4_CMPBUF_Pos           (0)                                               /*!< PWM_T::CMPBUF4: CMPBUF Position        */
+#define PWM_CMPBUF4_CMPBUF_Msk           (0xfffful << PWM_CMPBUF4_CMPBUF_Pos)              /*!< PWM_T::CMPBUF4: CMPBUF Mask            */
+
+#define PWM_CMPBUF5_CMPBUF_Pos           (0)                                               /*!< PWM_T::CMPBUF5: CMPBUF Position        */
+#define PWM_CMPBUF5_CMPBUF_Msk           (0xfffful << PWM_CMPBUF5_CMPBUF_Pos)              /*!< PWM_T::CMPBUF5: CMPBUF Mask            */
+
+/** @} PWM_CONST */
+/** @} end of PWM register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __PWM_REG_H__ */

--- a/hal/m258ke/nuvoton/qspi_reg.h
+++ b/hal/m258ke/nuvoton/qspi_reg.h
@@ -1,0 +1,593 @@
+/**************************************************************************//**
+ * @file     qspi_reg.h
+ * @version  V1.00
+ * @brief    QSPI register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __QSPI_REG_H__
+#define __QSPI_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup QSPI Quad Serial Peripheral Interface Controller (QSPI)
+    Memory Mapped Structure for QSPI Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var QSPI_T::CTL
+     * Offset: 0x00  QSPI Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |QSPIEN    |QSPI Transfer Control Enable Bit
+     * |        |          |In Master mode, the transfer will start when there is data in the FIFO buffer after this bit is set to 1
+     * |        |          |In Slave mode, this device is ready to receive data when this bit is set to 1.
+     * |        |          |0 = Transfer control Disabled.
+     * |        |          |1 = Transfer control Enabled.
+     * |        |          |Note: Before changing the configurations of QSPIx_CTL, QSPIx_CLKDIV, QSPIx_SSCTL and QSPIx_FIFOCTL registers, user shall clear the QSPIEN (QSPIx_CTL[0]) and confirm the QSPIENSTS (QSPIx_STATUS[15]) is 0.
+     * |[1]     |RXNEG     |Receive on Negative Edge
+     * |        |          |0 = Received data input signal is latched on the rising edge of QSPI bus clock.
+     * |        |          |1 = Received data input signal is latched on the falling edge of QSPI bus clock.
+     * |[2]     |TXNEG     |Transmit on Negative Edge
+     * |        |          |0 = Transmitted data output signal is changed on the rising edge of QSPI bus clock.
+     * |        |          |1 = Transmitted data output signal is changed on the falling edge of QSPI bus clock.
+     * |[3]     |CLKPOL    |Clock Polarity
+     * |        |          |0 = QSPI bus clock is idle low.
+     * |        |          |1 = QSPI bus clock is idle high.
+     * |[7:4]   |SUSPITV   |Suspend Interval (Master Only)
+     * |        |          |The four bits provide configurable suspend interval between two successive transmit/receive transaction in a transfer
+     * |        |          |The definition of the suspend interval is the interval between the last clock edge of the preceding transaction word and the first clock edge of the following transaction word
+     * |        |          |The default value is 0x3
+     * |        |          |The period of the suspend interval is obtained according to the following equation.
+     * |        |          |(SUSPITV[3:0] + 0.5) * period of QSPICLK clock cycle
+     * |        |          |Example:
+     * |        |          |SUSPITV = 0x0 .... 0.5 QSPICLK clock cycle.
+     * |        |          |SUSPITV = 0x1 .... 1.5 QSPICLK clock cycle.
+     * |        |          |.....
+     * |        |          |SUSPITV = 0xE .... 14.5 QSPICLK clock cycle.
+     * |        |          |SUSPITV = 0xF .... 15.5 QSPICLK clock cycle.
+     * |[12:8]  |DWIDTH    |Data Width
+     * |        |          |This field specifies how many bits can be transmitted / received in one transaction
+     * |        |          |The minimum bit length is 8 bits and can up to 32 bits.
+     * |        |          |DWIDTH = 0x08 .... 8 bits.
+     * |        |          |DWIDTH = 0x09 .... 9 bits.
+     * |        |          |.....
+     * |        |          |DWIDTH = 0x1F .... 31 bits.
+     * |        |          |DWIDTH = 0x00 .... 32 bits.
+     * |[13]    |LSB       |Send LSB First
+     * |        |          |0 = The MSB, which bit of transmit/receive register depends on the setting of DWIDTH, is transmitted/received first.
+     * |        |          |1 = The LSB, bit 0 of the QSPI TX register, is sent first to the QSPI data output pin, and the first bit received from the QSPI data input pin will be put in the LSB position of the RX register (bit 0 of QSPI_RX).
+     * |[14]    |HALFDPX   |QSPI Half-duplex Transfer Enable Bit
+     * |        |          |This bit is used to select full-duplex or half-duplex for QSPI transfer
+     * |        |          |The bit field DATDIR (QSPIx_CTL[20]) can be used to set the data direction in half-duplex transfer.
+     * |        |          |0 = QSPI operates in full-duplex transfer.
+     * |        |          |1 = QSPI operates in half-duplex transfer.
+     * |[15]    |RXONLY    |Receive-only Mode Enable Bit (Master Only)
+     * |        |          |This bit field is only available in Master mode
+     * |        |          |In receive-only mode, QSPI Master will generate QSPI bus clock continuously for receiving data bit from QSPI slave device and assert the BUSY status.
+     * |        |          |0 = Receive-only mode Disabled.
+     * |        |          |1 = Receive-only mode Enabled.
+     * |[16]    |TWOBIT    |2-bit Transfer Mode Enable Bit (Only Supported in QSPI0)
+     * |        |          |0 = 2-Bit Transfer mode Disabled.
+     * |        |          |1 = 2-Bit Transfer mode Enabled.
+     * |        |          |Note: When 2-Bit Transfer mode is enabled, the first serial transmitted bit data is from the first FIFO buffer data, and the 2nd serial transmitted bit data is from the second FIFO buffer data
+     * |        |          |As the same as transmitted function, the first received bit data is stored into the first FIFO buffer and the 2nd received bit data is stored into the second FIFO buffer at the same time.
+     * |[17]    |UNITIEN   |Unit Transfer Interrupt Enable Bit
+     * |        |          |0 = QSPI unit transfer interrupt Disabled.
+     * |        |          |1 = QSPI unit transfer interrupt Enabled.
+     * |[18]    |SLAVE     |Slave Mode Control
+     * |        |          |0 = Master mode.
+     * |        |          |1 = Slave mode.
+     * |[19]    |REORDER   |Byte Reorder Function Enable Bit
+     * |        |          |0 = Byte Reorder function Disabled.
+     * |        |          |1 = Byte Reorder function Enabled
+     * |        |          |A byte suspend interval will be inserted among each byte
+     * |        |          |The period of the byte suspend interval depends on the setting of SUSPITV.
+     * |        |          |Note: Byte Reorder function is only available if DWIDTH is defined as 16, 24, and 32 bits.
+     * |[20]    |DATDIR    |Data Port Direction Control
+     * |        |          |This bit is used to select the data input/output direction in half-duplex transfer and Dual/Quad transfer
+     * |        |          |0 = QSPI data is input direction.
+     * |        |          |1 = QSPI data is output direction.
+     * |[21]    |DUALIOEN  |Dual I/O Mode Enable Bit (Only Supported in QSPI0)
+     * |        |          |0 = Dual I/O mode Disabled.
+     * |        |          |1 = Dual I/O mode Enabled.
+     * |[22]    |QUADIOEN  |Quad I/O Mode Enable Bit (Only Supported in QSPI0)
+     * |        |          |0 = Quad I/O mode Disabled.
+     * |        |          |1 = Quad I/O mode Enabled.
+     * @var QSPI_T::CLKDIV
+     * Offset: 0x04  QSPI Clock Divider Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |DIVIDER   |Clock Divider
+     * |        |          |The value in this field is the frequency divider for generating the peripheral clock, fspi_eclk, and the QSPI bus clock of QSPI Master
+     * |        |          |The frequency is obtained according to the following equation.
+     * |        |          |where
+     * |        |          |is the peripheral clock source, which is defined in the clock control register, CLK_CLKSEL2.
+     * @var QSPI_T::SSCTL
+     * Offset: 0x08  QSPI Slave Select Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SS        |Slave Selection Control (Master Only)
+     * |        |          |If AUTOSS bit is cleared to 0,
+     * |        |          |0 = set the QSPIx_SS line to inactive state.
+     * |        |          |1 = set the QSPIx_SS line to active state.
+     * |        |          |If the AUTOSS bit is set to 1,
+     * |        |          |0 = Keep the QSPIx_SS line at inactive state.
+     * |        |          |1 = QSPIx_SS line will be automatically driven to active state for the duration of data transfer, and will be driven to inactive state for the rest of the time
+     * |        |          |The active state of QSPIx_SS is specified in SSACTPOL (QSPIx_SSCTL[2]).
+     * |[2]     |SSACTPOL  |Slave Selection Active Polarity
+     * |        |          |This bit defines the active polarity of slave selection signal (QSPIx_SS).
+     * |        |          |0 = The slave selection signal QSPIx_SS is active low.
+     * |        |          |1 = The slave selection signal QSPIx_SS is active high.
+     * |[3]     |AUTOSS    |Automatic Slave Selection Function Enable Bit (Master Only)
+     * |        |          |0 = Automatic slave selection function Disabled
+     * |        |          |Slave selection signal will be asserted/de-asserted according to SS (QSPIx_SSCTL[0]).
+     * |        |          |1 = Automatic slave selection function Enabled.
+     * |[4]     |SLV3WIRE  |Slave 3-wire Mode Enable Bit (Only Supported in QSPI0)
+     * |        |          |Slave 3-wire mode is only available in QSPI0
+     * |        |          |In Slave 3-wire mode, the QSPI controller can work with 3-wire interface including QSPI0_CLK, QSPI0_MISO and QSPI0_MOSI pins.
+     * |        |          |0 = 4-wire bi-direction interface.
+     * |        |          |1 = 3-wire bi-direction interface.
+     * |[5]     |SLVTOIEN  |Slave Mode Time-out Interrupt Enable Bit (Only Supported in QSPI0)
+     * |        |          |0 = Slave mode time-out interrupt Disabled.
+     * |        |          |1 = Slave mode time-out interrupt Enabled.
+     * |[6]     |SLVTORST  |Slave Mode Time-out Reset Control (Only Supported in QSPI0)
+     * |        |          |0 = When Slave mode time-out event occurs, the TX and RX control circuit will not be reset.
+     * |        |          |1 = When Slave mode time-out event occurs, the TX and RX control circuit will be reset by hardware.
+     * |[8]     |SLVBEIEN  |Slave Mode Bit Count Error Interrupt Enable Bit
+     * |        |          |0 = Slave mode bit count error interrupt Disabled.
+     * |        |          |1 = Slave mode bit count error interrupt Enabled.
+     * |[9]     |SLVURIEN  |Slave Mode TX Under Run Interrupt Enable Bit
+     * |        |          |0 = Slave mode TX under run interrupt Disabled.
+     * |        |          |1 = Slave mode TX under run interrupt Enabled.
+     * |[12]    |SSACTIEN  |Slave Select Active Interrupt Enable Bit
+     * |        |          |0 = Slave select active interrupt Disabled.
+     * |        |          |1 = Slave select active interrupt Enabled.
+     * |[13]    |SSINAIEN  |Slave Select Inactive Interrupt Enable Bit
+     * |        |          |0 = Slave select inactive interrupt Disabled.
+     * |        |          |1 = Slave select inactive interrupt Enabled.
+     * |[31:16] |SLVTOCNT  |Slave Mode Time-out Period (Only Supported in QSPI0)
+     * |        |          |In Slave mode, these bits indicate the time-out period when there is bus clock input during slave select active
+     * |        |          |The clock source of the time-out counter is Slave peripheral clock
+     * |        |          |If the value is 0, it indicates the slave mode time-out function is disabled.
+     * @var QSPI_T::PDMACTL
+     * Offset: 0x0C  QSPI PDMA Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TXPDMAEN  |Transmit PDMA Enable Bit
+     * |        |          |0 = Transmit PDMA function Disabled.
+     * |        |          |1 = Transmit PDMA function Enabled.
+     * |        |          |Note: In QSPI Master mode with full duplex transfer, if both TX and RX PDMA functions are enabled, RX PDMA function cannot be enabled prior to TX PDMA function
+     * |        |          |User can enable TX PDMA function firstly or enable both functions simultaneously.
+     * |[1]     |RXPDMAEN  |Receive PDMA Enable Bit
+     * |        |          |0 = Receive PDMA function Disabled.
+     * |        |          |1 = Receive PDMA function Enabled.
+     * |[2]     |PDMARST   |PDMA Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the PDMA control logic of the QSPI controller. This bit will be automatically cleared to 0.
+     * @var QSPI_T::FIFOCTL
+     * Offset: 0x10  QSPI FIFO Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RXRST     |Receive Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset receive FIFO pointer and receive circuit
+     * |        |          |The RXFULL bit will be cleared to 0 and the RXEMPTY bit will be set to 1
+     * |        |          |This bit will be cleared to 0 by hardware about 3 system clock cycles + 2 peripheral clock cycles after it is set to 1
+     * |        |          |User can read TXRXRST (QSPIx_STATUS[23]) to check if reset is accomplished or not.
+     * |[1]     |TXRST     |Transmit Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset transmit FIFO pointer and transmit circuit
+     * |        |          |The TXFULL bit will be cleared to 0 and the TXEMPTY bit will be set to 1
+     * |        |          |This bit will be cleared to 0 by hardware about 3 system clock cycles + 2 peripheral clock cycles after it is set to 1
+     * |        |          |User can read TXRXRST (QSPIx_STATUS[23]) to check if reset is accomplished or not.
+     * |        |          |Note: If TX underflow event occurs in QSPI Slave mode, this bit can be used to make QSPI return to idle state.
+     * |[2]     |RXTHIEN   |Receive FIFO Threshold Interrupt Enable Bit
+     * |        |          |0 = RX FIFO threshold interrupt Disabled.
+     * |        |          |1 = RX FIFO threshold interrupt Enabled.
+     * |[3]     |TXTHIEN   |Transmit FIFO Threshold Interrupt Enable Bit
+     * |        |          |0 = TX FIFO threshold interrupt Disabled.
+     * |        |          |1 = TX FIFO threshold interrupt Enabled.
+     * |[4]     |RXTOIEN   |Slave Receive Time-out Interrupt Enable Bit
+     * |        |          |0 = Receive time-out interrupt Disabled.
+     * |        |          |1 = Receive time-out interrupt Enabled.
+     * |[5]     |RXOVIEN   |Receive FIFO Overrun Interrupt Enable Bit
+     * |        |          |0 = Receive FIFO overrun interrupt Disabled.
+     * |        |          |1 = Receive FIFO overrun interrupt Enabled.
+     * |[6]     |TXUFPOL   |TX Underflow Data Polarity
+     * |        |          |0 = The QSPI data out is keep 0 if there is TX underflow event in Slave mode.
+     * |        |          |1 = The QSPI data out is keep 1 if there is TX underflow event in Slave mode.
+     * |        |          |Note:
+     * |        |          |1. The TX underflow event occurs if there is no any data in TX FIFO when the slave selection signal is active.
+     * |        |          |2. When TX underflow event occurs, QSPIx_MISO pin state will be determined by this setting even though TX FIFO is not empty afterward
+     * |        |          |Data stored in TX FIFO will be sent through QSPIx_MISO pin in the next transfer frame.
+     * |[7]     |TXUFIEN   |TX Underflow Interrupt Enable Bit
+     * |        |          |When TX underflow event occurs in Slave mode, TXUFIF (QSPIx_STATUS[19]) will be set to 1
+     * |        |          |This bit is used to enable the TX underflow interrupt.
+     * |        |          |0 = Slave TX underflow interrupt Disabled.
+     * |        |          |1 = Slave TX underflow interrupt Enabled.
+     * |[8]     |RXFBCLR   |Receive FIFO Buffer Clear
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear receive FIFO pointer
+     * |        |          |The RXFULL bit will be cleared to 0 and the RXEMPTY bit will be set to 1
+     * |        |          |This bit will be cleared to 0 by hardware about 1 system clock after it is set to 1.
+     * |        |          |Note: The RX shift register will not be cleared.
+     * |[9]     |TXFBCLR   |Transmit FIFO Buffer Clear
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear transmit FIFO pointer
+     * |        |          |The TXFULL bit will be cleared to 0 and the TXEMPTY bit will be set to 1
+     * |        |          |This bit will be cleared to 0 by hardware about 1 system clock after it is set to 1.
+     * |        |          |Note: The TX shift register will not be cleared.
+     * |[26:24] |RXTH      |Receive FIFO Threshold
+     * |        |          |If the valid data count of the receive FIFO buffer is larger than the RXTH setting, the RXTHIF bit will be set to 1, else the RXTHIF bit will be cleared to 0
+     * |[30:28] |TXTH      |Transmit FIFO Threshold
+     * |        |          |If the valid data count of the transmit FIFO buffer is less than or equal to the TXTH setting, the TXTHIF bit will be set to 1, else the TXTHIF bit will be cleared to 0
+     * @var QSPI_T::STATUS
+     * Offset: 0x14  QSPI Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BUSY      |Busy Status (Read Only)
+     * |        |          |0 = QSPI controller is in idle state.
+     * |        |          |1 = QSPI controller is in busy state.
+     * |        |          |The following listing are the bus busy conditions:
+     * |        |          |a. QSPIx_CTL[0] = 1 and TXEMPTY = 0.
+     * |        |          |b
+     * |        |          |For QSPI Master mode, QSPIx_CTL[0] = 1 and TXEMPTY = 1 but the current transaction is not finished yet.
+     * |        |          |c. For QSPI Master mode, QSPIx_CTL[0] = 1 and RXONLY = 1.
+     * |        |          |d
+     * |        |          |For QSPI Slave mode, the QSPIx_CTL[0] = 1 and there is serial clock input into the QSPI core logic when slave select is active.
+     * |        |          |For QSPI Slave mode, the QSPIx_CTL[0] = 1 and the transmit buffer or transmit shift register is not empty even if the slave select is inactive.
+     * |[1]     |UNITIF    |Unit Transfer Interrupt Flag
+     * |        |          |0 = No transaction has been finished since this bit was cleared to 0.
+     * |        |          |1 = QSPI controller has finished one unit transfer.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[2]     |SSACTIF   |Slave Select Active Interrupt Flag
+     * |        |          |0 = Slave select active interrupt was cleared or not occurred.
+     * |        |          |1 = Slave select active interrupt event occurred.
+     * |        |          |Note: Only available in Slave mode. This bit will be cleared by writing 1 to it.
+     * |[3]     |SSINAIF   |Slave Select Inactive Interrupt Flag
+     * |        |          |0 = Slave select inactive interrupt was cleared or not occurred.
+     * |        |          |1 = Slave select inactive interrupt event occurred.
+     * |        |          |Note: Only available in Slave mode. This bit will be cleared by writing 1 to it.
+     * |[4]     |SSLINE    |Slave Select Line Bus Status (Read Only)
+     * |        |          |0 = The slave select line status is 0.
+     * |        |          |1 = The slave select line status is 1.
+     * |        |          |Note: This bit is only available in Slave mode
+     * |        |          |If SSACTPOL (QSPIx_SSCTL[2]) is set 0, and the SSLINE is 1, the QSPI slave select is in inactive status.
+     * |[5]     |SLVTOIF   |Slave Time-out Interrupt Flag (Only Supported in QSPI0)
+     * |        |          |When the slave select is active and the value of SLVTOCNT is not 0, as the bus clock is detected, the slave time-out counter in QSPI controller logic will be started
+     * |        |          |When the value of time-out counter is greater than or equal to the value of SLVTOCNT (QSPI_SSCTL[31:16]) before one transaction is done, the slave time-out interrupt event will be asserted.
+     * |        |          |0 = Slave time-out is not active.
+     * |        |          |1 = Slave time-out is active.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[6]     |SLVBEIF   |Slave Mode Bit Count Error Interrupt Flag
+     * |        |          |In Slave mode, when the slave select line goes to inactive state, if bit counter is mismatch with DWIDTH, this interrupt flag will be set to 1.
+     * |        |          |0 = No Slave mode bit count error event.
+     * |        |          |1 = Slave mode bit count error event occurs.
+     * |        |          |Note: If the slave select active but there is no any bus clock input, the SLVBEIF also active when the slave select goes to inactive state
+     * |        |          |This bit will be cleared by writing 1 to it.
+     * |[7]     |SLVURIF   |Slave Mode TX Under Run Interrupt Flag
+     * |        |          |In Slave mode, if TX underflow event occurs and the slave select line goes to inactive state, this interrupt flag will be set to 1.
+     * |        |          |0 = No Slave TX under run event.
+     * |        |          |1 = Slave TX under run event occurs.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[8]     |RXEMPTY   |Receive FIFO Buffer Empty Indicator (Read Only)
+     * |        |          |0 = Receive FIFO buffer is not empty.
+     * |        |          |1 = Receive FIFO buffer is empty.
+     * |[9]     |RXFULL    |Receive FIFO Buffer Full Indicator (Read Only)
+     * |        |          |0 = Receive FIFO buffer is not full.
+     * |        |          |1 = Receive FIFO buffer is full.
+     * |[10]    |RXTHIF    |Receive FIFO Threshold Interrupt Flag (Read Only)
+     * |        |          |0 = The valid data count within the receive FIFO buffer is smaller than or equal to the setting value of RXTH.
+     * |        |          |1 = The valid data count within the receive FIFO buffer is larger than the setting value of RXTH.
+     * |[11]    |RXOVIF    |Receive FIFO Overrun Interrupt Flag
+     * |        |          |When the receive FIFO buffer is full, the follow-up data will be dropped and this bit will be set to 1.
+     * |        |          |0 = No FIFO is overrun.
+     * |        |          |1 = Receive FIFO is overrun.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[12]    |RXTOIF    |Receive Time-out Interrupt Flag
+     * |        |          |0 = No receive FIFO time-out event.
+     * |        |          |1 = Receive FIFO buffer is not empty and no read operation on receive FIFO buffer over 64 QSPI peripheral clock periods in Master mode or over 576 QSPI peripheral clock periods in Slave mode
+     * |        |          |When the received FIFO buffer is read by software, the time-out status will be cleared automatically.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[15]    |QSPIENSTS |QSPI Enable Status (Read Only)
+     * |        |          |0 = The QSPI controller is disabled.
+     * |        |          |1 = The QSPI controller is enabled.
+     * |        |          |Note: The QSPI peripheral clock is asynchronous with the system clock
+     * |        |          |In order to make sure the QSPI control logic is disabled, this bit indicates the real status of QSPI controller.
+     * |[16]    |TXEMPTY   |Transmit FIFO Buffer Empty Indicator (Read Only)
+     * |        |          |0 = Transmit FIFO buffer is not empty.
+     * |        |          |1 = Transmit FIFO buffer is empty.
+     * |[17]    |TXFULL    |Transmit FIFO Buffer Full Indicator (Read Only)
+     * |        |          |0 = Transmit FIFO buffer is not full.
+     * |        |          |1 = Transmit FIFO buffer is full.
+     * |[18]    |TXTHIF    |Transmit FIFO Threshold Interrupt Flag (Read Only)
+     * |        |          |0 = The valid data count within the transmit FIFO buffer is larger than the setting value of TXTH.
+     * |        |          |1 = The valid data count within the transmit FIFO buffer is less than or equal to the setting value of TXTH.
+     * |[19]    |TXUFIF    |TX Underflow Interrupt Flag
+     * |        |          |When the TX underflow event occurs, this bit will be set to 1, the state of data output pin depends on the setting of TXUFPOL.
+     * |        |          |0 = No effect.
+     * |        |          |1 = No data in Transmit FIFO and TX shift register when the slave selection signal is active.
+     * |        |          |Note 1: This bit will be cleared by writing 1 to it.
+     * |        |          |Note 2: If reset slave's transmission circuit when slave selection signal is active, this flag will be set to 1 after 2 peripheral clock cycles + 3 system clock cycles since the reset operation is done.
+     * |[23]    |TXRXRST   |TX or RX Reset Status (Read Only)
+     * |        |          |0 = The reset function of TXRST or RXRST is done.
+     * |        |          |1 = Doing the reset function of TXRST or RXRST.
+     * |        |          |Note: Both the reset operations of TXRST and RXRST need 3 system clock cycles + 2 peripheral clock cycles
+     * |        |          |User can check the status of this bit to monitor the reset function is doing or done.
+     * |[27:24] |RXCNT     |Receive FIFO Data Count (Read Only)
+     * |        |          |This bit field indicates the valid data count of receive FIFO buffer.
+     * |[31:28] |TXCNT     |Transmit FIFO Data Count (Read Only)
+     * |        |          |This bit field indicates the valid data count of transmit FIFO buffer.
+     * @var QSPI_T::TX
+     * Offset: 0x20  QSPI Data Transmit Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |TX        |Data Transmit Register
+     * |        |          |The data transmit registers pass through the transmitted data into the 4-level transmit FIFO buffers
+     * |        |          |The number of valid bits depends on the setting of DWIDTH (QSPIx_CTL[12:8]) in QSPI mode.
+     * |        |          |In QSPI mode, if DWIDTH is set to 0x08, the bits TX[7:0] will be transmitted
+     * |        |          |If DWIDTH is set to 0x00 , the QSPI controller will perform a 32-bit transfer.
+     * |        |          |If WDWIDTH is set as 0x0, 0x1, or 0x3, all bits of this field are valid
+     * |        |          |Note: In Master mode, QSPI controller will start to transfer the QSPI bus clock after 1 APB clock and 6 peripheral clock cycles after user writes to this register.
+     * @var QSPI_T::RX
+     * Offset: 0x30  QSPI Data Receive Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |RX        |Data Receive Register
+     * |        |          |There are 4-level FIFO buffers in this controller
+     * |        |          |The data receive register holds the data received from QSPI data input pin
+     * |        |          |This is a read only register.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] QSPI Control Register                                             */
+    __IO uint32_t CLKDIV;                /*!< [0x0004] QSPI Clock Divider Register                                       */
+    __IO uint32_t SSCTL;                 /*!< [0x0008] QSPI Slave Select Control Register                                */
+    __IO uint32_t PDMACTL;               /*!< [0x000c] QSPI PDMA Control Register                                        */
+    __IO uint32_t FIFOCTL;               /*!< [0x0010] QSPI FIFO Control Register                                        */
+    __IO uint32_t STATUS;                /*!< [0x0014] QSPI Status Register                                              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __O  uint32_t TX;                    /*!< [0x0020] QSPI Data Transmit Register                                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t RX;                    /*!< [0x0030] QSPI Data Receive Register                                        */
+
+} QSPI_T;
+
+/**
+    @addtogroup QSPI_CONST QSPI Bit Field Definition
+    Constant Definitions for QSPI Controller
+@{ */
+
+#define QSPI_CTL_QSPIEN_Pos               (0)                                                /*!< QSPI_T::CTL: QSPIEN Position             */
+#define QSPI_CTL_QSPIEN_Msk               (0x1ul << QSPI_CTL_QSPIEN_Pos)                     /*!< QSPI_T::CTL: QSPIEN Mask                 */
+
+#define QSPI_CTL_RXNEG_Pos                (1)                                                /*!< QSPI_T::CTL: RXNEG Position             */
+#define QSPI_CTL_RXNEG_Msk                (0x1ul << QSPI_CTL_RXNEG_Pos)                      /*!< QSPI_T::CTL: RXNEG Mask                 */
+
+#define QSPI_CTL_TXNEG_Pos                (2)                                                /*!< QSPI_T::CTL: TXNEG Position             */
+#define QSPI_CTL_TXNEG_Msk                (0x1ul << QSPI_CTL_TXNEG_Pos)                      /*!< QSPI_T::CTL: TXNEG Mask                 */
+
+#define QSPI_CTL_CLKPOL_Pos               (3)                                                /*!< QSPI_T::CTL: CLKPOL Position            */
+#define QSPI_CTL_CLKPOL_Msk               (0x1ul << QSPI_CTL_CLKPOL_Pos)                     /*!< QSPI_T::CTL: CLKPOL Mask                */
+
+#define QSPI_CTL_SUSPITV_Pos              (4)                                                /*!< QSPI_T::CTL: SUSPITV Position           */
+#define QSPI_CTL_SUSPITV_Msk              (0xful << QSPI_CTL_SUSPITV_Pos)                    /*!< QSPI_T::CTL: SUSPITV Mask               */
+
+#define QSPI_CTL_DWIDTH_Pos               (8)                                                /*!< QSPI_T::CTL: DWIDTH Position            */
+#define QSPI_CTL_DWIDTH_Msk               (0x1ful << QSPI_CTL_DWIDTH_Pos)                    /*!< QSPI_T::CTL: DWIDTH Mask                */
+
+#define QSPI_CTL_LSB_Pos                  (13)                                               /*!< QSPI_T::CTL: LSB Position               */
+#define QSPI_CTL_LSB_Msk                  (0x1ul << QSPI_CTL_LSB_Pos)                        /*!< QSPI_T::CTL: LSB Mask                   */
+
+#define QSPI_CTL_HALFDPX_Pos              (14)                                               /*!< QSPI_T::CTL: HALFDPX Position           */
+#define QSPI_CTL_HALFDPX_Msk              (0x1ul << QSPI_CTL_HALFDPX_Pos)                    /*!< QSPI_T::CTL: HALFDPX Mask               */
+
+#define QSPI_CTL_RXONLY_Pos               (15)                                               /*!< QSPI_T::CTL: RXONLY Position            */
+#define QSPI_CTL_RXONLY_Msk               (0x1ul << QSPI_CTL_RXONLY_Pos)                     /*!< QSPI_T::CTL: RXONLY Mask                */
+
+#define QSPI_CTL_TWOBIT_Pos               (16)                                               /*!< QSPI_T::CTL: TWOBIT Position            */
+#define QSPI_CTL_TWOBIT_Msk               (0x1ul << QSPI_CTL_TWOBIT_Pos)                     /*!< QSPI_T::CTL: TWOBIT Mask                */
+
+#define QSPI_CTL_UNITIEN_Pos              (17)                                               /*!< QSPI_T::CTL: UNITIEN Position           */
+#define QSPI_CTL_UNITIEN_Msk              (0x1ul << QSPI_CTL_UNITIEN_Pos)                    /*!< QSPI_T::CTL: UNITIEN Mask               */
+
+#define QSPI_CTL_SLAVE_Pos                (18)                                               /*!< QSPI_T::CTL: SLAVE Position             */
+#define QSPI_CTL_SLAVE_Msk                (0x1ul << QSPI_CTL_SLAVE_Pos)                      /*!< QSPI_T::CTL: SLAVE Mask                 */
+
+#define QSPI_CTL_REORDER_Pos              (19)                                               /*!< QSPI_T::CTL: REORDER Position           */
+#define QSPI_CTL_REORDER_Msk              (0x1ul << QSPI_CTL_REORDER_Pos)                    /*!< QSPI_T::CTL: REORDER Mask               */
+
+#define QSPI_CTL_DATDIR_Pos               (20)                                               /*!< QSPI_T::CTL: DATDIR Position            */
+#define QSPI_CTL_DATDIR_Msk               (0x1ul << QSPI_CTL_DATDIR_Pos)                     /*!< QSPI_T::CTL: DATDIR Mask                */
+
+#define QSPI_CTL_DUALIOEN_Pos             (21)                                               /*!< QSPI_T::CTL: DUALIOEN Position          */
+#define QSPI_CTL_DUALIOEN_Msk             (0x1ul << QSPI_CTL_DUALIOEN_Pos)                   /*!< QSPI_T::CTL: DUALIOEN Mask              */
+
+#define QSPI_CTL_QUADIOEN_Pos             (22)                                               /*!< QSPI_T::CTL: QUADIOEN Position          */
+#define QSPI_CTL_QUADIOEN_Msk             (0x1ul << QSPI_CTL_QUADIOEN_Pos)                   /*!< QSPI_T::CTL: QUADIOEN Mask              */
+
+#define QSPI_CLKDIV_DIVIDER_Pos           (0)                                                /*!< QSPI_T::CLKDIV: DIVIDER Position        */
+#define QSPI_CLKDIV_DIVIDER_Msk           (0x1fful << QSPI_CLKDIV_DIVIDER_Pos)               /*!< QSPI_T::CLKDIV: DIVIDER Mask            */
+
+#define QSPI_SSCTL_SS_Pos                 (0)                                                /*!< QSPI_T::SSCTL: SS Position              */
+#define QSPI_SSCTL_SS_Msk                 (0x1ul << QSPI_SSCTL_SS_Pos)                       /*!< QSPI_T::SSCTL: SS Mask                  */
+
+#define QSPI_SSCTL_SSACTPOL_Pos           (2)                                                /*!< QSPI_T::SSCTL: SSACTPOL Position        */
+#define QSPI_SSCTL_SSACTPOL_Msk           (0x1ul << QSPI_SSCTL_SSACTPOL_Pos)                 /*!< QSPI_T::SSCTL: SSACTPOL Mask            */
+
+#define QSPI_SSCTL_AUTOSS_Pos             (3)                                                /*!< QSPI_T::SSCTL: AUTOSS Position          */
+#define QSPI_SSCTL_AUTOSS_Msk             (0x1ul << QSPI_SSCTL_AUTOSS_Pos)                   /*!< QSPI_T::SSCTL: AUTOSS Mask              */
+
+#define QSPI_SSCTL_SLV3WIRE_Pos           (4)                                                /*!< QSPI_T::SSCTL: SLV3WIRE Position        */
+#define QSPI_SSCTL_SLV3WIRE_Msk           (0x1ul << QSPI_SSCTL_SLV3WIRE_Pos)                 /*!< QSPI_T::SSCTL: SLV3WIRE Mask            */
+
+#define QSPI_SSCTL_SLVTOIEN_Pos           (5)                                                /*!< QSPI_T::SSCTL: SLVTOIEN Position        */
+#define QSPI_SSCTL_SLVTOIEN_Msk           (0x1ul << QSPI_SSCTL_SLVTOIEN_Pos)                 /*!< QSPI_T::SSCTL: SLVTOIEN Mask            */
+
+#define QSPI_SSCTL_SLVTORST_Pos           (6)                                                /*!< QSPI_T::SSCTL: SLVTORST Position        */
+#define QSPI_SSCTL_SLVTORST_Msk           (0x1ul << QSPI_SSCTL_SLVTORST_Pos)                 /*!< QSPI_T::SSCTL: SLVTORST Mask            */
+
+#define QSPI_SSCTL_SLVBEIEN_Pos           (8)                                                /*!< QSPI_T::SSCTL: SLVBEIEN Position        */
+#define QSPI_SSCTL_SLVBEIEN_Msk           (0x1ul << QSPI_SSCTL_SLVBEIEN_Pos)                 /*!< QSPI_T::SSCTL: SLVBEIEN Mask            */
+
+#define QSPI_SSCTL_SLVURIEN_Pos           (9)                                                /*!< QSPI_T::SSCTL: SLVURIEN Position        */
+#define QSPI_SSCTL_SLVURIEN_Msk           (0x1ul << QSPI_SSCTL_SLVURIEN_Pos)                 /*!< QSPI_T::SSCTL: SLVURIEN Mask            */
+
+#define QSPI_SSCTL_SSACTIEN_Pos           (12)                                               /*!< QSPI_T::SSCTL: SSACTIEN Position        */
+#define QSPI_SSCTL_SSACTIEN_Msk           (0x1ul << QSPI_SSCTL_SSACTIEN_Pos)                 /*!< QSPI_T::SSCTL: SSACTIEN Mask            */
+
+#define QSPI_SSCTL_SSINAIEN_Pos           (13)                                               /*!< QSPI_T::SSCTL: SSINAIEN Position        */
+#define QSPI_SSCTL_SSINAIEN_Msk           (0x1ul << QSPI_SSCTL_SSINAIEN_Pos)                 /*!< QSPI_T::SSCTL: SSINAIEN Mask            */
+
+#define QSPI_SSCTL_SLVTOCNT_Pos           (16)                                               /*!< QSPI_T::SSCTL: SLVTOCNT Position        */
+#define QSPI_SSCTL_SLVTOCNT_Msk           (0xfffful << QSPI_SSCTL_SLVTOCNT_Pos)              /*!< QSPI_T::SSCTL: SLVTOCNT Mask            */
+
+#define QSPI_PDMACTL_TXPDMAEN_Pos         (0)                                                /*!< QSPI_T::PDMACTL: TXPDMAEN Position      */
+#define QSPI_PDMACTL_TXPDMAEN_Msk         (0x1ul << QSPI_PDMACTL_TXPDMAEN_Pos)               /*!< QSPI_T::PDMACTL: TXPDMAEN Mask          */
+
+#define QSPI_PDMACTL_RXPDMAEN_Pos         (1)                                                /*!< QSPI_T::PDMACTL: RXPDMAEN Position      */
+#define QSPI_PDMACTL_RXPDMAEN_Msk         (0x1ul << QSPI_PDMACTL_RXPDMAEN_Pos)               /*!< QSPI_T::PDMACTL: RXPDMAEN Mask          */
+
+#define QSPI_PDMACTL_PDMARST_Pos          (2)                                                /*!< QSPI_T::PDMACTL: PDMARST Position       */
+#define QSPI_PDMACTL_PDMARST_Msk          (0x1ul << QSPI_PDMACTL_PDMARST_Pos)                /*!< QSPI_T::PDMACTL: PDMARST Mask           */
+
+#define QSPI_FIFOCTL_RXRST_Pos            (0)                                                /*!< QSPI_T::FIFOCTL: RXRST Position         */
+#define QSPI_FIFOCTL_RXRST_Msk            (0x1ul << QSPI_FIFOCTL_RXRST_Pos)                  /*!< QSPI_T::FIFOCTL: RXRST Mask             */
+
+#define QSPI_FIFOCTL_TXRST_Pos            (1)                                                /*!< QSPI_T::FIFOCTL: TXRST Position         */
+#define QSPI_FIFOCTL_TXRST_Msk            (0x1ul << QSPI_FIFOCTL_TXRST_Pos)                  /*!< QSPI_T::FIFOCTL: TXRST Mask             */
+
+#define QSPI_FIFOCTL_RXTHIEN_Pos          (2)                                                /*!< QSPI_T::FIFOCTL: RXTHIEN Position       */
+#define QSPI_FIFOCTL_RXTHIEN_Msk          (0x1ul << QSPI_FIFOCTL_RXTHIEN_Pos)                /*!< QSPI_T::FIFOCTL: RXTHIEN Mask           */
+
+#define QSPI_FIFOCTL_TXTHIEN_Pos          (3)                                                /*!< QSPI_T::FIFOCTL: TXTHIEN Position       */
+#define QSPI_FIFOCTL_TXTHIEN_Msk          (0x1ul << QSPI_FIFOCTL_TXTHIEN_Pos)                /*!< QSPI_T::FIFOCTL: TXTHIEN Mask           */
+
+#define QSPI_FIFOCTL_RXTOIEN_Pos          (4)                                                /*!< QSPI_T::FIFOCTL: RXTOIEN Position       */
+#define QSPI_FIFOCTL_RXTOIEN_Msk          (0x1ul << QSPI_FIFOCTL_RXTOIEN_Pos)                /*!< QSPI_T::FIFOCTL: RXTOIEN Mask           */
+
+#define QSPI_FIFOCTL_RXOVIEN_Pos          (5)                                                /*!< QSPI_T::FIFOCTL: RXOVIEN Position       */
+#define QSPI_FIFOCTL_RXOVIEN_Msk          (0x1ul << QSPI_FIFOCTL_RXOVIEN_Pos)                /*!< QSPI_T::FIFOCTL: RXOVIEN Mask           */
+
+#define QSPI_FIFOCTL_TXUFPOL_Pos          (6)                                                /*!< QSPI_T::FIFOCTL: TXUFPOL Position       */
+#define QSPI_FIFOCTL_TXUFPOL_Msk          (0x1ul << QSPI_FIFOCTL_TXUFPOL_Pos)                /*!< QSPI_T::FIFOCTL: TXUFPOL Mask           */
+
+#define QSPI_FIFOCTL_TXUFIEN_Pos          (7)                                                /*!< QSPI_T::FIFOCTL: TXUFIEN Position       */
+#define QSPI_FIFOCTL_TXUFIEN_Msk          (0x1ul << QSPI_FIFOCTL_TXUFIEN_Pos)                /*!< QSPI_T::FIFOCTL: TXUFIEN Mask           */
+
+#define QSPI_FIFOCTL_RXFBCLR_Pos          (8)                                                /*!< QSPI_T::FIFOCTL: RXFBCLR Position       */
+#define QSPI_FIFOCTL_RXFBCLR_Msk          (0x1ul << QSPI_FIFOCTL_RXFBCLR_Pos)                /*!< QSPI_T::FIFOCTL: RXFBCLR Mask           */
+
+#define QSPI_FIFOCTL_TXFBCLR_Pos          (9)                                                /*!< QSPI_T::FIFOCTL: TXFBCLR Position       */
+#define QSPI_FIFOCTL_TXFBCLR_Msk          (0x1ul << QSPI_FIFOCTL_TXFBCLR_Pos)                /*!< QSPI_T::FIFOCTL: TXFBCLR Mask           */
+
+#define QSPI_FIFOCTL_RXTH_Pos             (24)                                               /*!< QSPI_T::FIFOCTL: RXTH Position          */
+#define QSPI_FIFOCTL_RXTH_Msk             (0x7ul << QSPI_FIFOCTL_RXTH_Pos)                   /*!< QSPI_T::FIFOCTL: RXTH Mask              */
+
+#define QSPI_FIFOCTL_TXTH_Pos             (28)                                               /*!< QSPI_T::FIFOCTL: TXTH Position          */
+#define QSPI_FIFOCTL_TXTH_Msk             (0x7ul << QSPI_FIFOCTL_TXTH_Pos)                   /*!< QSPI_T::FIFOCTL: TXTH Mask              */
+
+#define QSPI_STATUS_BUSY_Pos              (0)                                                /*!< QSPI_T::STATUS: BUSY Position           */
+#define QSPI_STATUS_BUSY_Msk              (0x1ul << QSPI_STATUS_BUSY_Pos)                    /*!< QSPI_T::STATUS: BUSY Mask               */
+
+#define QSPI_STATUS_UNITIF_Pos            (1)                                                /*!< QSPI_T::STATUS: UNITIF Position         */
+#define QSPI_STATUS_UNITIF_Msk            (0x1ul << QSPI_STATUS_UNITIF_Pos)                  /*!< QSPI_T::STATUS: UNITIF Mask             */
+
+#define QSPI_STATUS_SSACTIF_Pos           (2)                                                /*!< QSPI_T::STATUS: SSACTIF Position        */
+#define QSPI_STATUS_SSACTIF_Msk           (0x1ul << QSPI_STATUS_SSACTIF_Pos)                 /*!< QSPI_T::STATUS: SSACTIF Mask            */
+
+#define QSPI_STATUS_SSINAIF_Pos           (3)                                                /*!< QSPI_T::STATUS: SSINAIF Position        */
+#define QSPI_STATUS_SSINAIF_Msk           (0x1ul << QSPI_STATUS_SSINAIF_Pos)                 /*!< QSPI_T::STATUS: SSINAIF Mask            */
+
+#define QSPI_STATUS_SSLINE_Pos            (4)                                                /*!< QSPI_T::STATUS: SSLINE Position         */
+#define QSPI_STATUS_SSLINE_Msk            (0x1ul << QSPI_STATUS_SSLINE_Pos)                  /*!< QSPI_T::STATUS: SSLINE Mask             */
+
+#define QSPI_STATUS_SLVTOIF_Pos           (5)                                                /*!< QSPI_T::STATUS: SLVTOIF Position        */
+#define QSPI_STATUS_SLVTOIF_Msk           (0x1ul << QSPI_STATUS_SLVTOIF_Pos)                 /*!< QSPI_T::STATUS: SLVTOIF Mask            */
+
+#define QSPI_STATUS_SLVBEIF_Pos           (6)                                                /*!< QSPI_T::STATUS: SLVBEIF Position        */
+#define QSPI_STATUS_SLVBEIF_Msk           (0x1ul << QSPI_STATUS_SLVBEIF_Pos)                 /*!< QSPI_T::STATUS: SLVBEIF Mask            */
+
+#define QSPI_STATUS_SLVURIF_Pos           (7)                                                /*!< QSPI_T::STATUS: SLVURIF Position        */
+#define QSPI_STATUS_SLVURIF_Msk           (0x1ul << QSPI_STATUS_SLVURIF_Pos)                 /*!< QSPI_T::STATUS: SLVURIF Mask            */
+
+#define QSPI_STATUS_RXEMPTY_Pos           (8)                                                /*!< QSPI_T::STATUS: RXEMPTY Position        */
+#define QSPI_STATUS_RXEMPTY_Msk           (0x1ul << QSPI_STATUS_RXEMPTY_Pos)                 /*!< QSPI_T::STATUS: RXEMPTY Mask            */
+
+#define QSPI_STATUS_RXFULL_Pos            (9)                                                /*!< QSPI_T::STATUS: RXFULL Position         */
+#define QSPI_STATUS_RXFULL_Msk            (0x1ul << QSPI_STATUS_RXFULL_Pos)                  /*!< QSPI_T::STATUS: RXFULL Mask             */
+
+#define QSPI_STATUS_RXTHIF_Pos            (10)                                               /*!< QSPI_T::STATUS: RXTHIF Position         */
+#define QSPI_STATUS_RXTHIF_Msk            (0x1ul << QSPI_STATUS_RXTHIF_Pos)                  /*!< QSPI_T::STATUS: RXTHIF Mask             */
+
+#define QSPI_STATUS_RXOVIF_Pos            (11)                                               /*!< QSPI_T::STATUS: RXOVIF Position         */
+#define QSPI_STATUS_RXOVIF_Msk            (0x1ul << QSPI_STATUS_RXOVIF_Pos)                  /*!< QSPI_T::STATUS: RXOVIF Mask             */
+
+#define QSPI_STATUS_RXTOIF_Pos            (12)                                               /*!< QSPI_T::STATUS: RXTOIF Position         */
+#define QSPI_STATUS_RXTOIF_Msk            (0x1ul << QSPI_STATUS_RXTOIF_Pos)                  /*!< QSPI_T::STATUS: RXTOIF Mask             */
+
+#define QSPI_STATUS_QSPIENSTS_Pos          (15)                                              /*!< QSPI_T::STATUS: QSPIENSTS Position       */
+#define QSPI_STATUS_QSPIENSTS_Msk          (0x1ul << QSPI_STATUS_QSPIENSTS_Pos)              /*!< QSPI_T::STATUS: QSPIENSTS Mask           */
+
+#define QSPI_STATUS_TXEMPTY_Pos           (16)                                               /*!< QSPI_T::STATUS: TXEMPTY Position        */
+#define QSPI_STATUS_TXEMPTY_Msk           (0x1ul << QSPI_STATUS_TXEMPTY_Pos)                 /*!< QSPI_T::STATUS: TXEMPTY Mask            */
+
+#define QSPI_STATUS_TXFULL_Pos            (17)                                               /*!< QSPI_T::STATUS: TXFULL Position         */
+#define QSPI_STATUS_TXFULL_Msk            (0x1ul << QSPI_STATUS_TXFULL_Pos)                  /*!< QSPI_T::STATUS: TXFULL Mask             */
+
+#define QSPI_STATUS_TXTHIF_Pos            (18)                                               /*!< QSPI_T::STATUS: TXTHIF Position         */
+#define QSPI_STATUS_TXTHIF_Msk            (0x1ul << QSPI_STATUS_TXTHIF_Pos)                  /*!< QSPI_T::STATUS: TXTHIF Mask             */
+
+#define QSPI_STATUS_TXUFIF_Pos            (19)                                               /*!< QSPI_T::STATUS: TXUFIF Position         */
+#define QSPI_STATUS_TXUFIF_Msk            (0x1ul << QSPI_STATUS_TXUFIF_Pos)                  /*!< QSPI_T::STATUS: TXUFIF Mask             */
+
+#define QSPI_STATUS_TXRXRST_Pos           (23)                                               /*!< QSPI_T::STATUS: TXRXRST Position        */
+#define QSPI_STATUS_TXRXRST_Msk           (0x1ul << QSPI_STATUS_TXRXRST_Pos)                 /*!< QSPI_T::STATUS: TXRXRST Mask            */
+
+#define QSPI_STATUS_RXCNT_Pos             (24)                                               /*!< QSPI_T::STATUS: RXCNT Position          */
+#define QSPI_STATUS_RXCNT_Msk             (0xful << QSPI_STATUS_RXCNT_Pos)                   /*!< QSPI_T::STATUS: RXCNT Mask              */
+
+#define QSPI_STATUS_TXCNT_Pos             (28)                                               /*!< QSPI_T::STATUS: TXCNT Position          */
+#define QSPI_STATUS_TXCNT_Msk             (0xful << QSPI_STATUS_TXCNT_Pos)                   /*!< QSPI_T::STATUS: TXCNT Mask              */
+
+#define QSPI_TX_TX_Pos                    (0)                                                /*!< QSPI_T::TX: TX Position                 */
+#define QSPI_TX_TX_Msk                    (0xfffffffful << QSPI_TX_TX_Pos)                   /*!< QSPI_T::TX: TX Mask                     */
+
+#define QSPI_RX_RX_Pos                    (0)                                                /*!< QSPI_T::RX: RX Position                 */
+#define QSPI_RX_RX_Msk                    (0xfffffffful << QSPI_RX_RX_Pos)                   /*!< QSPI_T::RX: RX Mask                     */
+
+/** @} QSPI_CONST */
+/** @} end of QSPI register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __QSPI_REG_H__ */

--- a/hal/m258ke/nuvoton/rtc_reg.h
+++ b/hal/m258ke/nuvoton/rtc_reg.h
@@ -1,0 +1,786 @@
+/**************************************************************************//**
+ * @file     rtc_reg.h
+ * @version  V1.00
+ * @brief    RTC register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __RTC_REG_H__
+#define __RTC_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup RTC Real Time Clock Controller (RTC)
+    Memory Mapped Structure for RTC Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var RTC_T::INIT
+     * Offset: 0x00  RTC Initiation Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |INIT_ACTIVE|RTC Active Status (Read Only)
+     * |        |           |0 = RTC is at reset state.
+     * |        |           |1 = RTC is at normal active state.
+     * |[31:1]  |INIT       |RTC Initiation (Write Only)
+     * |        |           |When RTC block is powered on, RTC is at reset state.
+     * |        |           |User has to write a number (0xa5eb1357) to INIT to make RTC leave reset state.
+     * |        |           |Once the INIT is written as 0xa5eb1357, the RTC will be in un-reset state permanently.
+     * |        |           |The INIT is a write-only field and read value will be always 0.
+     * @var RTC_T::FREQADJ
+     * Offset: 0x08  RTC Frequency Compensation Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[5:0]   |FRACTION   |Fraction Part
+     * |        |           |Formula: FRACTION = (fraction part of detected value) X 64.
+     * |        |           |Note: Digit in FCR must be expressed as hexadecimal number.
+     * |[12:8]  |INTEGER    |Integer Part
+     * |        |           |00000 = Integer part of detected value is 32752.
+     * |        |           |00001 = Integer part of detected value is 32753.
+     * |        |           |00010 = Integer part of detected value is 32754.
+     * |        |           |00011 = Integer part of detected value is 32755.
+     * |        |           |00100 = Integer part of detected value is 32756.
+     * |        |           |00101 = Integer part of detected value is 32757.
+     * |        |           |00110 = Integer part of detected value is 32758.
+     * |        |           |00111 = Integer part of detected value is 32759.
+     * |        |           |01000 = Integer part of detected value is 32760.
+     * |        |           |01001 = Integer part of detected value is 32761.
+     * |        |           |01010 = Integer part of detected value is 32762.
+     * |        |           |01011 = Integer part of detected value is 32763.
+     * |        |           |01100 = Integer part of detected value is 32764.
+     * |        |           |01101 = Integer part of detected value is 32765.
+     * |        |           |01110 = Integer part of detected value is 32766.
+     * |        |           |01111 = Integer part of detected value is 32767.
+     * |        |           |10000 = Integer part of detected value is 32768.
+     * |        |           |10001 = Integer part of detected value is 32769.
+     * |        |           |10010 = Integer part of detected value is 32770.
+     * |        |           |10011 = Integer part of detected value is 32771.
+     * |        |           |10100 = Integer part of detected value is 32772.
+     * |        |           |10101 = Integer part of detected value is 32773.
+     * |        |           |10110 = Integer part of detected value is 32774.
+     * |        |           |10111 = Integer part of detected value is 32775.
+     * |        |           |11000 = Integer part of detected value is 32776.
+     * |        |           |11001 = Integer part of detected value is 32777.
+     * |        |           |11010 = Integer part of detected value is 32778.
+     * |        |           |11011 = Integer part of detected value is 32779.
+     * |        |           |11100 = Integer part of detected value is 32780.
+     * |        |           |11101 = Integer part of detected value is 32781.
+     * |        |           |11110 = Integer part of detected value is 32782.
+     * |        |           |11111 = Integer part of detected value is 32783.
+     * |[31]    |FCRBUSY    |Frequency Compensation Register Write Operation Busy (Read Only) (only for M252_C/E)
+     * |        |           |0 = The new register write operation is acceptable.
+     * |        |           |1 = The last write operation is in progress and new register write operation prohibited.
+     * |        |           |Note: This bit is only used when DCOMPEN(RTC_CLKFMT[16]) enabled.
+     * @var RTC_T::TIME
+     * Offset: 0x0C  RTC Time Loading Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[3:0]   |SEC        |1-Sec Time Digit (0~9)
+     * |[6:4]   |TENSEC     |10-Sec Time Digit (0~5)
+     * |[11:8]  |MIN        |1-Min Time Digit (0~9)
+     * |[14:12] |TENMIN     |10-Min Time Digit (0~5)
+     * |[19:16] |HR         |1-Hour Time Digit (0~9)
+     * |[21:20] |TENHR      |10-Hour Time Digit (0~2)
+     * |        |           |When RTC runs as 12-hour time scale mode, RTC_TIME[21] (the high bit of TENHR[1:0])
+     * |        |           |means AM/PM indication (If RTC_TIME[21] is 1, it indicates PM time message.)
+     * @var RTC_T::CAL
+     * Offset: 0x10  RTC Calendar Loading Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[3:0]   |DAY        |1-Day Calendar Digit (0~9)
+     * |[5:4]   |TENDAY     |10-Day Calendar Digit (0~3)
+     * |[11:8]  |MON        |1-Month Calendar Digit (0~9)
+     * |[12]    |TENMON     |10-Month Calendar Digit (0~1)
+     * |[19:16] |YEAR       |1-Year Calendar Digit (0~9)
+     * |[23:20] |TENYEAR    |10-Year Calendar Digit (0~9)
+     * @var RTC_T::CLKFMT
+     * Offset: 0x14  RTC Time Scale Selection Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |24HEN      |24-hour / 12-hour Time Scale Selection
+     * |        |           |Indicates that RTC_TIME and RTC_TALM are in 24-hour time scale or 12-hour time scale.
+     * |        |           |0 = 12-hour time scale with AM and PM indication selected.
+     * |        |           |1 = 24-hour time scale selected.
+     * |[16]    |DCOMPEN    |Dynamic Compensation Enable Bit (only for M252_C/E)
+     * |        |           |0 = Dynamic Compensation Disabled.
+     * |        |           |1 = Dynamic Compensation Enabled.
+     * @var RTC_T::WEEKDAY
+     * Offset: 0x18  RTC Day of the Week Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[2:0]   |WEEKDAY    |Day of the Week Register
+     * |        |           |000 = Sunday.
+     * |        |           |001 = Monday.
+     * |        |           |010 = Tuesday.
+     * |        |           |011 = Wednesday.
+     * |        |           |100 = Thursday.
+     * |        |           |101 = Friday.
+     * |        |           |110 = Saturday.
+     * |        |           |111 = Reserved.
+     * @var RTC_T::TALM
+     * Offset: 0x1C  RTC Time Alarm Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[3:0]   |SEC        |1-Sec Time Digit of Alarm Setting (0~9)
+     * |[6:4]   |TENSEC     |10-Sec Time Digit of Alarm Setting (0~5)
+     * |[11:8]  |MIN        |1-Min Time Digit of Alarm Setting (0~9)
+     * |[14:12] |TENMIN     |10-Min Time Digit of Alarm Setting (0~5)
+     * |[19:16] |HR         |1-Hour Time Digit of Alarm Setting (0~9)
+     * |[21:20] |TENHR      |10-Hour Time Digit of Alarm Setting (0~2)
+     * |        |           |When RTC runs as 12-hour time scale mode, RTC_TIME[21] (the high bit of TENHR[1:0])
+     * |        |           |means AM/PM indication (If RTC_TIME[21] is 1, it indicates PM time message.)
+     * @var RTC_T::CALM
+     * Offset: 0x20  RTC Calendar Alarm Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[3:0]   |DAY        |1-Day Calendar Digit of Alarm Setting (0~9)
+     * |[5:4]   |TENDAY     |10-Day Calendar Digit of Alarm Setting (0~3)
+     * |[11:8]  |MON        |1-Month Calendar Digit of Alarm Setting (0~9)
+     * |[12]    |TENMON     |10-Month Calendar Digit of Alarm Setting (0~1)
+     * |[19:16] |YEAR       |1-Year Calendar Digit of Alarm Setting (0~9)
+     * |[23:20] |TENYEAR    |10-Year Calendar Digit of Alarm Setting (0~9)
+     * @var RTC_T::LEAPYEAR
+     * Offset: 0x24  RTC Leap Year Indicator Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |LEAPYEAR   |Leap Year Indication Register (Read Only)
+     * |        |           |0 = This year is not a leap year.
+     * |        |           |1 = This year is leap year.
+     * @var RTC_T::INTEN
+     * Offset: 0x28  RTC Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |ALMIEN     |Alarm Interrupt Enable Bit
+     * |        |           |Set ALMIEN to 1 can also enable chip wake-up function when RTC alarm interrupt event is generated.
+     * |        |           |0 = RTC Alarm interrupt Disabled.
+     * |        |           |1 = RTC Alarm interrupt Enabled.
+     * |[1]     |TICKIEN    |Time Tick Interrupt Enable Bit
+     * |        |           |Set TICKIEN to 1 can also enable chip wake-up function when RTC tick interrupt event is generated.
+     * |        |           |0 = RTC Time Tick interrupt Disabled.
+     * |        |           |1 = RTC Time Tick interrupt Enabled.
+     * |[8]     |TAMP0IEN   |Tamper 0 Interrupt Enable Bit
+     * |        |           |Set TAMP0IEN to 1 can also enable chip wake-up function when tamper 0 interrupt event is generated.
+     * |        |           |0 = Tamper 0 interrupt Disabled.
+     * |        |           |1 = Tamper 0 interrupt Enabled.
+     * @var RTC_T::INTSTS
+     * Offset: 0x2C  RTC Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |ALMIF      |RTC Alarm Interrupt Flag
+     * |        |           |0 = Alarm condition is not matched.
+     * |        |           |1 = Alarm condition is matched.
+     * |        |           |Note: Write 1 to clear this bit.
+     * |[1]     |TICKIF     |RTC Time Tick Interrupt Flag
+     * |        |           |0 = Tick condition does not occur.
+     * |        |           |1 = Tick condition occur.
+     * |        |           |Note: Write 1 to clear this bit.
+     * |[8]     |TAMP0IF    |Tamper 0 Interrupt Flag
+     * |        |           |0 = No Tamper 0 interrupt flag is generated.
+     * |        |           |1 = Tamper 0 interrupt flag is generated.
+     * |        |           |Note1: Write 1 to clear this bit.
+     * @var RTC_T::TICK
+     * Offset: 0x30  RTC Time Tick Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[2:0]   |TICK       |Time Tick Register
+     * |        |           |These bits are used to select RTC time tick period for Periodic Time Tick Interrupt request.
+     * |        |           |000 = Time tick is 1 second.
+     * |        |           |001 = Time tick is 1/2 second.
+     * |        |           |010 = Time tick is 1/4 second.
+     * |        |           |011 = Time tick is 1/8 second.
+     * |        |           |100 = Time tick is 1/16 second.
+     * |        |           |101 = Time tick is 1/32 second.
+     * |        |           |110 = Time tick is 1/64 second.
+     * |        |           |111 = Time tick is 1/128 second.
+     * @var RTC_T::TAMSK
+     * Offset: 0x34  RTC Time Alarm Mask Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |MSEC       |Mask 1-Sec Time Digit of Alarm Setting (0~9)
+     * |[1]     |MTENSEC    |Mask 10-Sec Time Digit of Alarm Setting (0~5)
+     * |[2]     |MMIN       |Mask 1-Min Time Digit of Alarm Setting (0~9)
+     * |[3]     |MTENMIN    |Mask 10-Min Time Digit of Alarm Setting (0~5)
+     * |[4]     |MHR        |Mask 1-Hour Time Digit of Alarm Setting (0~9)
+     * |[5]     |MTENHR     |Mask 10-Hour Time Digit of Alarm Setting (0~2)
+     * @var RTC_T::CAMSK
+     * Offset: 0x38  RTC Calendar Alarm Mask Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |MDAY       |Mask 1-Day Calendar Digit of Alarm Setting (0~9)
+     * |[1]     |MTENDAY    |Mask 10-Day Calendar Digit of Alarm Setting (0~3)
+     * |[2]     |MMON       |Mask 1-Month Calendar Digit of Alarm Setting (0~9)
+     * |[3]     |MTENMON    |Mask 10-Month Calendar Digit of Alarm Setting (0~1)
+     * |[4]     |MYEAR      |Mask 1-Year Calendar Digit of Alarm Setting (0~9)
+     * |[5]     |MTENYEAR   |Mask 10-Year Calendar Digit of Alarm Setting (0~9)
+     * @var RTC_T::SPRCTL
+     * Offset: 0x3C  RTC Spare Functional Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |SPRCLRM    |Spare Register Clear Mask Bit
+     * |        |           |0 = Spare register will be clear after TAMPER occur.
+     * |        |           |1 = Spare register will not be clear after TAMPER occur.
+     * |[2]     |SPRRWEN    |Spare Register Enable Bit
+     * |        |           |0 = Spare register is Disabled.
+     * |        |           |1 = Spare register is Enabled.
+     * |        |           |Note: When spare register is disabled, RTC_SPR0 ~ RTC_SPR4 cannot be accessed.
+     * |[5]     |SPRCSTS    |SPR Clear Flag
+     * |        |           |This bit indicates if the RTC_SPR0 ~ RTC_SPR4 content is cleared when specify tamper event is detected.
+     * |        |           |0 = Spare register content is not cleared.
+     * |        |           |1 = Spare register content is cleared.
+     * |        |           |Note1:Writes 1 to clear this bit.
+     * |        |           |Note2:This bit keep 1 when RTC_INTSTS[8] is not equal to 0.
+     * @var RTC_T::SPR
+     * Offset: 0x40~0x50  RTC Spare Register 0/1/2/3/4
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[31:0]  |SPARE      |Spare Register
+     * |        |           |This field is used to store back-up information defined by user.
+     * |        |           |This field will be cleared by hardware automatically once a tamper pin event is detected.
+     * |        |           |Before storing back-up information in to RTC_SPRx register, user should check the register
+     * |        |           |read/write enable bit SPRRWEN (RTC_SPRCTL[2]) is enabled.
+     * @var RTC_T::LXTCTL
+     * Offset: 0x100  RTC 32KHz Oscillator Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[3:1]   |GAIN       |Oscillator Gain Option
+     * |        |           |User can select oscillator gain according to crystal external loading and operating temperature range.
+     * |        |           |The larger gain value corresponding to stronger driving capability and higher power consumption.
+     * |        |           |000 = L0 mode.
+     * |        |           |001 = L1 mode.
+     * |        |           |010 = L2 mode.
+     * |        |           |011 = L3 mode.
+     * |        |           |100 = L4 mode(Only for VBAT domain).
+     * |        |           |101 = L5 mode(Only for VBAT domain).
+     * |        |           |110 = L6 mode(Only for VBAT domain).
+     * |        |           |111 = L7 mode(Only for VBAT domain).
+     * |[7]     |C32KS      |RTC Clock 32K Source Selection:
+     * |        |           |0 = Internal RTC clock is from 32K crystal .
+     * |        |           |1 = Internal RTC clock is from LIRC.
+     * |[8]     |IOCTLSEL   |IO Pin Backup Control Selection (Only for VBAT Domain)
+     * |        |           |When low speed 32 kHz oscillator is disabled or TAMP0EN is disabled, PF.4 pin (X32KO pin), PF.5 pin (X32KI pin) or
+     * |        |           |PF.6 pin (TAMPER0 pin) can be used as GPIO function.User can program IOCTLSEL to decide PF.4, 5, 6 I/O function
+     * |        |           |is controlled by system power domain GPIO module or VBAT power domain RTC_GPIOCTL0 control register.
+     * |        |           |0 = PF.4, 5, 6 pin I/O function is controlled by GPIO module.
+     * |        |           |1 = PF.4, 5, 6 pin I/O function is controlled by VBAT power domain.
+     * |        |           |Note1: IOCTLSEL will automatically be set by hardware to 1 when system power is off and RTC_GPIOCTL0 had been configured.
+     * |        |           |Note2: The GPIO control feature is not supported when there is not any VBAT power domain.
+     * |[13]    |RTCLVDPD   |RTC Low Voltage Detector Power Down (Only for VBAT domain)
+     * |        |           |0= RTC Low Voltage Detector active..
+     * |        |           |1= RTC Low Voltage Detector enter power down.
+     * |[14]    |RTCPORPD   |RTC Power on Reset Power Down (Only for VBAT domain)
+     * |        |           |0= RTC POR active 1sec after first power up.
+     * |        |           |1= RTC POR enter power down.
+     * |        |           |Note: This bit only can be set to 1.
+     * @var RTC_T::GPIOCTL0
+     * Offset: 0x104  RTC GPIO Control 0 Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[1:0]   |OPMODE0    |IO Operation Mode(Only for VBAT domain)
+     * |        |           |00 = PF.4 is input only mode.
+     * |        |           |01 = PF.4 is output push pull mode.
+     * |        |           |10 = PF.4 is open drain mode.
+     * |        |           |11 = PF.4 is quasi-bidirectional mode.
+     * |[2]     |DOUT0      |IO Output Data(Only for VBAT domain)
+     * |        |           |0 = PF.4 output low.
+     * |        |           |1 = PF.4 output high.
+     * |[3]     |DINOFF0    |IO Pin Digital Input Path Disable Bit (Only for VBAT Domain)
+     * |        |           |0 = PF.4 digital input path Enabled.
+     * |        |           |1 = PF.4 digital input path Disabled (digital input tied to low).
+     * |[5:4]   |PUSEL0     |IO Pull-up and Pull-down Enable Bits(Only for VBAT domain)
+     * |        |           |Determine PF.4 I/O pull-up or pull-down.
+     * |        |           |00 = PF.4 pull-up and pull-down disable.
+     * |        |           |01 = PF.4 pull-up enable.
+     * |        |           |10 = PF.4 pull-down enable.
+     * |        |           |11 = PF.4 pull-up and pull-down disable.
+     * |        |           |Note:Basically, the pull-up control and pull-down control has following behavior limitation.
+     * |        |           |The independent pull-up / pull-down control register only valid when OPMODE0 set as input tri-state
+     * |        |           |and open-drain mode.
+     * |[6]     |SMTEN0     |Input Schmitt Trigger Enable Bit(Only for VBAT domain)
+     * |        |           |0 = PF.4 input schmitt trigger function Disabled.
+     * |        |           |1 = PF.4 input schmitt trigger function Enabled.
+     * |[9:8]   |OPMODE1    |IO Operation Mode(Only for VBAT domain)
+     * |        |           |00 = PF.5 is input only mode.
+     * |        |           |01 = PF.5 is output push pull mode.
+     * |        |           |10 = PF.5 is open drain mode.
+     * |        |           |11 = PF.5 is quasi-bidirectional mode.
+     * |[10]    |DOUT1      |IO Output Data(Only for VBAT domain)
+     * |        |           |0 = PF.5 output low.
+     * |        |           |1 = PF.5 output high.
+     * |[11]    |DINOFF1    |IO Pin State Backup Selection(Only for VBAT domain)
+     * |        |           |0 = PF.5 digital input path Enabled.
+     * |        |           |1 = PF.5 digital input path Disabled (digital input tied to low).
+     * |[13:12] |PUSEL1     |IO Pull-up and Pull-down Enable Bits(Only for VBAT domain)
+     * |        |           |Determine PF.5 I/O pull-up or pull-down.
+     * |        |           |00 = PF.5 pull-up and pull-down disable.
+     * |        |           |01 = PF.5 pull-up enable.
+     * |        |           |10 = PF.5 pull-down enable.
+     * |        |           |11 = PF.5 pull-up and pull-down disable.
+     * |        |           |Note:Basically, the pull-up control and pull-down control has following behavior limitation.
+     * |        |           |The independent pull-up / pull-down control register only valid when OPMODE1 set as input tri-state
+     * |        |           |and open-drain mode.
+     * |[14]    |SMTEN1     |Input Schmitt Trigger Enable Bit(Only for VBAT domain)
+     * |        |           |0 = PF.5 input schmitt trigger function Disabled.
+     * |        |           |1 = PF.5 input schmitt trigger function Enabled.
+     * |[17:16] |OPMODE2    |IO Operation Mode(Only for VBAT domain)
+     * |        |           |00 = PF.6 is input only mode.
+     * |        |           |01 = PF.6 is output push pull mode.
+     * |        |           |10 = PF.6 is open drain mode.
+     * |        |           |11 = PF.6 is quasi-bidirectional mode.
+     * |[18]    |DOUT2      |IO Output Data(Only for VBAT domain)
+     * |        |           |0 = PF.6 output low.
+     * |        |           |1 = PF.6 output high.
+     * |[19]    |DINOFF2    |IO Pin Digital Input Path Disable Bit (Only for VBAT Domain)
+     * |        |           |0 = PF.6 input schmitt trigger function Disabled.
+     * |        |           |1 = PF.6 input schmitt trigger function Enabled.
+     * |[21:20] |PUSEL2     |IO Pull-up and Pull-down Enable Bits(Only for VBAT domain)
+     * |        |           |Determine PF.6 I/O pull-up or pull-down.
+     * |        |           |00 = PF.6 pull-up and pull-down disable.
+     * |        |           |01 = PF.6 pull-up enable.
+     * |        |           |10 = PF.6 pull-down enable.
+     * |        |           |11 = PF.6 pull-up and pull-down disable.
+     * |        |           |Note:Basically, the pull-up control and pull-down control has following behavior limitation.
+     * |        |           |The independent pull-up / pull-down control register only valid when OPMODE2 set as input tri-state
+     * |        |           |and open-drain mode and PF6 as tamper pin.
+     * |[22]    |SMTEN2     |Input Schmitt Trigger Enable Bit(Only for VBAT domain)
+     * |        |           |0 = PF.6 input schmitt trigger function Disabled.
+     * |        |           |1 = PF.6 input schmitt trigger function Enabled.
+     * @var RTC_T::DSTCTL
+     * Offset: 0x110  RTC Daylight Saving Time Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[0]     |ADDHR      |Add 1 Hour
+     * |        |           |0 = No effect.
+     * |        |           |1 = RTC hour digit has been added one hour for summer time change.
+     * |[1]     |SUBHR      |Subtract 1 Hour
+     * |        |           |0 = No effect.
+     * |        |           |1 = RTC hour digit has been subtracted one hour for winter time change.
+     * |[2]     |DSBAK      |Daylight Saving Back
+     * |        |           |0= Normal mode.
+     * |        |           |1= Daylight saving mode.
+     * @var RTC_T::TAMPCTL
+     * Offset: 0x120  RTC Tamper Pin Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[8]     |TAMP0EN    |Tamper0 Detect Enable Bit
+     * |        |           |0 = Tamper 0 detect Disabled.
+     * |        |           |1 = Tamper 0 detect Enabled.
+     * |        |           |Note: The reference is RTC-clock. Tamper detector need sync 2 ~ 3 RTC-clock.
+     * |[9]     |TAMP0LV    |Tamper 0 Level
+     * |        |           |This bit depend on level attribute of tamper pin for static tamper detection.
+     * |        |           |0 = Detect Rising detection, will trigger tamper status when RTC_TAMPCTL[11] = 1.
+     * |        |           |Detect voltage level should be low. High will trigger tamper status when RTC_TAMPCTL[11] = 0.
+     * |        |           |1 = Detect Falling detection, will trigger tamper status when RTC_TAMPCTL[11] = 1.
+     * |        |           |Detect voltage level shoulld be high. Low will trigger tamper status when RTC_TAMPCTL[11] = 0.
+     * |[10]    |TAMP0DBEN  |Tamper 0 De-bounce Enable Bit
+     * |        |           |0 = Tamper 0 de-bounce Disabled.
+     * |        |           |1 = Tamper 0 de-bounce Enabled.
+     * |        |           |Note: In normal condition (25'C), it can deglitch 1~2 ns noise.
+     * |[11]    |TAMP0TYPE  |Tamper 0 Detect Type
+     * |        |           |0 = Tamper as edge detector.
+     * |        |           |1 = Tamper as Level detector.
+     * @var RTC_T::TAMPTIME
+     * Offset: 0x130  RTC Tamper Time Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[3:0]   |SEC        |1-Sec Time Digit of TAMPER Time (0~9)
+     * |[6:4]   |TENSEC     |10-Sec Time Digit of TAMPER Time (0~5)
+     * |[11:8]  |MIN        |1-Min Time Digit of TAMPER Time (0~9)
+     * |[14:12] |TENMIN     |10-Min Time Digit of TAMPER Time (0~5)
+     * |[19:16] |HR         |1-Hour Time Digit of TAMPER Time (0~9)
+     * |[21:20] |TENHR      |10-hour Time Digit of TAMPER Time (0~2)
+     * |        |           |Note: 24-hour time scale only.
+     * @var RTC_T::TAMPCAL
+     * Offset: 0x134  RTC Tamper Calendar Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field      |Descriptions
+     * | :----: | :----:    | :---- |
+     * |[3:0]   |DAY        |1-Day Calendar Digit of TAMPER Calendar (0~9)
+     * |[5:4]   |TENDAY     |10-Day Calendar Digit of TAMPER Calendar (0~3)
+     * |[11:8]  |MON        |1-Month Calendar Digit of TAMPER Calendar (0~9)
+     * |[12]    |TENMON     |10-Month Calendar Digit of TAMPER Calendar (0~1)
+     * |[19:16] |YEAR       |1-Year Calendar Digit of TAMPER Calendar (0~9)
+     * |[23:20] |TENYEAR    |10-Year Calendar Digit of TAMPER Calendar (0~9)
+     */
+    __IO uint32_t INIT;                  /*!< [0x0000] RTC Initiation Register                                          */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t FREQADJ;               /*!< [0x0008] RTC Frequency Compensation Register                              */
+    __IO uint32_t TIME;                  /*!< [0x000c] RTC Time Loading Register                                        */
+    __IO uint32_t CAL;                   /*!< [0x0010] RTC Calendar Loading Register                                    */
+    __IO uint32_t CLKFMT;                /*!< [0x0014] RTC Time Scale Selection Register                                */
+    __IO uint32_t WEEKDAY;               /*!< [0x0018] RTC Day of the Week Register                                     */
+    __IO uint32_t TALM;                  /*!< [0x001c] RTC Time Alarm Register                                          */
+    __IO uint32_t CALM;                  /*!< [0x0020] RTC Calendar Alarm Register                                      */
+    __I  uint32_t LEAPYEAR;              /*!< [0x0024] RTC Leap Year Indicator Register                                 */
+    __IO uint32_t INTEN;                 /*!< [0x0028] RTC Interrupt Enable Register                                    */
+    __IO uint32_t INTSTS;                /*!< [0x002c] RTC Interrupt Status Register                                    */
+    __IO uint32_t TICK;                  /*!< [0x0030] RTC Time Tick Register                                           */
+    __IO uint32_t TAMSK;                 /*!< [0x0034] RTC Time Alarm Mask Register                                     */
+    __IO uint32_t CAMSK;                 /*!< [0x0038] RTC Calendar Alarm Mask Register                                 */
+    __IO uint32_t SPRCTL;                /*!< [0x003c] RTC Spare Functional Control Register                            */
+    __IO uint32_t SPR[5];                /*!< [0x0040 ~ 0x0050] RTC Spare Register 0 ~ 4                                */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[43];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t LXTCTL;                /*!< [0x0100] RTC 32KHz Oscillator Control Register                            */
+    __IO uint32_t GPIOCTL0;              /*!< [0x0104] RTC GPIO Control 0 Register                                      */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t DSTCTL;                /*!< [0x0110] RTC Daylight Saving Time Control Register                        */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t TAMPCTL;               /*!< [0x0120] RTC Tamper Pin Control Register                                  */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE4[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t TAMPTIME;              /*!< [0x0130] RTC Tamper Time Register                                         */
+    __I  uint32_t TAMPCAL;               /*!< [0x0134] RTC Tamper Calendar Register                                     */
+} RTC_T;
+
+/**
+    @addtogroup RTC_CONST RTC Bit Field Definition
+    Constant Definitions for RTC Controller
+@{ */
+
+#define RTC_INIT_ACTIVE_Pos              (0)                                               /*!< RTC_T::INIT: INIT_ACTIVE Position      */
+#define RTC_INIT_ACTIVE_Msk              (0x1ul << RTC_INIT_ACTIVE_Pos)                    /*!< RTC_T::INIT: INIT_ACTIVE Mask          */
+
+#define RTC_FREQADJ_FRACTION_Pos         (0)                                               /*!< RTC_T::FREQADJ: FRACTION Position      */
+#define RTC_FREQADJ_FRACTION_Msk         (0x3ful << RTC_FREQADJ_FRACTION_Pos)              /*!< RTC_T::FREQADJ: FRACTION Mask          */
+
+#define RTC_FREQADJ_INTEGER_Pos          (8)                                               /*!< RTC_T::FREQADJ: INTEGER Position       */
+#define RTC_FREQADJ_INTEGER_Msk          (0x1ful << RTC_FREQADJ_INTEGER_Pos)               /*!< RTC_T::FREQADJ: INTEGER Mask           */
+
+#define RTC_FREQADJ_FCRBUSY_Pos          (31)                                              /*!< RTC_T::FREQADJ: FCRBUSY Position       */
+#define RTC_FREQADJ_FCRBUSY_Msk          (0x1ful << RTC_FREQADJ_FCRBUSY_Pos)               /*!< RTC_T::FREQADJ: FCRBUSY Mask           */
+
+#define RTC_TIME_SEC_Pos                 (0)                                               /*!< RTC_T::TIME: SEC Position              */
+#define RTC_TIME_SEC_Msk                 (0xful << RTC_TIME_SEC_Pos)                       /*!< RTC_T::TIME: SEC Mask                  */
+
+#define RTC_TIME_TENSEC_Pos              (4)                                               /*!< RTC_T::TIME: TENSEC Position           */
+#define RTC_TIME_TENSEC_Msk              (0x7ul << RTC_TIME_TENSEC_Pos)                    /*!< RTC_T::TIME: TENSEC Mask               */
+
+#define RTC_TIME_MIN_Pos                 (8)                                               /*!< RTC_T::TIME: MIN Position              */
+#define RTC_TIME_MIN_Msk                 (0xful << RTC_TIME_MIN_Pos)                       /*!< RTC_T::TIME: MIN Mask                  */
+
+#define RTC_TIME_TENMIN_Pos              (12)                                              /*!< RTC_T::TIME: TENMIN Position           */
+#define RTC_TIME_TENMIN_Msk              (0x7ul << RTC_TIME_TENMIN_Pos)                    /*!< RTC_T::TIME: TENMIN Mask               */
+
+#define RTC_TIME_HR_Pos                  (16)                                              /*!< RTC_T::TIME: HR Position               */
+#define RTC_TIME_HR_Msk                  (0xful << RTC_TIME_HR_Pos)                        /*!< RTC_T::TIME: HR Mask                   */
+
+#define RTC_TIME_TENHR_Pos               (20)                                              /*!< RTC_T::TIME: TENHR Position            */
+#define RTC_TIME_TENHR_Msk               (0x3ul << RTC_TIME_TENHR_Pos)                     /*!< RTC_T::TIME: TENHR Mask                */
+
+#define RTC_CAL_DAY_Pos                  (0)                                               /*!< RTC_T::CAL: DAY Position               */
+#define RTC_CAL_DAY_Msk                  (0xful << RTC_CAL_DAY_Pos)                        /*!< RTC_T::CAL: DAY Mask                   */
+
+#define RTC_CAL_TENDAY_Pos               (4)                                               /*!< RTC_T::CAL: TENDAY Position            */
+#define RTC_CAL_TENDAY_Msk               (0x3ul << RTC_CAL_TENDAY_Pos)                     /*!< RTC_T::CAL: TENDAY Mask                */
+
+#define RTC_CAL_MON_Pos                  (8)                                               /*!< RTC_T::CAL: MON Position               */
+#define RTC_CAL_MON_Msk                  (0xful << RTC_CAL_MON_Pos)                        /*!< RTC_T::CAL: MON Mask                   */
+
+#define RTC_CAL_TENMON_Pos               (12)                                              /*!< RTC_T::CAL: TENMON Position            */
+#define RTC_CAL_TENMON_Msk               (0x1ul << RTC_CAL_TENMON_Pos)                     /*!< RTC_T::CAL: TENMON Mask                */
+
+#define RTC_CAL_YEAR_Pos                 (16)                                              /*!< RTC_T::CAL: YEAR Position              */
+#define RTC_CAL_YEAR_Msk                 (0xful << RTC_CAL_YEAR_Pos)                       /*!< RTC_T::CAL: YEAR Mask                  */
+
+#define RTC_CAL_TENYEAR_Pos              (20)                                              /*!< RTC_T::CAL: TENYEAR Position           */
+#define RTC_CAL_TENYEAR_Msk              (0xful << RTC_CAL_TENYEAR_Pos)                    /*!< RTC_T::CAL: TENYEAR Mask               */
+
+#define RTC_CLKFMT_24HEN_Pos             (0)                                               /*!< RTC_T::CLKFMT: 24HEN Position          */
+#define RTC_CLKFMT_24HEN_Msk             (0x1ul << RTC_CLKFMT_24HEN_Pos)                   /*!< RTC_T::CLKFMT: 24HEN Mask              */
+
+#define RTC_CLKFMT_DCOMPEN_Pos           (8)                                               /*!< RTC_T::CLKFMT: DCOMPEN Position        */
+#define RTC_CLKFMT_DCOMPEN_Msk           (0x1ul << RTC_CLKFMT_DCOMPEN_Pos)                 /*!< RTC_T::CLKFMT: DCOMPEN Mask            */
+
+#define RTC_WEEKDAY_WEEKDAY_Pos          (0)                                               /*!< RTC_T::WEEKDAY: WEEKDAY Position       */
+#define RTC_WEEKDAY_WEEKDAY_Msk          (0x7ul << RTC_WEEKDAY_WEEKDAY_Pos)                /*!< RTC_T::WEEKDAY: WEEKDAY Mask           */
+
+#define RTC_TALM_SEC_Pos                 (0)                                               /*!< RTC_T::TALM: SEC Position              */
+#define RTC_TALM_SEC_Msk                 (0xful << RTC_TALM_SEC_Pos)                       /*!< RTC_T::TALM: SEC Mask                  */
+
+#define RTC_TALM_TENSEC_Pos              (4)                                               /*!< RTC_T::TALM: TENSEC Position           */
+#define RTC_TALM_TENSEC_Msk              (0x7ul << RTC_TALM_TENSEC_Pos)                    /*!< RTC_T::TALM: TENSEC Mask               */
+
+#define RTC_TALM_MIN_Pos                 (8)                                               /*!< RTC_T::TALM: MIN Position              */
+#define RTC_TALM_MIN_Msk                 (0xful << RTC_TALM_MIN_Pos)                       /*!< RTC_T::TALM: MIN Mask                  */
+
+#define RTC_TALM_TENMIN_Pos              (12)                                              /*!< RTC_T::TALM: TENMIN Position           */
+#define RTC_TALM_TENMIN_Msk              (0x7ul << RTC_TALM_TENMIN_Pos)                    /*!< RTC_T::TALM: TENMIN Mask               */
+
+#define RTC_TALM_HR_Pos                  (16)                                              /*!< RTC_T::TALM: HR Position               */
+#define RTC_TALM_HR_Msk                  (0xful << RTC_TALM_HR_Pos)                        /*!< RTC_T::TALM: HR Mask                   */
+
+#define RTC_TALM_TENHR_Pos               (20)                                              /*!< RTC_T::TALM: TENHR Position            */
+#define RTC_TALM_TENHR_Msk               (0x3ul << RTC_TALM_TENHR_Pos)                     /*!< RTC_T::TALM: TENHR Mask                */
+
+#define RTC_CALM_DAY_Pos                 (0)                                               /*!< RTC_T::CALM: DAY Position              */
+#define RTC_CALM_DAY_Msk                 (0xful << RTC_CALM_DAY_Pos)                       /*!< RTC_T::CALM: DAY Mask                  */
+
+#define RTC_CALM_TENDAY_Pos              (4)                                               /*!< RTC_T::CALM: TENDAY Position           */
+#define RTC_CALM_TENDAY_Msk              (0x3ul << RTC_CALM_TENDAY_Pos)                    /*!< RTC_T::CALM: TENDAY Mask               */
+
+#define RTC_CALM_MON_Pos                 (8)                                               /*!< RTC_T::CALM: MON Position              */
+#define RTC_CALM_MON_Msk                 (0xful << RTC_CALM_MON_Pos)                       /*!< RTC_T::CALM: MON Mask                  */
+
+#define RTC_CALM_TENMON_Pos              (12)                                              /*!< RTC_T::CALM: TENMON Position           */
+#define RTC_CALM_TENMON_Msk              (0x1ul << RTC_CALM_TENMON_Pos)                    /*!< RTC_T::CALM: TENMON Mask               */
+
+#define RTC_CALM_YEAR_Pos                (16)                                              /*!< RTC_T::CALM: YEAR Position             */
+#define RTC_CALM_YEAR_Msk                (0xful << RTC_CALM_YEAR_Pos)                      /*!< RTC_T::CALM: YEAR Mask                 */
+
+#define RTC_CALM_TENYEAR_Pos             (20)                                              /*!< RTC_T::CALM: TENYEAR Position          */
+#define RTC_CALM_TENYEAR_Msk             (0xful << RTC_CALM_TENYEAR_Pos)                   /*!< RTC_T::CALM: TENYEAR Mask              */
+
+#define RTC_LEAPYEAR_LEAPYEAR_Pos        (0)                                               /*!< RTC_T::LEAPYEAR: LEAPYEAR Position     */
+#define RTC_LEAPYEAR_LEAPYEAR_Msk        (0x1ul << RTC_LEAPYEAR_LEAPYEAR_Pos)              /*!< RTC_T::LEAPYEAR: LEAPYEAR Mask         */
+
+#define RTC_INTEN_ALMIEN_Pos             (0)                                               /*!< RTC_T::INTEN: ALMIEN Position          */
+#define RTC_INTEN_ALMIEN_Msk             (0x1ul << RTC_INTEN_ALMIEN_Pos)                   /*!< RTC_T::INTEN: ALMIEN Mask              */
+
+#define RTC_INTEN_TICKIEN_Pos            (1)                                               /*!< RTC_T::INTEN: TICKIEN Position         */
+#define RTC_INTEN_TICKIEN_Msk            (0x1ul << RTC_INTEN_TICKIEN_Pos)                  /*!< RTC_T::INTEN: TICKIEN Mask             */
+
+#define RTC_INTEN_TAMP0IEN_Pos           (8)                                               /*!< RTC_T::INTEN: TAMP0IEN Position        */
+#define RTC_INTEN_TAMP0IEN_Msk           (0x1ul << RTC_INTEN_TAMP0IEN_Pos)                 /*!< RTC_T::INTEN: TAMP0IEN Mask            */
+
+#define RTC_INTSTS_ALMIF_Pos             (0)                                               /*!< RTC_T::INTSTS: ALMIF Position          */
+#define RTC_INTSTS_ALMIF_Msk             (0x1ul << RTC_INTSTS_ALMIF_Pos)                   /*!< RTC_T::INTSTS: ALMIF Mask              */
+
+#define RTC_INTSTS_TICKIF_Pos            (1)                                               /*!< RTC_T::INTSTS: TICKIF Position         */
+#define RTC_INTSTS_TICKIF_Msk            (0x1ul << RTC_INTSTS_TICKIF_Pos)                  /*!< RTC_T::INTSTS: TICKIF Mask             */
+
+#define RTC_INTSTS_TAMP0IF_Pos           (8)                                               /*!< RTC_T::INTSTS: TAMP0IF Position        */
+#define RTC_INTSTS_TAMP0IF_Msk           (0x1ul << RTC_INTSTS_TAMP0IF_Pos)                 /*!< RTC_T::INTSTS: TAMP0IF Mask            */
+
+#define RTC_TICK_TICK_Pos                (0)                                               /*!< RTC_T::TICK: TICK Position             */
+#define RTC_TICK_TICK_Msk                (0x7ul << RTC_TICK_TICK_Pos)                      /*!< RTC_T::TICK: TICK Mask                 */
+
+#define RTC_TAMSK_MSEC_Pos               (0)                                               /*!< RTC_T::TAMSK: MSEC Position            */
+#define RTC_TAMSK_MSEC_Msk               (0x1ul << RTC_TAMSK_MSEC_Pos)                     /*!< RTC_T::TAMSK: MSEC Mask                */
+
+#define RTC_TAMSK_MTENSEC_Pos            (1)                                               /*!< RTC_T::TAMSK: MTENSEC Position         */
+#define RTC_TAMSK_MTENSEC_Msk            (0x1ul << RTC_TAMSK_MTENSEC_Pos)                  /*!< RTC_T::TAMSK: MTENSEC Mask             */
+
+#define RTC_TAMSK_MMIN_Pos               (2)                                               /*!< RTC_T::TAMSK: MMIN Position            */
+#define RTC_TAMSK_MMIN_Msk               (0x1ul << RTC_TAMSK_MMIN_Pos)                     /*!< RTC_T::TAMSK: MMIN Mask                */
+
+#define RTC_TAMSK_MTENMIN_Pos            (3)                                               /*!< RTC_T::TAMSK: MTENMIN Position         */
+#define RTC_TAMSK_MTENMIN_Msk            (0x1ul << RTC_TAMSK_MTENMIN_Pos)                  /*!< RTC_T::TAMSK: MTENMIN Mask             */
+
+#define RTC_TAMSK_MHR_Pos                (4)                                               /*!< RTC_T::TAMSK: MHR Position             */
+#define RTC_TAMSK_MHR_Msk                (0x1ul << RTC_TAMSK_MHR_Pos)                      /*!< RTC_T::TAMSK: MHR Mask                 */
+
+#define RTC_TAMSK_MTENHR_Pos             (5)                                               /*!< RTC_T::TAMSK: MTENHR Position          */
+#define RTC_TAMSK_MTENHR_Msk             (0x1ul << RTC_TAMSK_MTENHR_Pos)                   /*!< RTC_T::TAMSK: MTENHR Mask              */
+
+#define RTC_CAMSK_MDAY_Pos               (0)                                               /*!< RTC_T::CAMSK: MDAY Position            */
+#define RTC_CAMSK_MDAY_Msk               (0x1ul << RTC_CAMSK_MDAY_Pos)                     /*!< RTC_T::CAMSK: MDAY Mask                */
+
+#define RTC_CAMSK_MTENDAY_Pos            (1)                                               /*!< RTC_T::CAMSK: MTENDAY Position         */
+#define RTC_CAMSK_MTENDAY_Msk            (0x1ul << RTC_CAMSK_MTENDAY_Pos)                  /*!< RTC_T::CAMSK: MTENDAY Mask             */
+
+#define RTC_CAMSK_MMON_Pos               (2)                                               /*!< RTC_T::CAMSK: MMON Position            */
+#define RTC_CAMSK_MMON_Msk               (0x1ul << RTC_CAMSK_MMON_Pos)                     /*!< RTC_T::CAMSK: MMON Mask                */
+
+#define RTC_CAMSK_MTENMON_Pos            (3)                                               /*!< RTC_T::CAMSK: MTENMON Position         */
+#define RTC_CAMSK_MTENMON_Msk            (0x1ul << RTC_CAMSK_MTENMON_Pos)                  /*!< RTC_T::CAMSK: MTENMON Mask             */
+
+#define RTC_CAMSK_MYEAR_Pos              (4)                                               /*!< RTC_T::CAMSK: MYEAR Position           */
+#define RTC_CAMSK_MYEAR_Msk              (0x1ul << RTC_CAMSK_MYEAR_Pos)                    /*!< RTC_T::CAMSK: MYEAR Mask               */
+
+#define RTC_CAMSK_MTENYEAR_Pos           (5)                                               /*!< RTC_T::CAMSK: MTENYEAR Position        */
+#define RTC_CAMSK_MTENYEAR_Msk           (0x1ul << RTC_CAMSK_MTENYEAR_Pos)                 /*!< RTC_T::CAMSK: MTENYEAR Mask            */
+
+#define RTC_SPRCTL_SPRCLRM_Pos           (0)                                               /*!< RTC_T::SPRCTL: SPRCLRM Position        */
+#define RTC_SPRCTL_SPRCLRM_Msk           (0x1ul << RTC_SPRCTL_SPRCLRM_Pos)                 /*!< RTC_T::SPRCTL: SPRCLRM Mask            */
+
+#define RTC_SPRCTL_SPRRWEN_Pos           (2)                                               /*!< RTC_T::SPRCTL: SPRRWEN Position        */
+#define RTC_SPRCTL_SPRRWEN_Msk           (0x1ul << RTC_SPRCTL_SPRRWEN_Pos)                 /*!< RTC_T::SPRCTL: SPRRWEN Mask            */
+
+#define RTC_SPRCTL_SPRCSTS_Pos           (5)                                               /*!< RTC_T::SPRCTL: SPRCSTS Position        */
+#define RTC_SPRCTL_SPRCSTS_Msk           (0x1ul << RTC_SPRCTL_SPRCSTS_Pos)                 /*!< RTC_T::SPRCTL: SPRCSTS Mask            */
+
+#define RTC_SPR0_SPARE_Pos               (0)                                               /*!< RTC_T::SPR0: SPARE Position            */
+#define RTC_SPR0_SPARE_Msk               (0xfffffffful << RTC_SPR0_SPARE_Pos)              /*!< RTC_T::SPR0: SPARE Mask                */
+
+#define RTC_SPR1_SPARE_Pos               (0)                                               /*!< RTC_T::SPR1: SPARE Position            */
+#define RTC_SPR1_SPARE_Msk               (0xfffffffful << RTC_SPR1_SPARE_Pos)              /*!< RTC_T::SPR1: SPARE Mask                */
+
+#define RTC_SPR2_SPARE_Pos               (0)                                               /*!< RTC_T::SPR2: SPARE Position            */
+#define RTC_SPR2_SPARE_Msk               (0xfffffffful << RTC_SPR2_SPARE_Pos)              /*!< RTC_T::SPR2: SPARE Mask                */
+
+#define RTC_SPR3_SPARE_Pos               (0)                                               /*!< RTC_T::SPR3: SPARE Position            */
+#define RTC_SPR3_SPARE_Msk               (0xfffffffful << RTC_SPR3_SPARE_Pos)              /*!< RTC_T::SPR3: SPARE Mask                */
+
+#define RTC_SPR4_SPARE_Pos               (0)                                               /*!< RTC_T::SPR4: SPARE Position            */
+#define RTC_SPR4_SPARE_Msk               (0xfffffffful << RTC_SPR4_SPARE_Pos)              /*!< RTC_T::SPR4: SPARE Mask                */
+
+#define RTC_LXTCTL_GAIN_Pos              (1)                                               /*!< RTC_T::LXTCTL: GAIN Position           */
+#define RTC_LXTCTL_GAIN_Msk              (0x7ul << RTC_LXTCTL_GAIN_Pos)                    /*!< RTC_T::LXTCTL: GAIN Mask               */
+
+#define RTC_LXTCTL_C32KS_Pos             (7)                                               /*!< RTC_T::LXTCTL: C32KS Position          */
+#define RTC_LXTCTL_C32KS_Msk             (0x1ul << RTC_LXTCTL_C32KS_Pos)                   /*!< RTC_T::LXTCTL: C32KS Mask              */
+
+#define RTC_LXTCTL_IOCTLSEL_Pos          (8)                                               /*!< RTC_T::LXTCTL: IOCTLSEL Position       */
+#define RTC_LXTCTL_IOCTLSEL_Msk          (0x1ul << RTC_LXTCTL_IOCTLSEL_Pos)                /*!< RTC_T::LXTCTL: IOCTLSEL Mask           */
+
+#define RTC_LXTCTL_RTCLVDPD_Pos          (13)                                              /*!< RTC_T::LXTCTL: RTCLVDPD Position       */
+#define RTC_LXTCTL_RTCLVDPD_Msk          (0x1ul << RTC_LXTCTL_RTCLVDPD_Pos)                /*!< RTC_T::LXTCTL: RTCLVDPD Mask           */
+
+#define RTC_LXTCTL_RTCPORPD_Pos          (14)                                              /*!< RTC_T::LXTCTL: RTCPORPD Position       */
+#define RTC_LXTCTL_RTCPORPD_Msk          (0x1ul << RTC_LXTCTL_RTCPORPD_Pos)                /*!< RTC_T::LXTCTL: RTCPORPD Mask           */
+
+#define RTC_GPIOCTL0_OPMODE0_Pos         (0)                                               /*!< RTC_T::GPIOCTL0: OPMODE0 Position      */
+#define RTC_GPIOCTL0_OPMODE0_Msk         (0x3ul << RTC_GPIOCTL0_OPMODE0_Pos)               /*!< RTC_T::GPIOCTL0: OPMODE0 Mask          */
+
+#define RTC_GPIOCTL0_DOUT0_Pos           (2)                                               /*!< RTC_T::GPIOCTL0: DOUT0 Position        */
+#define RTC_GPIOCTL0_DOUT0_Msk           (0x1ul << RTC_GPIOCTL0_DOUT0_Pos)                 /*!< RTC_T::GPIOCTL0: DOUT0 Mask            */
+
+#define RTC_GPIOCTL0_DINOFF0_Pos         (3)                                               /*!< RTC_T::GPIOCTL0: DINOFF0 Position      */
+#define RTC_GPIOCTL0_DINOFF0_Msk         (0x1ul << RTC_GPIOCTL0_DINOFF0_Pos)               /*!< RTC_T::GPIOCTL0: DINOFF0 Mask          */
+
+#define RTC_GPIOCTL0_PUSEL0_Pos          (4)                                               /*!< RTC_T::GPIOCTL0: PUSEL0 Position       */
+#define RTC_GPIOCTL0_PUSEL0_Msk          (0x3ul << RTC_GPIOCTL0_PUSEL0_Pos)                /*!< RTC_T::GPIOCTL0: PUSEL0 Mask           */
+
+#define RTC_GPIOCTL0_SMTEN0_Pos          (6)                                               /*!< RTC_T::GPIOCTL0: SMTEN0 Position       */
+#define RTC_GPIOCTL0_SMTEN0_Msk          (0x1ul << RTC_GPIOCTL0_SMTEN0_Pos)                /*!< RTC_T::GPIOCTL0: SMTEN0 Mask           */
+
+#define RTC_GPIOCTL0_OPMODE1_Pos         (8)                                               /*!< RTC_T::GPIOCTL0: OPMODE1 Position      */
+#define RTC_GPIOCTL0_OPMODE1_Msk         (0x3ul << RTC_GPIOCTL0_OPMODE1_Pos)               /*!< RTC_T::GPIOCTL0: OPMODE1 Mask          */
+
+#define RTC_GPIOCTL0_DOUT1_Pos           (10)                                              /*!< RTC_T::GPIOCTL0: DOUT1 Position        */
+#define RTC_GPIOCTL0_DOUT1_Msk           (0x1ul << RTC_GPIOCTL0_DOUT1_Pos)                 /*!< RTC_T::GPIOCTL0: DOUT1 Mask            */
+
+#define RTC_GPIOCTL0_DINOFF1_Pos         (11)                                              /*!< RTC_T::GPIOCTL0: DINOFF1 Position      */
+#define RTC_GPIOCTL0_DINOFF1_Msk         (0x1ul << RTC_GPIOCTL0_DINOFF1_Pos)               /*!< RTC_T::GPIOCTL0: DINOFF1 Mask          */
+
+#define RTC_GPIOCTL0_PUSEL1_Pos          (12)                                              /*!< RTC_T::GPIOCTL0: PUSEL1 Position       */
+#define RTC_GPIOCTL0_PUSEL1_Msk          (0x3ul << RTC_GPIOCTL0_PUSEL1_Pos)                /*!< RTC_T::GPIOCTL0: PUSEL1 Mask           */
+
+#define RTC_GPIOCTL0_SMTEN1_Pos          (14)                                              /*!< RTC_T::GPIOCTL0: SMTEN1 Position       */
+#define RTC_GPIOCTL0_SMTEN1_Msk          (0x1ul << RTC_GPIOCTL0_SMTEN1_Pos)                /*!< RTC_T::GPIOCTL0: SMTEN1 Mask           */
+
+#define RTC_GPIOCTL0_OPMODE2_Pos         (16)                                              /*!< RTC_T::GPIOCTL0: OPMODE2 Position      */
+#define RTC_GPIOCTL0_OPMODE2_Msk         (0x3ul << RTC_GPIOCTL0_OPMODE2_Pos)               /*!< RTC_T::GPIOCTL0: OPMODE2 Mask          */
+
+#define RTC_GPIOCTL0_DOUT2_Pos           (18)                                              /*!< RTC_T::GPIOCTL0: DOUT2 Position        */
+#define RTC_GPIOCTL0_DOUT2_Msk           (0x1ul << RTC_GPIOCTL0_DOUT2_Pos)                 /*!< RTC_T::GPIOCTL0: DOUT2 Mask            */
+
+#define RTC_GPIOCTL0_DINOFF2_Pos         (19)                                              /*!< RTC_T::GPIOCTL0: DINOFF2 Position      */
+#define RTC_GPIOCTL0_DINOFF2_Msk         (0x1ul << RTC_GPIOCTL0_DINOFF2_Pos)               /*!< RTC_T::GPIOCTL0: DINOFF2 Mask          */
+
+#define RTC_GPIOCTL0_PUSEL2_Pos          (20)                                              /*!< RTC_T::GPIOCTL0: PUSEL2 Position       */
+#define RTC_GPIOCTL0_PUSEL2_Msk          (0x3ul << RTC_GPIOCTL0_PUSEL2_Pos)                /*!< RTC_T::GPIOCTL0: PUSEL2 Mask           */
+
+#define RTC_GPIOCTL0_SMTEN2_Pos          (22)                                              /*!< RTC_T::GPIOCTL0: SMTEN2 Position       */
+#define RTC_GPIOCTL0_SMTEN2_Msk          (0x1ul << RTC_GPIOCTL0_SMTEN2_Pos)                /*!< RTC_T::GPIOCTL0: SMTEN2 Mask           */
+
+#define RTC_DSTCTL_ADDHR_Pos             (0)                                               /*!< RTC_T::DSTCTL: ADDHR Position          */
+#define RTC_DSTCTL_ADDHR_Msk             (0x1ul << RTC_DSTCTL_ADDHR_Pos)                   /*!< RTC_T::DSTCTL: ADDHR Mask              */
+
+#define RTC_DSTCTL_SUBHR_Pos             (1)                                               /*!< RTC_T::DSTCTL: SUBHR Position          */
+#define RTC_DSTCTL_SUBHR_Msk             (0x1ul << RTC_DSTCTL_SUBHR_Pos)                   /*!< RTC_T::DSTCTL: SUBHR Mask              */
+
+#define RTC_DSTCTL_DSBAK_Pos             (2)                                               /*!< RTC_T::DSTCTL: DSBAK Position          */
+#define RTC_DSTCTL_DSBAK_Msk             (0x1ul << RTC_DSTCTL_DSBAK_Pos)                   /*!< RTC_T::DSTCTL: DSBAK Mask              */
+
+#define RTC_TAMPCTL_TAMP0EN_Pos          (8)                                               /*!< RTC_T::TAMPCTL: TAMP0EN Position       */
+#define RTC_TAMPCTL_TAMP0EN_Msk          (0x1ul << RTC_TAMPCTL_TAMP0EN_Pos)                /*!< RTC_T::TAMPCTL: TAMP0EN Mask           */
+
+#define RTC_TAMPCTL_TAMP0LV_Pos          (9)                                               /*!< RTC_T::TAMPCTL: TAMP0LV Position       */
+#define RTC_TAMPCTL_TAMP0LV_Msk          (0x1ul << RTC_TAMPCTL_TAMP0LV_Pos)                /*!< RTC_T::TAMPCTL: TAMP0LV Mask           */
+
+#define RTC_TAMPCTL_TAMP0DBEN_Pos        (10)                                              /*!< RTC_T::TAMPCTL: TAMP0DBEN Position     */
+#define RTC_TAMPCTL_TAMP0DBEN_Msk        (0x1ul << RTC_TAMPCTL_TAMP0DBEN_Pos)              /*!< RTC_T::TAMPCTL: TAMP0DBEN Mask         */
+
+#define RTC_TAMPCTL_TAMP0TYPE_Pos        (11)                                              /*!< RTC_T::TAMPCTL: TAMP0TYPE Position     */
+#define RTC_TAMPCTL_TAMP0TYPE_Msk        (0x1ul << RTC_TAMPCTL_TAMP0TYPE_Pos)              /*!< RTC_T::TAMPCTL: TAMP0TYPE Mask         */
+
+#define RTC_TAMPTIME_SEC_Pos             (0)                                               /*!< RTC_T::TAMPTIME: SEC Position          */
+#define RTC_TAMPTIME_SEC_Msk             (0xful << RTC_TAMPTIME_SEC_Pos)                   /*!< RTC_T::TAMPTIME: SEC Mask              */
+
+#define RTC_TAMPTIME_TENSEC_Pos          (4)                                               /*!< RTC_T::TAMPTIME: TENSEC Position       */
+#define RTC_TAMPTIME_TENSEC_Msk          (0x7ul << RTC_TAMPTIME_TENSEC_Pos)                /*!< RTC_T::TAMPTIME: TENSEC Mask           */
+
+#define RTC_TAMPTIME_MIN_Pos             (8)                                               /*!< RTC_T::TAMPTIME: MIN Position          */
+#define RTC_TAMPTIME_MIN_Msk             (0xful << RTC_TAMPTIME_MIN_Pos)                   /*!< RTC_T::TAMPTIME: MIN Mask              */
+
+#define RTC_TAMPTIME_TENMIN_Pos          (12)                                              /*!< RTC_T::TAMPTIME: TENMIN Position       */
+#define RTC_TAMPTIME_TENMIN_Msk          (0x7ul << RTC_TAMPTIME_TENMIN_Pos)                /*!< RTC_T::TAMPTIME: TENMIN Mask           */
+
+#define RTC_TAMPTIME_HR_Pos              (16)                                              /*!< RTC_T::TAMPTIME: HR Position           */
+#define RTC_TAMPTIME_HR_Msk              (0xful << RTC_TAMPTIME_HR_Pos)                    /*!< RTC_T::TAMPTIME: HR Mask               */
+
+#define RTC_TAMPTIME_TENHR_Pos           (20)                                              /*!< RTC_T::TAMPTIME: TENHR Position        */
+#define RTC_TAMPTIME_TENHR_Msk           (0x3ul << RTC_TAMPTIME_TENHR_Pos)                 /*!< RTC_T::TAMPTIME: TENHR Mask            */
+
+#define RTC_TAMPCAL_DAY_Pos              (0)                                               /*!< RTC_T::TAMPCAL: DAY Position           */
+#define RTC_TAMPCAL_DAY_Msk              (0xful << RTC_TAMPCAL_DAY_Pos)                    /*!< RTC_T::TAMPCAL: DAY Mask               */
+
+#define RTC_TAMPCAL_TENDAY_Pos           (4)                                               /*!< RTC_T::TAMPCAL: TENDAY Position        */
+#define RTC_TAMPCAL_TENDAY_Msk           (0x3ul << RTC_TAMPCAL_TENDAY_Pos)                 /*!< RTC_T::TAMPCAL: TENDAY Mask            */
+
+#define RTC_TAMPCAL_MON_Pos              (8)                                               /*!< RTC_T::TAMPCAL: MON Position           */
+#define RTC_TAMPCAL_MON_Msk              (0xful << RTC_TAMPCAL_MON_Pos)                    /*!< RTC_T::TAMPCAL: MON Mask               */
+
+#define RTC_TAMPCAL_TENMON_Pos           (12)                                              /*!< RTC_T::TAMPCAL: TENMON Position        */
+#define RTC_TAMPCAL_TENMON_Msk           (0x1ul << RTC_TAMPCAL_TENMON_Pos)                 /*!< RTC_T::TAMPCAL: TENMON Mask            */
+
+#define RTC_TAMPCAL_YEAR_Pos             (16)                                              /*!< RTC_T::TAMPCAL: YEAR Position          */
+#define RTC_TAMPCAL_YEAR_Msk             (0xful << RTC_TAMPCAL_YEAR_Pos)                   /*!< RTC_T::TAMPCAL: YEAR Mask              */
+
+#define RTC_TAMPCAL_TENYEAR_Pos          (20)                                              /*!< RTC_T::TAMPCAL: TENYEAR Position       */
+#define RTC_TAMPCAL_TENYEAR_Msk          (0xful << RTC_TAMPCAL_TENYEAR_Pos)                /*!< RTC_T::TAMPCAL: TENYEAR Mask           */
+
+/** @} RTC_CONST */
+/** @} end of RTC register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __RTC_REG_H__ */

--- a/hal/m258ke/nuvoton/sc_reg.h
+++ b/hal/m258ke/nuvoton/sc_reg.h
@@ -1,0 +1,976 @@
+/**************************************************************************//**
+ * @file     sc_reg.h
+ * @version  V1.00
+ * @brief    SC register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __SC_REG_H__
+#define __SC_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup SC Smart Card Host Interface Controller (SC)
+    Memory Mapped Structure for SC Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var SC_T::DAT
+     * Offset: 0x00  SC Receive/Transmit Holding Buffer Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DAT       |Receive/Transmit Holding Buffer
+     * |        |          |Write Operation:
+     * |        |          |By writing data to DAT, the SC will send out an 8-bit data.
+     * |        |          |Note: If SCEN (SCn_CTL[0]) is not enabled, DAT cannot be programmed.
+     * |        |          |Read Operation:
+     * |        |          |By reading DAT, the SC will return an 8-bit received data.
+     * @var SC_T::CTL
+     * Offset: 0x04  SC Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SCEN      |SC Controller Enable Bit
+     * |        |          |Set this bit to 1 to enable SC operation. If this bit is cleared,
+     * |        |          |0 = SC will force all transition to IDLE state.
+     * |        |          |1 = SC controller is enabled and all function can work correctly.
+     * |        |          |Note: SCEN must be set to 1 before filling in other SC registers, or smart card will not work properly.
+     * |[1]     |RXOFF     |RX Transition Disable Control Bit
+     * |        |          |This bit is used for disable Rx transition function.
+     * |        |          |0 = The receiver Enabled.
+     * |        |          |1 = The receiver Disabled.
+     * |        |          |Note: If AUTOCEN (SCn_CTL[3]) is enabled, this field is ignored.
+     * |[2]     |TXOFF     |TX Transition Disable Control Bit
+     * |        |          |This bit is used for disable Tx transition function.
+     * |        |          |0 = The transceiver Enabled.
+     * |        |          |1 = The transceiver Disabled.
+     * |[3]     |AUTOCEN   |Auto Convention Enable Bit
+     * |        |          |This bit is used for enable auto convention function.
+     * |        |          |0 = Auto-convention Disabled.
+     * |        |          |1 = Auto-convention Enabled.
+     * |        |          |If user enables auto convention function, the setting step must be done before Answer to Reset (ATR) state and the first data must be 0x3B or 0x3F
+     * |        |          |After hardware received first data and stored it at buffer, hardware will decided the convention and change the CONSEL (SCn_CTL[5:4]) bits automatically when received first data is 0x3B or 0x3F
+     * |        |          |If received first byte is 0x3B, TS is direct convention, CONSEL (SCn_CTL[5:4]) will be set to 00 automatically, otherwise the TS is inverse convention, and CONSEL (SCn_CTL[5:4]) will be set to 11.
+     * |        |          |If the first data is not 0x3B or 0x3F, hardware will set ACERRIF (SCn_INTSTS[10]) and generate an interrupt to CPU when ACERRIEN (SCn_INTEN[10]) is enabled.
+     * |[5:4]   |CONSEL    |Convention Selection
+     * |        |          |00 = Direct convention.
+     * |        |          |01 = Reserved.
+     * |        |          |10 = Reserved.
+     * |        |          |11 = Inverse convention.
+     * |        |          |Note: If AUTOCEN (SCn_CTL[3]) is enabled, this field is ignored.
+     * |[7:6]   |RXTRGLV   |Rx Buffer Trigger Level
+     * |        |          |When the number of bytes in the receiving buffer equals the RXTRGLV, the RDAIF will be set
+     * |        |          |If RDAIEN (SCn_INTEN[0]) is enabled, an interrupt will be generated to CPU.
+     * |        |          |00 = Rx Buffer Trigger Level with 01 bytes.
+     * |        |          |01 = Rx Buffer Trigger Level with 02 bytes.
+     * |        |          |10 = Rx Buffer Trigger Level with 03 bytes.
+     * |        |          |11 = Reserved.
+     * |[12:8]  |BGT       |Block Guard Time (BGT)
+     * |        |          |Block guard time means the minimum interval between the leading edges of two consecutive characters between different transfer directions
+     * |        |          |This field indicates the counter for the bit length of block guard time
+     * |        |          |According to ISO 7816-3, in T = 0 mode, user must fill 15 (real block guard time = 16.5) to this field; in T = 1 mode, user must fill 21 (real block guard time = 22.5) to it.
+     * |        |          |Note: The real block guard time is BGT + 1.
+     * |[14:13] |TMRSEL    |Timer Channel Selection
+     * |        |          |00 = All internal timer function Disabled.
+     * |        |          |11 = Internal 24 bit timer and two 8 bit timers Enabled
+     * |        |          |User can configure them by setting SCn_TMRCTL0[23:0], SCn_TMRCTL1[7:0] and SCn_TMRCTL2[7:0].
+     * |        |          |Other configurations are reserved
+     * |[15]    |NSB       |Stop Bit Length
+     * |        |          |This field indicates the length of stop bit.
+     * |        |          |0 = The stop bit length is 2 ETU.
+     * |        |          |1= The stop bit length is 1 ETU.
+     * |        |          |Note1: The default stop bit length is 2. SC and UART adopts NSB to program the stop bit length.
+     * |        |          |Note2: In UART mode, RX can receive the data sequence in 1 stop bit or 2 stop bits with NSB is set to 0.
+     * |[18:16] |RXRTY     |RX Error Retry Count Number
+     * |        |          |This field indicates the maximum number of receiver retries that are allowed when parity error has occurred
+     * |        |          |Note1: The real retry number is RXRTY + 1, so 8 is the maximum retry number.
+     * |        |          |Note2: This field cannot be changed when RXRTYEN enabled
+     * |        |          |The change flow is to disable RXRTYEN first and then fill in new retry value.
+     * |[19]    |RXRTYEN   |RX Error Retry Enable Bit
+     * |        |          |This bit enables receiver retry function when parity error has occurred.
+     * |        |          |0 = RX error retry function Disabled.
+     * |        |          |1 = RX error retry function Enabled.
+     * |        |          |Note: User must fill in the RXRTY value before enabling this bit.
+     * |[22:20] |TXRTY     |TX Error Retry Count Number
+     * |        |          |This field indicates the maximum number of transmitter retries that are allowed when parity error has occurred.
+     * |        |          |Note1: The real retry number is TXRTY + 1, so 8 is the maximum retry number.
+     * |        |          |Note2: This field cannot be changed when TXRTYEN enabled
+     * |        |          |The change flow is to disable TXRTYEN first and then fill in new retry value.
+     * |[23]    |TXRTYEN   |TX Error Retry Enable Bit
+     * |        |          |This bit enables transmitter retry function when parity error has occurred.
+     * |        |          |0 = TX error retry function Disabled.
+     * |        |          |1 = TX error retry function Enabled.
+     * |[25:24] |CDDBSEL   |Card Detect De-bounce Selection
+     * |        |          |This field indicates the card detect de-bounce selection.
+     * |        |          |00 = De-bounce sample card insert once per 384 (128 * 3) SC module clocks and de-bounce sample card removal once per 128 SC module clocks.
+     * |        |          |Other configurations are reserved.
+     * |[26]    |CDLV      |Card Detect Level Selection
+     * |        |          |0 = When hardware detects the card detect pin (SCn_CD) from high to low, it indicates a card is detected.
+     * |        |          |1 = When hardware detects the card detect pin (SCn_CD) from low to high, it indicates a card is detected.
+     * |        |          |Note: User must select card detect level before Smart Card controller enabled.
+     * |[30]    |SYNC      |SYNC Flag Indicator (Read Only)
+     * |        |          |Due to synchronization, user should check this bit before writing a new value to RXRTY and TXRTY fields.
+     * |        |          |0 = Synchronizing is completion, user can write new data to RXRTY and TXRTY.
+     * |        |          |1 = Last value is synchronizing.
+     * @var SC_T::ALTCTL
+     * Offset: 0x08  SC Alternate Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TXRST     |TX Software Reset
+     * |        |          |When TXRST is set, all the bytes in the transmit buffer and TX internal state machine will be cleared.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the TX internal state machine and pointers.
+     * |        |          |Note: This bit will be auto cleared after reset is complete.
+     * |[1]     |RXRST     |Rx Software Reset
+     * |        |          |When RXRST is set, all the bytes in the receive buffer and Rx internal state machine will be cleared.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the Rx internal state machine and pointers.
+     * |        |          |Note: This bit will be auto cleared after reset is complete.
+     * |[2]     |DACTEN    |Deactivation Sequence Generator Enable Bit
+     * |        |          |This bit enables SC controller to initiate the card by deactivation sequence.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Deactivation sequence generator Enabled.
+     * |        |          |Note1: When the deactivation sequence completed, this bit will be cleared automatically and the INITIF (SCn_INTSTS[8]) will be set to 1.
+     * |        |          |Note2: This field will be cleared by TXRST (SCn_ALTCTL[0]) and RXRST (SCn_ALTCTL[1])
+     * |        |          |Thus, do not fill in this bit DACTEN, TXRST and RXRST at the same time.
+     * |        |          |Note3: If SCEN (SCn_CTL[0]) is not enabled, this filed cannot be programmed.
+     * |[3]     |ACTEN     |Activation Sequence Generator Enable Bit
+     * |        |          |This bit enables SC controller to initiate the card by activation sequence.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Activation sequence generator Enabled.
+     * |        |          |Note1: When the activation sequence completed, this bit will be cleared automatically and the INITIF (SCn_INTSTS[8]) will be set to 1.
+     * |        |          |Note2: This field will be cleared by TXRST (SCn_ALTCTL[0]) and RXRST (SCn_ALTCTL[1])
+     * |        |          |Thus, do not fill in this bit ACTEN, TXRST and RXRST at the same time.
+     * |        |          |Note3: If SCEN (SCn_CTL[0]) is not enabled, this filed cannot be programmed.
+     * |        |          |Note4: During the activation sequence, RX is disabled automatically and can not receive data
+     * |        |          |After the activation sequence completion, RXOFF (SCn_CTL[1]) keeps the state before hardware activation.
+     * |[4]     |WARSTEN   |Warm Reset Sequence Generator Enable Bit
+     * |        |          |This bit enables SC controller to initiate the card by warm reset sequence.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Warm reset sequence generator Enabled.
+     * |        |          |Note1: When the warm reset sequence completed, this bit will be cleared automatically and the INITIF (SCn_INTSTS[8]) will be set to 1.
+     * |        |          |Note2: This field will be cleared by TXRST (SCn_ALTCTL[0]) and RXRST (SCn_ALTCTL[1])
+     * |        |          |Thus, do not fill in this bit WARSTEN, TXRST and RXRST at the same time.
+     * |        |          |Note3: If SCEN (SCn_CTL[0]) is not enabled, this filed cannot be programmed.
+     * |        |          |Note4: During the warm reset sequence, RX is disabled automatically and can not receive data
+     * |        |          |After the warm reset sequence completion, RXOFF (SCn_CTL[1]) keeps the state before perform warm reset sequence.
+     * |[5]     |CNTEN0    |Internal Timer0 Start Enable Bit
+     * |        |          |This bit enables Timer 0 to start counting
+     * |        |          |User can fill 0 to stop it and set 1 to reload and count
+     * |        |          |The counter unit is ETU base.
+     * |        |          |0 = Stops counting.
+     * |        |          |1 = Start counting.
+     * |        |          |Note1: This field is used for internal 24 bit timer when TMRSEL (SCn_CTL[14:13]) is 11 only.
+     * |        |          |Note2: If the operation mode is not in auto-reload mode (SCn_TMRCTL0[26] = 0), this bit will be auto-cleared by hardware.
+     * |        |          |Note3: If SCEN (SCn_CTL[0]) is not enabled, this filed cannot be programmed.
+     * |[6]     |CNTEN1    |Internal Timer1 Start Enable Bit
+     * |        |          |This bit enables Timer 1 to start counting
+     * |        |          |User can fill 0 to stop it and set 1 to reload and count
+     * |        |          |The counter unit is ETU base.
+     * |        |          |0 = Stops counting.
+     * |        |          |1 = Start counting.
+     * |        |          |Note1: This field is used for internal 8 bit timer when TMRSEL(SCn_CTL[14:13]) is 11 only
+     * |        |          |Do not fill CNTEN1 when TMRSEL (SCn_CTL[14:13]) is not equal to 11.
+     * |        |          |Note2: If the operation mode is not in auto-reload mode (SCn_TMRCTL1[26] = 0), this bit will be auto-cleared by hardware.
+     * |        |          |Note3: If SCEN (SCn_CTL[0]) is not enabled, this filed cannot be programmed.
+     * |[7]     |CNTEN2    |Internal Timer2 Start Enable Bit
+     * |        |          |This bit enables Timer 2 to start counting
+     * |        |          |User can fill 0 to stop it and set 1 to reload and count
+     * |        |          |The counter unit is ETU base.
+     * |        |          |0 = Stops counting.
+     * |        |          |1 = Start counting.
+     * |        |          |Note1: This field is used for internal 8 bit timer when TMRSEL (SCn_CTL[14:13]) is 11 only
+     * |        |          |Do not fill in CNTEN2 when TMRSEL (SCn_CTL[14:13]) is not equal to 11.
+     * |        |          |Note2: If the operation mode is not in auto-reload mode (SCn_TMRCTL2[26] = 0), this bit will be auto-cleared by hardware.
+     * |        |          |Note3: If SCEN (SCn_CTL[0]) is not enabled, this filed cannot be programmed.
+     * |[9:8]   |INITSEL   |Initial Timing Selection
+     * |        |          |This fields indicates the initial timing of hardware activation, warm-reset or deactivation.
+     * |        |          |The unit of initial timing is SC module clock.
+     * |        |          |Activation: refer to SC Activation Sequence in Figure 7.14-54.
+     * |        |          |Warm-reset: refer to Warm-Reset Sequence in Figure 7.14-5.
+     * |        |          |Deactivation: refer to Deactivation Sequence in Figure 7.14-56.
+     * |        |          |Note: When set activation and warm reset in Timer0 operation mode 0011, it may have deviation at most 128 SC module clock cycles.
+     * |[11]    |ADACEN    |Auto Deactivation When Card Removal
+     * |        |          |This bit is used for enable hardware auto deactivation when smart card is removed.
+     * |        |          |0 = Auto deactivation Disabled.
+     * |        |          |1 = Auto deactivation Enabled.
+     * |        |          |Note: When the card is removed, hardware will stop any process and then do deactivation sequence if this bit is set
+     * |        |          |If auto deactivation process completes, hardware will set INITIF (SCn_INTSTS[8]) also.
+     * |[12]    |RXBGTEN   |Receiver Block Guard Time Function Enable Bit
+     * |        |          |This bit enables the receiver block guard time function.
+     * |        |          |0 = Receiver block guard time function Disabled.
+     * |        |          |1 = Receiver block guard time function Enabled.
+     * |[13]    |ACTSTS0   |Internal Timer0 Active Status (Read Only)
+     * |        |          |This bit indicates the timer counter status of timer0.
+     * |        |          |0 = Timer0 is not active.
+     * |        |          |1 = Timer0 is active.
+     * |        |          |Note: Timer0 is active does not always mean timer0 is counting the CNT (SCn_TMRCTL0[23:0]).
+     * |[14]    |ACTSTS1   |Internal Timer1 Active Status (Read Only)
+     * |        |          |This bit indicates the timer counter status of timer1.
+     * |        |          |0 = Timer1 is not active.
+     * |        |          |1 = Timer1 is active.
+     * |        |          |Note: Timer1 is active does not always mean timer1 is counting the CNT (SCn_TMRCTL1[7:0]).
+     * |[15]    |ACTSTS2   |Internal Timer2 Active Status (Read Only)
+     * |        |          |This bit indicates the timer counter status of timer2.
+     * |        |          |0 = Timer2 is not active.
+     * |        |          |1 = Timer2 is active.
+     * |        |          |Note: Timer2 is active does not always mean timer2 is counting the CNT (SCn_TMRCTL2[7:0]).
+     * |[31]    |SYNC      |SYNC Flag Indicator (Read Only)
+     * |        |          |Due to synchronization, user should check this bit when writing a new value to SCn_ALTCTL register.
+     * |        |          |0 = Synchronizing is completion, user can write new data to SCn_ALTCTL register.
+     * |        |          |1 = Last value is synchronizing.
+     * @var SC_T::EGT
+     * Offset: 0x0C  SC Extra Guard Time Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |EGT       |Extra Guard Time
+     * |        |          |This field indicates the extra guard time value.
+     * |        |          |Note: The extra guard time unit is ETU base.
+     * @var SC_T::RXTOUT
+     * Offset: 0x10  SC Receive Buffer Time-out Counter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |RFTM      |SC Receiver FIFO Time-out Counter
+     * |        |          |The time-out down counter resets and starts counting whenever the RX buffer received a new data
+     * |        |          |Once the counter decrease to 1 and no new data is received or CPU does not read data by reading SCn_DAT, a receiver time-out flag RXTOIF (SCn_INTSTS[9]) will be set, and hardware will generate an interrupt to CPU when RXTOIEN (SCn_INTEN[9]) is enabled.
+     * |        |          |Note1: The counter unit is ETU based and the interval of time-out is RFTM + 0.5.
+     * |        |          |Note2: Filling in all 0 to this field indicates to disable this function.
+     * @var SC_T::ETUCTL
+     * Offset: 0x14  SC Element Time Unit Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[11:0]  |ETURDIV   |ETU Rate Divider
+     * |        |          |The field is used for ETU clock rate divider.
+     * |        |          |The real ETU is ETURDIV + 1.
+     * |        |          |Note: User can configure this field, but this field must be greater than 0x04.
+     * @var SC_T::INTEN
+     * Offset: 0x18  SC Interrupt Enable Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RDAIEN    |Receive Data Reach Interrupt Enable Bit
+     * |        |          |This field is used to enable received data reaching trigger level RXTRGLV (SCn_CTL[7:6]) interrupt.
+     * |        |          |0 = Receive data reach trigger level interrupt Disabled.
+     * |        |          |1 = Receive data reach trigger level interrupt Enabled.
+     * |[1]     |TBEIEN    |Transmit Buffer Empty Interrupt Enable Bit
+     * |        |          |This field is used to enable transmit buffer empty interrupt.
+     * |        |          |0 = Transmit buffer empty interrupt Disabled.
+     * |        |          |1 = Transmit buffer empty interrupt Enabled.
+     * |[2]     |TERRIEN   |Transfer Error Interrupt Enable Bit
+     * |        |          |This field is used to enable transfer error interrupt
+     * |        |          |The transfer error states is at SCn_STATUS register which includes receiver break error BEF (SCn_STATUS[6]), frame error FEF (SCn_STATUS[5]), parity error PEF (SCn_STATUS[4]), receive buffer overflow error RXOV (SCn_STATUS[0]), transmit buffer overflow error TXOV (SCn_STATUS[8]), receiver retry over limit error RXOVERR (SCn_STATUS[22]) and transmitter retry over limit error TXOVERR (SCn_STATUS[30]).
+     * |        |          |0 = Transfer error interrupt Disabled.
+     * |        |          |1 = Transfer error interrupt Enabled.
+     * |[3]     |TMR0IEN   |Timer0 Interrupt Enable Bit
+     * |        |          |This field is used to enable Timer0 interrupt function.
+     * |        |          |0 = Timer0 interrupt Disabled.
+     * |        |          |1 = Timer0 interrupt Enabled.
+     * |[4]     |TMR1IEN   |Timer1 Interrupt Enable Bit
+     * |        |          |This field is used to enable the Timer1 interrupt function.
+     * |        |          |0 = Timer1 interrupt Disabled.
+     * |        |          |1 = Timer1 interrupt Enabled.
+     * |[5]     |TMR2IEN   |Timer2 Interrupt Enable Bit
+     * |        |          |This field is used to enable Timer2 interrupt function.
+     * |        |          |0 = Timer2 interrupt Disabled.
+     * |        |          |1 = Timer2 interrupt Enabled.
+     * |[6]     |BGTIEN    |Block Guard Time Interrupt Enable Bit
+     * |        |          |This field is used to enable block guard time interrupt in receive direction.
+     * |        |          |0 = Block guard time interrupt Disabled.
+     * |        |          |1 = Block guard time interrupt Enabled.
+     * |        |          |Note: This bit is valid only for receive direction block guard time.
+     * |[7]     |CDIEN     |Card Detect Interrupt Enable Bit
+     * |        |          |This field is used to enable card detect interrupt
+     * |        |          |The card detect status is CDPINSTS (SCn_STATUS[13]).
+     * |        |          |0 = Card detect interrupt Disabled.
+     * |        |          |1 = Card detect interrupt Enabled.
+     * |[8]     |INITIEN   |Initial End Interrupt Enable Bit
+     * |        |          |This field is used to enable activation (ACTEN (SCn_ALTCTL[3] = 1)), deactivation (DACTEN (SCn_ALTCTL[2] = 1)) and warm reset (WARSTEN (SCn_ALTCTL [4])) sequence complete interrupt.
+     * |        |          |0 = Initial end interrupt Disabled.
+     * |        |          |1 = Initial end interrupt Enabled.
+     * |[9]     |RXTOIEN   |Receiver Buffer Time-out Interrupt Enable Bit
+     * |        |          |This field is used to enable receiver buffer time-out interrupt.
+     * |        |          |0 = Receiver buffer time-out interrupt Disabled.
+     * |        |          |1 = Receiver buffer time-out interrupt Enabled.
+     * |[10]    |ACERRIEN  |Auto Convention Error Interrupt Enable Bit
+     * |        |          |This field is used to enable auto-convention error interrupt.
+     * |        |          |0 = Auto-convention error interrupt Disabled.
+     * |        |          |1 = Auto-convention error interrupt Enabled.
+     * @var SC_T::INTSTS
+     * Offset: 0x1C  SC Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RDAIF     |Receive Data Reach Interrupt Status Flag (Read Only)
+     * |        |          |This field is used for received data reaching trigger level RXTRGLV (SCn_CTL[7:6]) interrupt status flag.
+     * |        |          |0 = Number of receive buffer is less than RXTRGLV setting.
+     * |        |          |1 = Number of receive buffer data equals the RXTRGLV setting.
+     * |        |          |Note: This bit is read only
+     * |        |          |If user reads data from SCn_DAT and receiver buffer data byte number is less than RXTRGLV, this bit will be cleared automatically.
+     * |[1]     |TBEIF     |Transmit Buffer Empty Interrupt Status Flag (Read Only)
+     * |        |          |This field is used for transmit buffer empty interrupt status flag.
+     * |        |          |0 = Transmit buffer is not empty.
+     * |        |          |1 = Transmit buffer is empty.
+     * |        |          |Note: This bit is read only
+     * |        |          |If user wants to clear this bit, user must write data to DAT (SCn_DAT[7:0]) and then this bit will be cleared automatically.
+     * |[2]     |TERRIF    |Transfer Error Interrupt Status Flag
+     * |        |          |This field is used for transfer error interrupt status flag
+     * |        |          |The transfer error states is at SCn_STATUS register which includes receiver break error BEF (SCn_STATUS[6]), frame error FEF (SCn_STATUS[5], parity error PEF (SCn_STATUS[4] and receive buffer overflow error RXOV (SCn_STATUS[0]), transmit buffer overflow error TXOV (SCn_STATUS[8]), receiver retry over limit error RXOVERR (SCn_STATUS[22] or transmitter retry over limit error TXOVERR (SCn_STATUS[30]).
+     * |        |          |0 = Transfer error interrupt did not occur.
+     * |        |          |1 = Transfer error interrupt occurred.
+     * |        |          |Note1: This field is the status flag of BEF, FEF, PEF, RXOV, TXOV, RXOVERR or TXOVERR.
+     * |        |          |Note2: This bit can be cleared by writing 1 to it.
+     * |[3]     |TMR0IF    |Timer0 Interrupt Status Flag
+     * |        |          |This field is used for Timer0 interrupt status flag.
+     * |        |          |0 = Timer0 interrupt did not occur.
+     * |        |          |1 = Timer0 interrupt occurred.
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * |[4]     |TMR1IF    |Timer1 Interrupt Status Flag
+     * |        |          |This field is used for Timer1 interrupt status flag.
+     * |        |          |0 = Timer1 interrupt did not occur.
+     * |        |          |1 = Timer1 interrupt occurred.
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * |[5]     |TMR2IF    |Timer2 Interrupt Status Flag
+     * |        |          |This field is used for Timer2 interrupt status flag.
+     * |        |          |0 = Timer2 interrupt did not occur.
+     * |        |          |1 = Timer2 interrupt occurred.
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * |[6]     |BGTIF     |Block Guard Time Interrupt Status Flag
+     * |        |          |This field is used for indicate block guard time interrupt status flag in receive direction.
+     * |        |          |0 = Block guard time interrupt did not occur.
+     * |        |          |1 = Block guard time interrupt occurred.
+     * |        |          |Note1: This bit is valid only when RXBGTEN (SCn_ALTCTL[12]) is enabled.
+     * |        |          |Note2: This bit can be cleared by writing 1 to it.
+     * |[7]     |CDIF      |Card Detect Interrupt Status Flag (Read Only)
+     * |        |          |This field is used for card detect interrupt status flag
+     * |        |          |The card detect status is CINSERT (SCn_STATUS[12]) and CREMOVE (SCn_STATUS[11]).
+     * |        |          |0 = Card detect event did not occur.
+     * |        |          |1 = Card detect event occurred.
+     * |        |          |Note: This bit is read only, user must to clear CINSERT or CREMOVE status to clear it.
+     * |[8]     |INITIF    |Initial End Interrupt Status Flag
+     * |        |          |This field is used for activation (ACTEN (SCn_ALTCTL[3])), deactivation (DACTEN (SCn_ALTCTL[2])) and warm reset (WARSTEN (SCn_ALTCTL[4])) sequence interrupt status flag.
+     * |        |          |0 = Initial sequence is not complete.
+     * |        |          |1 = Initial sequence is completed.
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * |[9]     |RXTOIF    |Receive Buffer Time-out Interrupt Status Flag (Read Only)
+     * |        |          |This field is used for indicate receive buffer time-out interrupt status flag.
+     * |        |          |0 = Receive buffer time-out interrupt did not occur.
+     * |        |          |1 = Receive buffer time-out interrupt occurred.
+     * |        |          |Note: This bit is read only, user must read all receive buffer remaining data by reading SCn_DAT register to clear it.
+     * |[10]    |ACERRIF   |Auto Convention Error Interrupt Status Flag
+     * |        |          |This field indicates auto convention sequence error.
+     * |        |          |0 = Received TS at ATR state is 0x3B or 0x3F.
+     * |        |          |1 = Received TS at ATR state is neither 0x3B nor 0x3F.
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * @var SC_T::STATUS
+     * Offset: 0x20  SC Transfer Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RXOV      |Receive Overflow Error Status Flag
+     * |        |          |This bit is set when Rx buffer overflow.
+     * |        |          |0 = Rx buffer is not overflow.
+     * |        |          |1 = Rx buffer is overflow when the number of received bytes is greater than Rx buffer size (4 bytes).
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * |[1]     |RXEMPTY   |Receive Buffer Empty Status Flag (Read Only)
+     * |        |          |This bit indicates Rx buffer empty or not.
+     * |        |          |0 = Rx buffer is not empty.
+     * |        |          |1 = Rx buffer is empty, it means the last byte of Rx buffer has read from DAT (SCn_DAT[7:0]) by CPU.
+     * |[2]     |RXFULL    |Receive Buffer Full Status Flag (Read Only)
+     * |        |          |This bit indicates Rx buffer full or not.
+     * |        |          |0 = Rx buffer count is less than 4.
+     * |        |          |1 = Rx buffer count equals to 4.
+     * |[4]     |PEF       |Receiver Parity Error Status Flag
+     * |        |          |This bit is set to logic 1 whenever the received character does not have a valid "parity bit".
+     * |        |          |0 = Receiver parity error flag did not occur.
+     * |        |          |1 = Receiver parity error flag occurred.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: If CPU sets receiver retries function by setting RXRTYEN (SCn_CTL[19]), hardware will not set this flag.
+     * |[5]     |FEF       |Receiver Frame Error Status Flag
+     * |        |          |This bit is set to logic 1 whenever the received character does not have a valid "stop bit" (that is, the stop bit following the last data bit or parity bit is detected as logic 0).
+     * |        |          |0 = Receiver frame error flag did not occur.
+     * |        |          |1 = Receiver frame error flag occurred.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: If CPU sets receiver retries function by setting RXRTYEN (SCn_CTL[19]), hardware will not set this flag.
+     * |[6]     |BEF       |Receiver Break Error Status Flag
+     * |        |          |This bit is set to logic 1 whenever the received data input (Rx) held in the "spacing state" (logic 0) is longer than a full word transmission time (that is, the total time of "start bit" + "data bits" + "parity bit" + "stop bits").
+     * |        |          |0 = Receiver break error flag did not occur.
+     * |        |          |1 = Receiver break error flag occurred.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: If CPU sets receiver retries function by setting RXRTYEN (SCn_CTL[19]), hardware will not set this flag.
+     * |[8]     |TXOV      |Transmit Overflow Error Interrupt Status Flag
+     * |        |          |This bit is set when Tx buffer overflow.
+     * |        |          |0 = Tx buffer is not overflow.
+     * |        |          |1 = Tx buffer is overflow when Tx buffer is full and an additional write operation to DAT (SCn_DAT[7:0]).
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * |[9]     |TXEMPTY   |Transmit Buffer Empty Status Flag (Read Only)
+     * |        |          |This bit indicates TX buffer empty or not.
+     * |        |          |0 = Tx buffer is not empty.
+     * |        |          |1 = Tx buffer is empty, it means the last byte of Tx buffer has been transferred to Transmitter Shift Register.
+     * |        |          |Note: This bit will be cleared when writing data into DAT (SCn_DAT[7:0]).
+     * |[10]    |TXFULL    |Transmit Buffer Full Status Flag (Read Only)
+     * |        |          |This bit indicates Tx buffer full or not.
+     * |        |          |0 = Tx buffer count is less than 4.
+     * |        |          |1 = Tx buffer count equals to 4.
+     * |[11]    |CREMOVE   |Card Removal Status of SCn_CD Pin
+     * |        |          |This bit is set whenever card has been removal.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Card removed.
+     * |        |          |Note1: This bit can be cleared by writing "1" to it.
+     * |        |          |Note2: Card detect function will start after SCEN (SCn_CTL[0]) set.
+     * |[12]    |CINSERT   |Card Insert Status of SCn_CD Pin
+     * |        |          |This bit is set whenever card has been inserted.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Card insert.
+     * |        |          |Note1: This bit can be cleared by writing "1" to it.
+     * |        |          |Note2: The card detect function will start after SCEN (SCn_CTL[0]) set.
+     * |[13]    |CDPINSTS  |Card Detect Pin Status (Read Only)
+     * |        |          |This bit is the pin status of SCn_CD.
+     * |        |          |0 = The SCn_CD pin state at low.
+     * |        |          |1 = The SCn_CD pin state at high.
+     * |[18:16] |RXPOINT   |Receive Buffer Pointer Status (Read Only)
+     * |        |          |This field indicates the Rx buffer pointer status
+     * |        |          |When SC controller receives one byte from external device, RXPOINT increases one
+     * |        |          |When one byte of Rx buffer is read by CPU, RXPOINT decreases one.
+     * |[21]    |RXRERR    |Receiver Retry Error
+     * |        |          |This bit is used for receiver error retry and set by hardware.
+     * |        |          |0 = No Rx retry transfer.
+     * |        |          |1 = Rx has any error and retries transfer.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2 This bit is a flag and cannot generate any interrupt to CPU.
+     * |        |          |Note3: If CPU enables receiver retries function by setting RXRTYEN (SCn_CTL[19]), hardware will not set this flag.
+     * |[22]    |RXOVERR   |Receiver over Retry Error
+     * |        |          |This bit is used for receiver retry counts over than retry number limitation.
+     * |        |          |0 = Receiver retries counts is less than RXRTY (SCn_CTL[18:16]) + 1.
+     * |        |          |1 = Receiver retries counts is equal or over than RXRTY (SCn_CTL[18:16]) + 1.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: If CPU enables receiver retries function by setting RXRTYEN (SCn_CTL[19]), hardware will not set this flag.
+     * |[23]    |RXACT     |Receiver in Active Status Flag (Read Only)
+     * |        |          |This bit indicates Rx transfer status.
+     * |        |          |0 = This bit is cleared automatically when Rx transfer is finished.
+     * |        |          |1 = This bit is set by hardware when Rx transfer is in active.
+     * |[26:24] |TXPOINT   |Transmit Buffer Pointer Status (Read Only)
+     * |        |          |This field indicates the Tx buffer pointer status
+     * |        |          |When CPU writes data into SCn_DAT, TXPOINT increases one
+     * |        |          |When one byte of Tx buffer is transferred to transmitter shift register, TXPOINT decreases one.
+     * |[29]    |TXRERR    |Transmitter Retry Error
+     * |        |          |This bit is used for indicate transmitter error retry and set by hardware..
+     * |        |          |0 = No Tx retry transfer.
+     * |        |          |1 = Tx has any error and retries transfer.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: This bit is a flag and cannot generate any interrupt to CPU.
+     * |[30]    |TXOVERR   |Transmitter over Retry Error
+     * |        |          |This bit is used for transmitter retry counts over than retry number limitation.
+     * |        |          |0 = Transmitter retries counts is less than TXRTY (SCn_CTL[22:20]) + 1.
+     * |        |          |1 = Transmitter retries counts is equal or over to TXRTY (SCn_CTL[22:20]) + 1.
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * |[31]    |TXACT     |Transmit in Active Status Flag (Read Only)
+     * |        |          |This bit indicates Tx transmit status.
+     * |        |          |0 = This bit is cleared automatically when Tx transfer is finished or the last byte transmission has completed.
+     * |        |          |1 = Transmit is active and this bit is set by hardware when Tx transfer is in active and the STOP bit of the last byte has not been transmitted.
+     * @var SC_T::PINCTL
+     * Offset: 0x24  SC Pin Control State Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PWREN     |SCn_PWR Pin Signal
+     * |        |          |User can set PWRINV (SCn_PINCTL[11]) and PWREN (SCn_PINCTL[0]) to decide SCn_PWR pin is in high or low level.
+     * |        |          |Write this field to drive SCn_PWR pin
+     * |        |          |Refer PWRINV (SCn_PINCTL[11]) description for programming SCn_PWR pin voltage level.
+     * |        |          |Read this field to get SCn_PWR signal status.
+     * |        |          |0 = SCn_PWR signal status is low.
+     * |        |          |1 = SCn_PWR signal status is high.
+     * |        |          |Note: When operating at activation, warm reset or deactivation mode, this bit will be changed automatically
+     * |        |          |Thus, do not fill in this field when operating in these modes.
+     * |[1]     |RSTEN     |SCn_RST Pin Signal
+     * |        |          |User can set RSTEN (SCn_PINCTL[1]) to decide SCn_RST pin is in high or low level.
+     * |        |          |Write this field to drive SCn_RST pin.
+     * |        |          |0 = Drive SCn_RST pin to low.
+     * |        |          |1 = Drive SCn_RST pin to high.
+     * |        |          |Read this field to get SCn_RST signal status.
+     * |        |          |0 = SCn_RST signal status is low.
+     * |        |          |1 = SCn_RST signal status is high.
+     * |        |          |Note: When operating at activation, warm reset or deactivation mode, this bit will be changed automatically
+     * |        |          |Thus, do not fill in this field when operating in these modes.
+     * |[6]     |CLKKEEP   |SC Clock Enable Bit
+     * |        |          |0 = SC clock generation Disabled.
+     * |        |          |1 = SC clock always keeps free running.
+     * |        |          |Note: When operating in activation, warm reset or deactivation mode, this bit will be changed automatically
+     * |        |          |Thus, do not fill in this field when operating in these modes.
+     * |[9]     |SCDATA    |SCn_DATA Pin Signal
+     * |        |          |This bit is the signal status of SCn_DATA but user can drive SCn_DATA pin to high or low by setting this bit.
+     * |        |          |0 = Drive SCn_DATA pin to low.
+     * |        |          |1 = Drive SCn_DATA pin to high.
+     * |        |          |Read this field to get SCn_DATA signal status.
+     * |        |          |0 = SCn_DATA signal status is low.
+     * |        |          |1 = SCn_DATA signal status is high.
+     * |        |          |Note: When SC is at activation, warm reset or deactivation mode, this bit will be changed automatically
+     * |        |          |Thus, do not fill in this field when SC is in these modes.
+     * |[11]    |PWRINV    |SCn_PWR Pin Inverse
+     * |        |          |This bit is used for inverse the SCn_PWR pin.
+     * |        |          |There are four kinds of combination for SCn_PWR pin setting by PWRINV (SCn_PINCTL[11]) and PWREN (SCn_PINCTL[0]).
+     * |        |          |PWRINV (SCn_PINCTL[11]) is bit 1 and PWREN (SCn_PINCTL[0]) is bit 0 and all conditions as below list,
+     * |        |          |00 = SCn_PWR pin is 0.
+     * |        |          |01 = SCn_PWR pin is 1.
+     * |        |          |10 = SCn_PWR pin is 1.
+     * |        |          |11 = SCn_PWR pin is 0.
+     * |        |          |Note: User must select PWRINV (SCn_PINCTL[11]) before smart card is enabled by SCEN (SCn_CTL[0]).
+     * |[16]    |DATASTS   |SCn_DATA Pin Status (Read Only)
+     * |        |          |This bit is the pin status of SCn_DATA.
+     * |        |          |0 = The SCn_DATA pin status is low.
+     * |        |          |1 = The SCn_DATA pin status is high.
+     * |[17]    |PWRSTS    |SCn_PWR Pin Status (Read Only)
+     * |        |          |This bit is the pin status of SCn_PWR.
+     * |        |          |0 = SCn_PWR pin to low.
+     * |        |          |1 = SCn_PWR pin to high.
+     * |[18]    |RSTSTS    |SCn_RST Pin Status (Read Only)
+     * |        |          |This bit is the pin status of SCn_RST.
+     * |        |          |0 = SCn_RST pin is low.
+     * |        |          |1 = SCn_RST pin is high.
+     * |[30]    |SYNC      |SYNC Flag Indicator (Read Only)
+     * |        |          |Due to synchronization, user should check this bit when writing a new value to SCn_PINCTL register.
+     * |        |          |0 = Synchronizing is completion, user can write new data to SCn_PINCTL register.
+     * |        |          |1 = Last value is synchronizing.
+     * @var SC_T::TMRCTL0
+     * Offset: 0x28  SC Internal Timer0 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[23:0]  |CNT       |Timer0 Counter Value
+     * |        |          |This field indicates the internal Timer0 counter values.
+     * |        |          |Note: Unit of Timer0 counter is ETU base.
+     * |[27:24] |OPMODE    |Timer0 Operation Mode Selection
+     * |        |          |This field indicates the internal 24-bit Timer0 operation selection.
+     * |        |          |Refer to Table 7.14-3 for programming Timer0.
+     * |[31]    |SYNC      |SYNC Flag Indicator (Read Only)
+     * |        |          |Due to synchronization, user should check this bit when writing a new value to the SCn_TMRCTL0 register.
+     * |        |          |0 = Synchronizing is completion, user can write new data to SCn_TMRCTL0 register.
+     * |        |          |1 = Last value is synchronizing.
+     * @var SC_T::TMRCTL1
+     * Offset: 0x2C  SC Internal Timer1 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CNT       |Timer 1 Counter Value
+     * |        |          |This field indicates the internal Timer1 counter values.
+     * |        |          |Note: Unit of Timer1 counter is ETU base.
+     * |[27:24] |OPMODE    |Timer 1 Operation Mode Selection
+     * |        |          |This field indicates the internal 8-bit Timer1 operation selection.
+     * |        |          |Refer to Table 7.14-3 for programming Timer1.
+     * |[31]    |SYNC      |SYNC Flag Indicator (Read Only)
+     * |        |          |Due to synchronization, software should check this bit when writing a new value to SCn_TMRCTL1 register.
+     * |        |          |0 = Synchronizing is completion, user can write new data to SCn_TMRCTL1 register.
+     * |        |          |1 = Last value is synchronizing.
+     * @var SC_T::TMRCTL2
+     * Offset: 0x30  SC Internal Timer2 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CNT       |Timer 2 Counter Value
+     * |        |          |This field indicates the internal Timer2 counter values.
+     * |        |          |Note: Unit of Timer2 counter is ETU base.
+     * |[27:24] |OPMODE    |Timer 2 Operation Mode Selection
+     * |        |          |This field indicates the internal 8-bit Timer2 operation selection
+     * |        |          |Refer to Table 7.14-3 for programming Timer2.
+     * |[31]    |SYNC      |SYNC Flag Indicator (Read Only)
+     * |        |          |Due to synchronization, user should check this bit when writing a new value to SCn_TMRCTL2 register.
+     * |        |          |0 = Synchronizing is completion, user can write new data to SCn_TMRCTL2 register.
+     * |        |          |1 = Last value is synchronizing.
+     * @var SC_T::UARTCTL
+     * Offset: 0x34  SC UART Mode Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |UARTEN    |UART Mode Enable Bit
+     * |        |          |Sets this bit to enable UART mode function.
+     * |        |          |0 = Smart Card mode.
+     * |        |          |1 = UART mode.
+     * |        |          |Note1: When operating in UART mode, user must set CONSEL (SCn_CTL[5:4]) = 00 and AUTOCEN (SCn_CTL[3]) = 0.
+     * |        |          |Note2: When operating in Smart Card mode, user must set UARTEN (SCn_UARTCTL[0]) = 0.
+     * |        |          |Note3: When UART mode is enabled, hardware will generate a reset to reset FIFO and internal state machine.
+     * |[5:4]   |WLS       |Word Length Selection
+     * |        |          |This field is used for select UART data length.
+     * |        |          |00 = Word length is 8 bits.
+     * |        |          |01 = Word length is 7 bits.
+     * |        |          |10 = Word length is 6 bits.
+     * |        |          |11 = Word length is 5 bits.
+     * |        |          |Note: In smart card mode, this WLS must be 00.
+     * |[6]     |PBOFF     |Parity Bit Disable Bit
+     * |        |          |Sets this bit is used for disable parity check function.
+     * |        |          |0 = Parity bit is generated or checked between the "last data word bit" and "stop bit" of the serial data.
+     * |        |          |1 = Parity bit is not generated (transmitting data) or checked (receiving data) during transfer.
+     * |        |          |Note: In smart card mode, this field must be 0 (default setting is with parity bit).
+     * |[7]     |OPE       |Odd Parity Enable Bit
+     * |        |          |This is used for odd/even parity selection.
+     * |        |          |0 = Even number of logic 1 are transmitted or check the data word and parity bits in receiving mode.
+     * |        |          |1 = Odd number of logic 1 are transmitted or check the data word and parity bits in receiving mode.
+     * |        |          |Note: This bit has effect only when PBOFF bit is 0.
+     * @var SC_T::ACTCTL
+     * Offset: 0x4C  SC Activation Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[4:0]   |T1EXT     |T1 Extend Time of Hardware Activation
+     * |        |          |This field provide the configurable cycles to extend the activation time T1 period.
+     * |        |          |The cycle scaling factor is 2048.
+     * |        |          |Extend cycles = (filled value * 2048) cycles.
+     * |        |          |Refer to SC activation sequence in Figure 7.14-4.
+     * |        |          |For example,
+     * |        |          |SCLK = 4MHz, each cycle = 0.25us,.
+     * |        |          |Filled 20 to this field
+     * |        |          |Extend time = 20 * 2048 * 0.25us = 10.24 ms.
+     * |        |          |Note: Setting 0 to this field conforms to the protocol ISO/IEC 7816-3
+     */
+    __IO uint32_t DAT;                   /*!< [0x0000] SC Receive/Transmit Holding Buffer Register                      */
+    __IO uint32_t CTL;                   /*!< [0x0004] SC Control Register                                              */
+    __IO uint32_t ALTCTL;                /*!< [0x0008] SC Alternate Control Register                                    */
+    __IO uint32_t EGT;                   /*!< [0x000c] SC Extra Guard Time Register                                     */
+    __IO uint32_t RXTOUT;                /*!< [0x0010] SC Receive Buffer Time-out Counter Register                      */
+    __IO uint32_t ETUCTL;                /*!< [0x0014] SC Element Time Unit Control Register                            */
+    __IO uint32_t INTEN;                 /*!< [0x0018] SC Interrupt Enable Control Register                             */
+    __IO uint32_t INTSTS;                /*!< [0x001c] SC Interrupt Status Register                                     */
+    __IO uint32_t STATUS;                /*!< [0x0020] SC Transfer Status Register                                      */
+    __IO uint32_t PINCTL;                /*!< [0x0024] SC Pin Control State Register                                    */
+    __IO uint32_t TMRCTL0;               /*!< [0x0028] SC Internal Timer0 Control Register                              */
+    __IO uint32_t TMRCTL1;               /*!< [0x002c] SC Internal Timer1 Control Register                              */
+    __IO uint32_t TMRCTL2;               /*!< [0x0030] SC Internal Timer2 Control Register                              */
+    __IO uint32_t UARTCTL;               /*!< [0x0034] SC UART Mode Control Register                                    */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[5];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t ACTCTL;                /*!< [0x004c] SC Activation Control Register                                   */
+} SC_T;
+
+/**
+    @addtogroup SC_CONST SC Bit Field Definition
+    Constant Definitions for SC Controller
+@{ */
+
+#define SC_DAT_DAT_Pos                   (0)                                               /*!< SC_T::DAT: DAT Position                */
+#define SC_DAT_DAT_Msk                   (0xfful << SC_DAT_DAT_Pos)                        /*!< SC_T::DAT: DAT Mask                    */
+
+#define SC_CTL_SCEN_Pos                  (0)                                               /*!< SC_T::CTL: SCEN Position               */
+#define SC_CTL_SCEN_Msk                  (0x1ul << SC_CTL_SCEN_Pos)                        /*!< SC_T::CTL: SCEN Mask                   */
+
+#define SC_CTL_RXOFF_Pos                 (1)                                               /*!< SC_T::CTL: RXOFF Position              */
+#define SC_CTL_RXOFF_Msk                 (0x1ul << SC_CTL_RXOFF_Pos)                       /*!< SC_T::CTL: RXOFF Mask                  */
+
+#define SC_CTL_TXOFF_Pos                 (2)                                               /*!< SC_T::CTL: TXOFF Position              */
+#define SC_CTL_TXOFF_Msk                 (0x1ul << SC_CTL_TXOFF_Pos)                       /*!< SC_T::CTL: TXOFF Mask                  */
+
+#define SC_CTL_AUTOCEN_Pos               (3)                                               /*!< SC_T::CTL: AUTOCEN Position            */
+#define SC_CTL_AUTOCEN_Msk               (0x1ul << SC_CTL_AUTOCEN_Pos)                     /*!< SC_T::CTL: AUTOCEN Mask                */
+
+#define SC_CTL_CONSEL_Pos                (4)                                               /*!< SC_T::CTL: CONSEL Position             */
+#define SC_CTL_CONSEL_Msk                (0x3ul << SC_CTL_CONSEL_Pos)                      /*!< SC_T::CTL: CONSEL Mask                 */
+
+#define SC_CTL_RXTRGLV_Pos               (6)                                               /*!< SC_T::CTL: RXTRGLV Position            */
+#define SC_CTL_RXTRGLV_Msk               (0x3ul << SC_CTL_RXTRGLV_Pos)                     /*!< SC_T::CTL: RXTRGLV Mask                */
+
+#define SC_CTL_BGT_Pos                   (8)                                               /*!< SC_T::CTL: BGT Position                */
+#define SC_CTL_BGT_Msk                   (0x1ful << SC_CTL_BGT_Pos)                        /*!< SC_T::CTL: BGT Mask                    */
+
+#define SC_CTL_TMRSEL_Pos                (13)                                              /*!< SC_T::CTL: TMRSEL Position             */
+#define SC_CTL_TMRSEL_Msk                (0x3ul << SC_CTL_TMRSEL_Pos)                      /*!< SC_T::CTL: TMRSEL Mask                 */
+
+#define SC_CTL_NSB_Pos                   (15)                                              /*!< SC_T::CTL: NSB Position                */
+#define SC_CTL_NSB_Msk                   (0x1ul << SC_CTL_NSB_Pos)                         /*!< SC_T::CTL: NSB Mask                    */
+
+#define SC_CTL_RXRTY_Pos                 (16)                                              /*!< SC_T::CTL: RXRTY Position              */
+#define SC_CTL_RXRTY_Msk                 (0x7ul << SC_CTL_RXRTY_Pos)                       /*!< SC_T::CTL: RXRTY Mask                  */
+
+#define SC_CTL_RXRTYEN_Pos               (19)                                              /*!< SC_T::CTL: RXRTYEN Position            */
+#define SC_CTL_RXRTYEN_Msk               (0x1ul << SC_CTL_RXRTYEN_Pos)                     /*!< SC_T::CTL: RXRTYEN Mask                */
+
+#define SC_CTL_TXRTY_Pos                 (20)                                              /*!< SC_T::CTL: TXRTY Position              */
+#define SC_CTL_TXRTY_Msk                 (0x7ul << SC_CTL_TXRTY_Pos)                       /*!< SC_T::CTL: TXRTY Mask                  */
+
+#define SC_CTL_TXRTYEN_Pos               (23)                                              /*!< SC_T::CTL: TXRTYEN Position            */
+#define SC_CTL_TXRTYEN_Msk               (0x1ul << SC_CTL_TXRTYEN_Pos)                     /*!< SC_T::CTL: TXRTYEN Mask                */
+
+#define SC_CTL_CDDBSEL_Pos               (24)                                              /*!< SC_T::CTL: CDDBSEL Position            */
+#define SC_CTL_CDDBSEL_Msk               (0x3ul << SC_CTL_CDDBSEL_Pos)                     /*!< SC_T::CTL: CDDBSEL Mask                */
+
+#define SC_CTL_CDLV_Pos                  (26)                                              /*!< SC_T::CTL: CDLV Position               */
+#define SC_CTL_CDLV_Msk                  (0x1ul << SC_CTL_CDLV_Pos)                        /*!< SC_T::CTL: CDLV Mask                   */
+
+#define SC_CTL_SYNC_Pos                  (30)                                              /*!< SC_T::CTL: SYNC Position               */
+#define SC_CTL_SYNC_Msk                  (0x1ul << SC_CTL_SYNC_Pos)                        /*!< SC_T::CTL: SYNC Mask                   */
+
+#define SC_ALTCTL_TXRST_Pos              (0)                                               /*!< SC_T::ALTCTL: TXRST Position           */
+#define SC_ALTCTL_TXRST_Msk              (0x1ul << SC_ALTCTL_TXRST_Pos)                    /*!< SC_T::ALTCTL: TXRST Mask               */
+
+#define SC_ALTCTL_RXRST_Pos              (1)                                               /*!< SC_T::ALTCTL: RXRST Position           */
+#define SC_ALTCTL_RXRST_Msk              (0x1ul << SC_ALTCTL_RXRST_Pos)                    /*!< SC_T::ALTCTL: RXRST Mask               */
+
+#define SC_ALTCTL_DACTEN_Pos             (2)                                               /*!< SC_T::ALTCTL: DACTEN Position          */
+#define SC_ALTCTL_DACTEN_Msk             (0x1ul << SC_ALTCTL_DACTEN_Pos)                   /*!< SC_T::ALTCTL: DACTEN Mask              */
+
+#define SC_ALTCTL_ACTEN_Pos              (3)                                               /*!< SC_T::ALTCTL: ACTEN Position           */
+#define SC_ALTCTL_ACTEN_Msk              (0x1ul << SC_ALTCTL_ACTEN_Pos)                    /*!< SC_T::ALTCTL: ACTEN Mask               */
+
+#define SC_ALTCTL_WARSTEN_Pos            (4)                                               /*!< SC_T::ALTCTL: WARSTEN Position         */
+#define SC_ALTCTL_WARSTEN_Msk            (0x1ul << SC_ALTCTL_WARSTEN_Pos)                  /*!< SC_T::ALTCTL: WARSTEN Mask             */
+
+#define SC_ALTCTL_CNTEN0_Pos             (5)                                               /*!< SC_T::ALTCTL: CNTEN0 Position          */
+#define SC_ALTCTL_CNTEN0_Msk             (0x1ul << SC_ALTCTL_CNTEN0_Pos)                   /*!< SC_T::ALTCTL: CNTEN0 Mask              */
+
+#define SC_ALTCTL_CNTEN1_Pos             (6)                                               /*!< SC_T::ALTCTL: CNTEN1 Position          */
+#define SC_ALTCTL_CNTEN1_Msk             (0x1ul << SC_ALTCTL_CNTEN1_Pos)                   /*!< SC_T::ALTCTL: CNTEN1 Mask              */
+
+#define SC_ALTCTL_CNTEN2_Pos             (7)                                               /*!< SC_T::ALTCTL: CNTEN2 Position          */
+#define SC_ALTCTL_CNTEN2_Msk             (0x1ul << SC_ALTCTL_CNTEN2_Pos)                   /*!< SC_T::ALTCTL: CNTEN2 Mask              */
+
+#define SC_ALTCTL_INITSEL_Pos            (8)                                               /*!< SC_T::ALTCTL: INITSEL Position         */
+#define SC_ALTCTL_INITSEL_Msk            (0x3ul << SC_ALTCTL_INITSEL_Pos)                  /*!< SC_T::ALTCTL: INITSEL Mask             */
+
+#define SC_ALTCTL_ADACEN_Pos             (11)                                              /*!< SC_T::ALTCTL: ADACEN Position          */
+#define SC_ALTCTL_ADACEN_Msk             (0x1ul << SC_ALTCTL_ADACEN_Pos)                   /*!< SC_T::ALTCTL: ADACEN Mask              */
+
+#define SC_ALTCTL_RXBGTEN_Pos            (12)                                              /*!< SC_T::ALTCTL: RXBGTEN Position         */
+#define SC_ALTCTL_RXBGTEN_Msk            (0x1ul << SC_ALTCTL_RXBGTEN_Pos)                  /*!< SC_T::ALTCTL: RXBGTEN Mask             */
+
+#define SC_ALTCTL_ACTSTS0_Pos            (13)                                              /*!< SC_T::ALTCTL: ACTSTS0 Position         */
+#define SC_ALTCTL_ACTSTS0_Msk            (0x1ul << SC_ALTCTL_ACTSTS0_Pos)                  /*!< SC_T::ALTCTL: ACTSTS0 Mask             */
+
+#define SC_ALTCTL_ACTSTS1_Pos            (14)                                              /*!< SC_T::ALTCTL: ACTSTS1 Position         */
+#define SC_ALTCTL_ACTSTS1_Msk            (0x1ul << SC_ALTCTL_ACTSTS1_Pos)                  /*!< SC_T::ALTCTL: ACTSTS1 Mask             */
+
+#define SC_ALTCTL_ACTSTS2_Pos            (15)                                              /*!< SC_T::ALTCTL: ACTSTS2 Position         */
+#define SC_ALTCTL_ACTSTS2_Msk            (0x1ul << SC_ALTCTL_ACTSTS2_Pos)                  /*!< SC_T::ALTCTL: ACTSTS2 Mask             */
+
+#define SC_ALTCTL_SYNC_Pos               (31)                                              /*!< SC_T::ALTCTL: SYNC Position            */
+#define SC_ALTCTL_SYNC_Msk               (0x1ul << SC_ALTCTL_SYNC_Pos)                     /*!< SC_T::ALTCTL: SYNC Mask                */
+
+#define SC_EGT_EGT_Pos                   (0)                                               /*!< SC_T::EGT: EGT Position                */
+#define SC_EGT_EGT_Msk                   (0xfful << SC_EGT_EGT_Pos)                        /*!< SC_T::EGT: EGT Mask                    */
+
+#define SC_RXTOUT_RFTM_Pos               (0)                                               /*!< SC_T::RXTOUT: RFTM Position            */
+#define SC_RXTOUT_RFTM_Msk               (0x1fful << SC_RXTOUT_RFTM_Pos)                   /*!< SC_T::RXTOUT: RFTM Mask                */
+
+#define SC_ETUCTL_ETURDIV_Pos            (0)                                               /*!< SC_T::ETUCTL: ETURDIV Position         */
+#define SC_ETUCTL_ETURDIV_Msk            (0xffful << SC_ETUCTL_ETURDIV_Pos)                /*!< SC_T::ETUCTL: ETURDIV Mask             */
+
+#define SC_INTEN_RDAIEN_Pos              (0)                                               /*!< SC_T::INTEN: RDAIEN Position           */
+#define SC_INTEN_RDAIEN_Msk              (0x1ul << SC_INTEN_RDAIEN_Pos)                    /*!< SC_T::INTEN: RDAIEN Mask               */
+
+#define SC_INTEN_TBEIEN_Pos              (1)                                               /*!< SC_T::INTEN: TBEIEN Position           */
+#define SC_INTEN_TBEIEN_Msk              (0x1ul << SC_INTEN_TBEIEN_Pos)                    /*!< SC_T::INTEN: TBEIEN Mask               */
+
+#define SC_INTEN_TERRIEN_Pos             (2)                                               /*!< SC_T::INTEN: TERRIEN Position          */
+#define SC_INTEN_TERRIEN_Msk             (0x1ul << SC_INTEN_TERRIEN_Pos)                   /*!< SC_T::INTEN: TERRIEN Mask              */
+
+#define SC_INTEN_TMR0IEN_Pos             (3)                                               /*!< SC_T::INTEN: TMR0IEN Position          */
+#define SC_INTEN_TMR0IEN_Msk             (0x1ul << SC_INTEN_TMR0IEN_Pos)                   /*!< SC_T::INTEN: TMR0IEN Mask              */
+
+#define SC_INTEN_TMR1IEN_Pos             (4)                                               /*!< SC_T::INTEN: TMR1IEN Position          */
+#define SC_INTEN_TMR1IEN_Msk             (0x1ul << SC_INTEN_TMR1IEN_Pos)                   /*!< SC_T::INTEN: TMR1IEN Mask              */
+
+#define SC_INTEN_TMR2IEN_Pos             (5)                                               /*!< SC_T::INTEN: TMR2IEN Position          */
+#define SC_INTEN_TMR2IEN_Msk             (0x1ul << SC_INTEN_TMR2IEN_Pos)                   /*!< SC_T::INTEN: TMR2IEN Mask              */
+
+#define SC_INTEN_BGTIEN_Pos              (6)                                               /*!< SC_T::INTEN: BGTIEN Position           */
+#define SC_INTEN_BGTIEN_Msk              (0x1ul << SC_INTEN_BGTIEN_Pos)                    /*!< SC_T::INTEN: BGTIEN Mask               */
+
+#define SC_INTEN_CDIEN_Pos               (7)                                               /*!< SC_T::INTEN: CDIEN Position            */
+#define SC_INTEN_CDIEN_Msk               (0x1ul << SC_INTEN_CDIEN_Pos)                     /*!< SC_T::INTEN: CDIEN Mask                */
+
+#define SC_INTEN_INITIEN_Pos             (8)                                               /*!< SC_T::INTEN: INITIEN Position          */
+#define SC_INTEN_INITIEN_Msk             (0x1ul << SC_INTEN_INITIEN_Pos)                   /*!< SC_T::INTEN: INITIEN Mask              */
+
+#define SC_INTEN_RXTOIEN_Pos             (9)                                               /*!< SC_T::INTEN: RXTOIEN Position          */
+#define SC_INTEN_RXTOIEN_Msk             (0x1ul << SC_INTEN_RXTOIEN_Pos)                   /*!< SC_T::INTEN: RXTOIEN Mask              */
+
+#define SC_INTEN_ACERRIEN_Pos            (10)                                              /*!< SC_T::INTEN: ACERRIEN Position         */
+#define SC_INTEN_ACERRIEN_Msk            (0x1ul << SC_INTEN_ACERRIEN_Pos)                  /*!< SC_T::INTEN: ACERRIEN Mask             */
+
+#define SC_INTSTS_RDAIF_Pos              (0)                                               /*!< SC_T::INTSTS: RDAIF Position           */
+#define SC_INTSTS_RDAIF_Msk              (0x1ul << SC_INTSTS_RDAIF_Pos)                    /*!< SC_T::INTSTS: RDAIF Mask               */
+
+#define SC_INTSTS_TBEIF_Pos              (1)                                               /*!< SC_T::INTSTS: TBEIF Position           */
+#define SC_INTSTS_TBEIF_Msk              (0x1ul << SC_INTSTS_TBEIF_Pos)                    /*!< SC_T::INTSTS: TBEIF Mask               */
+
+#define SC_INTSTS_TERRIF_Pos             (2)                                               /*!< SC_T::INTSTS: TERRIF Position          */
+#define SC_INTSTS_TERRIF_Msk             (0x1ul << SC_INTSTS_TERRIF_Pos)                   /*!< SC_T::INTSTS: TERRIF Mask              */
+
+#define SC_INTSTS_TMR0IF_Pos             (3)                                               /*!< SC_T::INTSTS: TMR0IF Position          */
+#define SC_INTSTS_TMR0IF_Msk             (0x1ul << SC_INTSTS_TMR0IF_Pos)                   /*!< SC_T::INTSTS: TMR0IF Mask              */
+
+#define SC_INTSTS_TMR1IF_Pos             (4)                                               /*!< SC_T::INTSTS: TMR1IF Position          */
+#define SC_INTSTS_TMR1IF_Msk             (0x1ul << SC_INTSTS_TMR1IF_Pos)                   /*!< SC_T::INTSTS: TMR1IF Mask              */
+
+#define SC_INTSTS_TMR2IF_Pos             (5)                                               /*!< SC_T::INTSTS: TMR2IF Position          */
+#define SC_INTSTS_TMR2IF_Msk             (0x1ul << SC_INTSTS_TMR2IF_Pos)                   /*!< SC_T::INTSTS: TMR2IF Mask              */
+
+#define SC_INTSTS_BGTIF_Pos              (6)                                               /*!< SC_T::INTSTS: BGTIF Position           */
+#define SC_INTSTS_BGTIF_Msk              (0x1ul << SC_INTSTS_BGTIF_Pos)                    /*!< SC_T::INTSTS: BGTIF Mask               */
+
+#define SC_INTSTS_CDIF_Pos               (7)                                               /*!< SC_T::INTSTS: CDIF Position            */
+#define SC_INTSTS_CDIF_Msk               (0x1ul << SC_INTSTS_CDIF_Pos)                     /*!< SC_T::INTSTS: CDIF Mask                */
+
+#define SC_INTSTS_INITIF_Pos             (8)                                               /*!< SC_T::INTSTS: INITIF Position          */
+#define SC_INTSTS_INITIF_Msk             (0x1ul << SC_INTSTS_INITIF_Pos)                   /*!< SC_T::INTSTS: INITIF Mask              */
+
+#define SC_INTSTS_RXTOIF_Pos             (9)                                               /*!< SC_T::INTSTS: RXTOIF Position          */
+#define SC_INTSTS_RXTOIF_Msk             (0x1ul << SC_INTSTS_RXTOIF_Pos)                   /*!< SC_T::INTSTS: RXTOIF Mask              */
+
+#define SC_INTSTS_ACERRIF_Pos            (10)                                              /*!< SC_T::INTSTS: ACERRIF Position         */
+#define SC_INTSTS_ACERRIF_Msk            (0x1ul << SC_INTSTS_ACERRIF_Pos)                  /*!< SC_T::INTSTS: ACERRIF Mask             */
+
+#define SC_STATUS_RXOV_Pos               (0)                                               /*!< SC_T::STATUS: RXOV Position            */
+#define SC_STATUS_RXOV_Msk               (0x1ul << SC_STATUS_RXOV_Pos)                     /*!< SC_T::STATUS: RXOV Mask                */
+
+#define SC_STATUS_RXEMPTY_Pos            (1)                                               /*!< SC_T::STATUS: RXEMPTY Position         */
+#define SC_STATUS_RXEMPTY_Msk            (0x1ul << SC_STATUS_RXEMPTY_Pos)                  /*!< SC_T::STATUS: RXEMPTY Mask             */
+
+#define SC_STATUS_RXFULL_Pos             (2)                                               /*!< SC_T::STATUS: RXFULL Position          */
+#define SC_STATUS_RXFULL_Msk             (0x1ul << SC_STATUS_RXFULL_Pos)                   /*!< SC_T::STATUS: RXFULL Mask              */
+
+#define SC_STATUS_PEF_Pos                (4)                                               /*!< SC_T::STATUS: PEF Position             */
+#define SC_STATUS_PEF_Msk                (0x1ul << SC_STATUS_PEF_Pos)                      /*!< SC_T::STATUS: PEF Mask                 */
+
+#define SC_STATUS_FEF_Pos                (5)                                               /*!< SC_T::STATUS: FEF Position             */
+#define SC_STATUS_FEF_Msk                (0x1ul << SC_STATUS_FEF_Pos)                      /*!< SC_T::STATUS: FEF Mask                 */
+
+#define SC_STATUS_BEF_Pos                (6)                                               /*!< SC_T::STATUS: BEF Position             */
+#define SC_STATUS_BEF_Msk                (0x1ul << SC_STATUS_BEF_Pos)                      /*!< SC_T::STATUS: BEF Mask                 */
+
+#define SC_STATUS_TXOV_Pos               (8)                                               /*!< SC_T::STATUS: TXOV Position            */
+#define SC_STATUS_TXOV_Msk               (0x1ul << SC_STATUS_TXOV_Pos)                     /*!< SC_T::STATUS: TXOV Mask                */
+
+#define SC_STATUS_TXEMPTY_Pos            (9)                                               /*!< SC_T::STATUS: TXEMPTY Position         */
+#define SC_STATUS_TXEMPTY_Msk            (0x1ul << SC_STATUS_TXEMPTY_Pos)                  /*!< SC_T::STATUS: TXEMPTY Mask             */
+
+#define SC_STATUS_TXFULL_Pos             (10)                                              /*!< SC_T::STATUS: TXFULL Position          */
+#define SC_STATUS_TXFULL_Msk             (0x1ul << SC_STATUS_TXFULL_Pos)                   /*!< SC_T::STATUS: TXFULL Mask              */
+
+#define SC_STATUS_CREMOVE_Pos            (11)                                              /*!< SC_T::STATUS: CREMOVE Position         */
+#define SC_STATUS_CREMOVE_Msk            (0x1ul << SC_STATUS_CREMOVE_Pos)                  /*!< SC_T::STATUS: CREMOVE Mask             */
+
+#define SC_STATUS_CINSERT_Pos            (12)                                              /*!< SC_T::STATUS: CINSERT Position         */
+#define SC_STATUS_CINSERT_Msk            (0x1ul << SC_STATUS_CINSERT_Pos)                  /*!< SC_T::STATUS: CINSERT Mask             */
+
+#define SC_STATUS_CDPINSTS_Pos           (13)                                              /*!< SC_T::STATUS: CDPINSTS Position        */
+#define SC_STATUS_CDPINSTS_Msk           (0x1ul << SC_STATUS_CDPINSTS_Pos)                 /*!< SC_T::STATUS: CDPINSTS Mask            */
+
+#define SC_STATUS_RXPOINT_Pos            (16)                                              /*!< SC_T::STATUS: RXPOINT Position         */
+#define SC_STATUS_RXPOINT_Msk            (0x7ul << SC_STATUS_RXPOINT_Pos)                  /*!< SC_T::STATUS: RXPOINT Mask             */
+
+#define SC_STATUS_RXRERR_Pos             (21)                                              /*!< SC_T::STATUS: RXRERR Position          */
+#define SC_STATUS_RXRERR_Msk             (0x1ul << SC_STATUS_RXRERR_Pos)                   /*!< SC_T::STATUS: RXRERR Mask              */
+
+#define SC_STATUS_RXOVERR_Pos            (22)                                              /*!< SC_T::STATUS: RXOVERR Position         */
+#define SC_STATUS_RXOVERR_Msk            (0x1ul << SC_STATUS_RXOVERR_Pos)                  /*!< SC_T::STATUS: RXOVERR Mask             */
+
+#define SC_STATUS_RXACT_Pos              (23)                                              /*!< SC_T::STATUS: RXACT Position           */
+#define SC_STATUS_RXACT_Msk              (0x1ul << SC_STATUS_RXACT_Pos)                    /*!< SC_T::STATUS: RXACT Mask               */
+
+#define SC_STATUS_TXPOINT_Pos            (24)                                              /*!< SC_T::STATUS: TXPOINT Position         */
+#define SC_STATUS_TXPOINT_Msk            (0x7ul << SC_STATUS_TXPOINT_Pos)                  /*!< SC_T::STATUS: TXPOINT Mask             */
+
+#define SC_STATUS_TXRERR_Pos             (29)                                              /*!< SC_T::STATUS: TXRERR Position          */
+#define SC_STATUS_TXRERR_Msk             (0x1ul << SC_STATUS_TXRERR_Pos)                   /*!< SC_T::STATUS: TXRERR Mask              */
+
+#define SC_STATUS_TXOVERR_Pos            (30)                                              /*!< SC_T::STATUS: TXOVERR Position         */
+#define SC_STATUS_TXOVERR_Msk            (0x1ul << SC_STATUS_TXOVERR_Pos)                  /*!< SC_T::STATUS: TXOVERR Mask             */
+
+#define SC_STATUS_TXACT_Pos              (31)                                              /*!< SC_T::STATUS: TXACT Position           */
+#define SC_STATUS_TXACT_Msk              (0x1ul << SC_STATUS_TXACT_Pos)                    /*!< SC_T::STATUS: TXACT Mask               */
+
+#define SC_PINCTL_PWREN_Pos              (0)                                               /*!< SC_T::PINCTL: PWREN Position           */
+#define SC_PINCTL_PWREN_Msk              (0x1ul << SC_PINCTL_PWREN_Pos)                    /*!< SC_T::PINCTL: PWREN Mask               */
+
+#define SC_PINCTL_RSTEN_Pos              (1)                                               /*!< SC_T::PINCTL: RSTEN Position           */
+#define SC_PINCTL_RSTEN_Msk              (0x1ul << SC_PINCTL_RSTEN_Pos)                    /*!< SC_T::PINCTL: RSTEN Mask               */
+
+#define SC_PINCTL_CLKKEEP_Pos            (6)                                               /*!< SC_T::PINCTL: CLKKEEP Position         */
+#define SC_PINCTL_CLKKEEP_Msk            (0x1ul << SC_PINCTL_CLKKEEP_Pos)                  /*!< SC_T::PINCTL: CLKKEEP Mask             */
+
+#define SC_PINCTL_SCDATA_Pos             (9)                                               /*!< SC_T::PINCTL: SCDATA Position          */
+#define SC_PINCTL_SCDATA_Msk             (0x1ul << SC_PINCTL_SCDATA_Pos)                   /*!< SC_T::PINCTL: SCDATA Mask              */
+
+#define SC_PINCTL_PWRINV_Pos             (11)                                              /*!< SC_T::PINCTL: PWRINV Position          */
+#define SC_PINCTL_PWRINV_Msk             (0x1ul << SC_PINCTL_PWRINV_Pos)                   /*!< SC_T::PINCTL: PWRINV Mask              */
+
+#define SC_PINCTL_DATASTS_Pos            (16)                                              /*!< SC_T::PINCTL: DATASTS Position         */
+#define SC_PINCTL_DATASTS_Msk            (0x1ul << SC_PINCTL_DATASTS_Pos)                  /*!< SC_T::PINCTL: DATASTS Mask             */
+
+#define SC_PINCTL_PWRSTS_Pos             (17)                                              /*!< SC_T::PINCTL: PWRSTS Position          */
+#define SC_PINCTL_PWRSTS_Msk             (0x1ul << SC_PINCTL_PWRSTS_Pos)                   /*!< SC_T::PINCTL: PWRSTS Mask              */
+
+#define SC_PINCTL_RSTSTS_Pos             (18)                                              /*!< SC_T::PINCTL: RSTSTS Position          */
+#define SC_PINCTL_RSTSTS_Msk             (0x1ul << SC_PINCTL_RSTSTS_Pos)                   /*!< SC_T::PINCTL: RSTSTS Mask              */
+
+#define SC_PINCTL_SYNC_Pos               (30)                                              /*!< SC_T::PINCTL: SYNC Position            */
+#define SC_PINCTL_SYNC_Msk               (0x1ul << SC_PINCTL_SYNC_Pos)                     /*!< SC_T::PINCTL: SYNC Mask                */
+
+#define SC_TMRCTL0_CNT_Pos               (0)                                               /*!< SC_T::TMRCTL0: CNT Position            */
+#define SC_TMRCTL0_CNT_Msk               (0xfffffful << SC_TMRCTL0_CNT_Pos)                /*!< SC_T::TMRCTL0: CNT Mask                */
+
+#define SC_TMRCTL0_OPMODE_Pos            (24)                                              /*!< SC_T::TMRCTL0: OPMODE Position         */
+#define SC_TMRCTL0_OPMODE_Msk            (0xful << SC_TMRCTL0_OPMODE_Pos)                  /*!< SC_T::TMRCTL0: OPMODE Mask             */
+
+#define SC_TMRCTL0_SYNC_Pos              (31)                                              /*!< SC_T::TMRCTL0: SYNC Position           */
+#define SC_TMRCTL0_SYNC_Msk              (0x1ul << SC_TMRCTL0_SYNC_Pos)                    /*!< SC_T::TMRCTL0: SYNC Mask               */
+
+#define SC_TMRCTL1_CNT_Pos               (0)                                               /*!< SC_T::TMRCTL1: CNT Position            */
+#define SC_TMRCTL1_CNT_Msk               (0xfful << SC_TMRCTL1_CNT_Pos)                    /*!< SC_T::TMRCTL1: CNT Mask                */
+
+#define SC_TMRCTL1_OPMODE_Pos            (24)                                              /*!< SC_T::TMRCTL1: OPMODE Position         */
+#define SC_TMRCTL1_OPMODE_Msk            (0xful << SC_TMRCTL1_OPMODE_Pos)                  /*!< SC_T::TMRCTL1: OPMODE Mask             */
+
+#define SC_TMRCTL1_SYNC_Pos              (31)                                              /*!< SC_T::TMRCTL1: SYNC Position           */
+#define SC_TMRCTL1_SYNC_Msk              (0x1ul << SC_TMRCTL1_SYNC_Pos)                    /*!< SC_T::TMRCTL1: SYNC Mask               */
+
+#define SC_TMRCTL2_CNT_Pos               (0)                                               /*!< SC_T::TMRCTL2: CNT Position            */
+#define SC_TMRCTL2_CNT_Msk               (0xfful << SC_TMRCTL2_CNT_Pos)                    /*!< SC_T::TMRCTL2: CNT Mask                */
+
+#define SC_TMRCTL2_OPMODE_Pos            (24)                                              /*!< SC_T::TMRCTL2: OPMODE Position         */
+#define SC_TMRCTL2_OPMODE_Msk            (0xful << SC_TMRCTL2_OPMODE_Pos)                  /*!< SC_T::TMRCTL2: OPMODE Mask             */
+
+#define SC_TMRCTL2_SYNC_Pos              (31)                                              /*!< SC_T::TMRCTL2: SYNC Position           */
+#define SC_TMRCTL2_SYNC_Msk              (0x1ul << SC_TMRCTL2_SYNC_Pos)                    /*!< SC_T::TMRCTL2: SYNC Mask               */
+
+#define SC_UARTCTL_UARTEN_Pos            (0)                                               /*!< SC_T::UARTCTL: UARTEN Position         */
+#define SC_UARTCTL_UARTEN_Msk            (0x1ul << SC_UARTCTL_UARTEN_Pos)                  /*!< SC_T::UARTCTL: UARTEN Mask             */
+
+#define SC_UARTCTL_WLS_Pos               (4)                                               /*!< SC_T::UARTCTL: WLS Position            */
+#define SC_UARTCTL_WLS_Msk               (0x3ul << SC_UARTCTL_WLS_Pos)                     /*!< SC_T::UARTCTL: WLS Mask                */
+
+#define SC_UARTCTL_PBOFF_Pos             (6)                                               /*!< SC_T::UARTCTL: PBOFF Position          */
+#define SC_UARTCTL_PBOFF_Msk             (0x1ul << SC_UARTCTL_PBOFF_Pos)                   /*!< SC_T::UARTCTL: PBOFF Mask              */
+
+#define SC_UARTCTL_OPE_Pos               (7)                                               /*!< SC_T::UARTCTL: OPE Position            */
+#define SC_UARTCTL_OPE_Msk               (0x1ul << SC_UARTCTL_OPE_Pos)                     /*!< SC_T::UARTCTL: OPE Mask                */
+
+#define SC_ACTCTL_T1EXT_Pos              (0)                                               /*!< SC_T::ACTCTL: T1EXT Position           */
+#define SC_ACTCTL_T1EXT_Msk              (0x1ful << SC_ACTCTL_T1EXT_Pos)                   /*!< SC_T::ACTCTL: T1EXT Mask               */
+
+/** @} SC_CONST */
+/** @} end of SC register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __SC_REG_H__ */

--- a/hal/m258ke/nuvoton/spi_reg.h
+++ b/hal/m258ke/nuvoton/spi_reg.h
@@ -1,0 +1,884 @@
+/**************************************************************************//**
+ * @file     spi_reg.h
+ * @version  V1.00
+ * @brief    SPI register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __SPI_REG_H__
+#define __SPI_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup SPI Serial Peripheral Interface Controller (SPI)
+    Memory Mapped Structure for SPI Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var SPI_T::CTL
+     * Offset: 0x00  SPI Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SPIEN     |SPI Transfer Control Enable Bit
+     * |        |          |In Master mode, the transfer will start when there is data in the FIFO buffer after this bit is set to 1
+     * |        |          |In Slave mode, this device is ready to receive data when this bit is set to 1.
+     * |        |          |0 = Transfer control Disabled.
+     * |        |          |1 = Transfer control Enabled.
+     * |        |          |Note: Before changing the configurations of SPIx_CTL, SPIx_CLKDIV, SPIx_SSCTL and SPIx_FIFOCTL registers, user shall clear the SPIEN (SPIx_CTL[0]) and confirm the SPIENSTS (SPIx_STATUS[15]) is 0.
+     * |[1]     |RXNEG     |Receive on Negative Edge
+     * |        |          |0 = Received data input signal is latched on the rising edge of SPI bus clock.
+     * |        |          |1 = Received data input signal is latched on the falling edge of SPI bus clock.
+     * |[2]     |TXNEG     |Transmit on Negative Edge
+     * |        |          |0 = Transmitted data output signal is changed on the rising edge of SPI bus clock.
+     * |        |          |1 = Transmitted data output signal is changed on the falling edge of SPI bus clock.
+     * |[3]     |CLKPOL    |Clock Polarity
+     * |        |          |0 = SPI bus clock is idle low.
+     * |        |          |1 = SPI bus clock is idle high.
+     * |[7:4]   |SUSPITV   |Suspend Interval (Master Only)
+     * |        |          |The four bits provide configurable suspend interval between two successive transmit/receive transaction in a transfer
+     * |        |          |The definition of the suspend interval is the interval between the last clock edge of the preceding transaction word and the first clock edge of the following transaction word
+     * |        |          |The default value is 0x3
+     * |        |          |The period of the suspend interval is obtained according to the following equation.
+     * |        |          |(SUSPITV[3:0] + 0.5) * period of SPICLK clock cycle
+     * |        |          |Example:
+     * |        |          |SUSPITV = 0x0 u2026. 0.5 SPICLK clock cycle.
+     * |        |          |SUSPITV = 0x1 u2026. 1.5 SPICLK clock cycle.
+     * |        |          |u2026u2026
+     * |        |          |SUSPITV = 0xE u2026. 14.5 SPICLK clock cycle.
+     * |        |          |SUSPITV = 0xF u2026. 15.5 SPICLK clock cycle.
+     * |[12:8]  |DWIDTH    |Data Width
+     * |        |          |This field specifies how many bits can be transmitted / received in one transaction
+     * |        |          |The minimum bit length is 8 bits and can up to 32 bits.
+     * |        |          |DWIDTH = 0x08 u2026. 8 bits.
+     * |        |          |DWIDTH = 0x09 u2026. 9 bits.
+     * |        |          |u2026u2026
+     * |        |          |DWIDTH = 0x1F u2026. 31 bits.
+     * |        |          |DWIDTH = 0x00 u2026. 32 bits.
+     * |        |          |Note: For SPI1, this bit field will decide the depth of TX/RX FIFO configuration in SPI mode
+     * |        |          |Therefore, changing this bit field will clear TX/RX FIFO by hardware automatically in SPI1.
+     * |[13]    |LSB       |Send LSB First
+     * |        |          |0 = The MSB, which bit of transmit/receive register depends on the setting of DWIDTH, is transmitted/received first.
+     * |        |          |1 = The LSB, bit 0 of the SPI TX register, is sent first to the SPI data output pin, and the first bit received from the SPI data input pin will be put in the LSB position of the RX register (bit 0 of SPI_RX).
+     * |[14]    |HALFDPX   |SPI Half-duplex Transfer Enable Bit
+     * |        |          |This bit is used to select full-duplex or half-duplex for SPI transfer
+     * |        |          |The bit field DATDIR (SPIx_CTL[20]) can be used to set the data direction in half-duplex transfer.
+     * |        |          |0 = SPI operates in full-duplex transfer.
+     * |        |          |1 = SPI operates in half-duplex transfer.
+     * |[15]    |RXONLY    |Receive-only Mode Enable Bit (Master Only)
+     * |        |          |This bit field is only available in Master mode
+     * |        |          |In receive-only mode, SPI Master will generate SPI bus clock continuously for receiving data bit from SPI slave device and assert the BUSY status.
+     * |        |          |0 = Receive-only mode Disabled.
+     * |        |          |1 = Receive-only mode Enabled.
+     * |[16]    |TWOBIT    |2-bit Transfer Mode Enable Bit (Only Supported in SPI0)
+     * |        |          |0 = 2-bit Transfer mode Disabled.
+     * |        |          |1 = 2-bit Transfer mode Enabled.
+     * |        |          |Note: When 2-bit Transfer mode is enabled, the first serial transmitted bit data is from the first FIFO buffer data, and the 2nd serial transmitted bit data is from the second FIFO buffer data
+     * |        |          |As the same as transmitted function, the first received bit data is stored into the first FIFO buffer and the 2nd received bit data is stored into the second FIFO buffer at the same time.
+     * |[17]    |UNITIEN   |Unit Transfer Interrupt Enable Bit
+     * |        |          |0 = SPI unit transfer interrupt Disabled.
+     * |        |          |1 = SPI unit transfer interrupt Enabled.
+     * |[18]    |SLAVE     |Slave Mode Control
+     * |        |          |0 = Master mode.
+     * |        |          |1 = Slave mode.
+     * |[19]    |REORDER   |Byte Reorder Function Enable Bit
+     * |        |          |0 = Byte Reorder function Disabled.
+     * |        |          |1 = Byte Reorder function Enabled
+     * |        |          |A byte suspend interval will be inserted among each byte
+     * |        |          |The period of the byte suspend interval depends on the setting of SUSPITV.
+     * |        |          |Note: Byte Reorder function is only available if DWIDTH is defined as 16, 24, and 32 bits.
+     * |[20]    |DATDIR    |Data Port Direction Control
+     * |        |          |This bit is used to select the data input/output direction in half-duplex transfer and Dual/Quad transfer
+     * |        |          |0 = SPI data is input direction.
+     * |        |          |1 = SPI data is output direction.
+     * |[21]    |DUALIOEN  |Dual I/O Mode Enable Bit (Only Supported in SPI0)
+     * |        |          |0 = Dual I/O mode Disabled.
+     * |        |          |1 = Dual I/O mode Enabled.
+     * |[22]    |QUADIOEN  |Quad I/O Mode Enable Bit (Only Supported in SPI0)
+     * |        |          |0 = Quad I/O mode Disabled.
+     * |        |          |1 = Quad I/O mode Enabled.
+     * @var SPI_T::CLKDIV
+     * Offset: 0x04  SPI Clock Divider Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |DIVIDER   |Clock Divider
+     * |        |          |The value in this field is the frequency divider for generating the peripheral clock, fspi_eclk, and the SPI bus clock of SPI Master
+     * |        |          |The frequency is obtained according to the following equation.
+     * |        |          |where
+     * |        |          |is the peripheral clock source, which is defined in the clock control register, CLK_CLKSEL2.
+     * |        |          |Note: Not supported in I2S mode.
+     * @var SPI_T::SSCTL
+     * Offset: 0x08  SPI Slave Select Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SS        |Slave Selection Control (Master Only)
+     * |        |          |If AUTOSS bit is cleared to 0,
+     * |        |          |0 = set the SPIx_SS line to inactive state.
+     * |        |          |1 = set the SPIx_SS line to active state.
+     * |        |          |If the AUTOSS bit is set to 1,
+     * |        |          |0 = Keep the SPIx_SS line at inactive state.
+     * |        |          |1 = SPIx_SS line will be automatically driven to active state for the duration of data transfer, and will be driven to inactive state for the rest of the time
+     * |        |          |The active state of SPIx_SS is specified in SSACTPOL (SPIx_SSCTL[2]).
+     * |[2]     |SSACTPOL  |Slave Selection Active Polarity
+     * |        |          |This bit defines the active polarity of slave selection signal (SPIx_SS).
+     * |        |          |0 = The slave selection signal SPIx_SS is active low.
+     * |        |          |1 = The slave selection signal SPIx_SS is active high.
+     * |[3]     |AUTOSS    |Automatic Slave Selection Function Enable Bit (Master Only)
+     * |        |          |0 = Automatic slave selection function Disabled
+     * |        |          |Slave selection signal will be asserted/de-asserted according to SS (SPIx_SSCTL[0]).
+     * |        |          |1 = Automatic slave selection function Enabled.
+     * |[4]     |SLV3WIRE  |Slave 3-wire Mode Enable Bit (Only Supported in SPI0)
+     * |        |          |Slave 3-wire mode is only available in SPI0
+     * |        |          |In Slave 3-wire mode, the SPI controller can work with 3-wire interface including SPI0_CLK, SPI0_MISO and SPI0_MOSI pins.
+     * |        |          |0 = 4-wire bi-direction interface.
+     * |        |          |1 = 3-wire bi-direction interface.
+     * |[5]     |SLVTOIEN  |Slave Mode Time-out Interrupt Enable Bit (Only Supported in SPI0)
+     * |        |          |0 = Slave mode time-out interrupt Disabled.
+     * |        |          |1 = Slave mode time-out interrupt Enabled.
+     * |[6]     |SLVTORST  |Slave Mode Time-out Reset Control (Only Supported in SPI0)
+     * |        |          |0 = When Slave mode time-out event occurs, the TX and RX control circuit will not be reset.
+     * |        |          |1 = When Slave mode time-out event occurs, the TX and RX control circuit will be reset by hardware.
+     * |[8]     |SLVBEIEN  |Slave Mode Bit Count Error Interrupt Enable Bit
+     * |        |          |0 = Slave mode bit count error interrupt Disabled.
+     * |        |          |1 = Slave mode bit count error interrupt Enabled.
+     * |[9]     |SLVURIEN  |Slave Mode TX Under Run Interrupt Enable Bit
+     * |        |          |0 = Slave mode TX under run interrupt Disabled.
+     * |        |          |1 = Slave mode TX under run interrupt Enabled.
+     * |[12]    |SSACTIEN  |Slave Select Active Interrupt Enable Bit
+     * |        |          |0 = Slave select active interrupt Disabled.
+     * |        |          |1 = Slave select active interrupt Enabled.
+     * |[13]    |SSINAIEN  |Slave Select Inactive Interrupt Enable Bit
+     * |        |          |0 = Slave select inactive interrupt Disabled.
+     * |        |          |1 = Slave select inactive interrupt Enabled.
+     * |[31:16] |SLVTOCNT  |Slave Mode Time-out Period (Only Supported in SPI0)
+     * |        |          |In Slave mode, these bits indicate the time-out period when there is bus clock input during slave select active
+     * |        |          |The clock source of the time-out counter is Slave peripheral clock
+     * |        |          |If the value is 0, it indicates the slave mode time-out function is disabled.
+     * @var SPI_T::PDMACTL
+     * Offset: 0x0C  SPI PDMA Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TXPDMAEN  |Transmit PDMA Enable Bit
+     * |        |          |0 = Transmit PDMA function Disabled.
+     * |        |          |1 = Transmit PDMA function Enabled.
+     * |        |          |Note: In SPI Master mode with full duplex transfer, if both TX and RX PDMA functions are enabled, RX PDMA function cannot be enabled prior to TX PDMA function
+     * |        |          |User can enable TX PDMA function firstly or enable both functions simultaneously.
+     * |[1]     |RXPDMAEN  |Receive PDMA Enable Bit
+     * |        |          |0 = Receive PDMA function Disabled.
+     * |        |          |1 = Receive PDMA function Enabled.
+     * |[2]     |PDMARST   |PDMA Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the PDMA control logic of the SPI controller. This bit will be automatically cleared to 0.
+     * @var SPI_T::FIFOCTL
+     * Offset: 0x10  SPI FIFO Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RXRST     |Receive Reset (Only for SPI)
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset receive FIFO pointer and receive circuit
+     * |        |          |The RXFULL bit will be cleared to 0 and the RXEMPTY bit will be set to 1
+     * |        |          |This bit will be cleared to 0 by hardware about 3 system clock cycles + 2 peripheral clock cycles after it is set to 1
+     * |        |          |User can read TXRXRST (SPIx_STATUS[23]) to check if reset is accomplished or not.
+     * |[1]     |TXRST     |Transmit Reset (Only for SPI)
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset transmit FIFO pointer and transmit circuit
+     * |        |          |The TXFULL bit will be cleared to 0 and the TXEMPTY bit will be set to 1
+     * |        |          |This bit will be cleared to 0 by hardware about 3 system clock cycles + 2 peripheral clock cycles after it is set to 1
+     * |        |          |User can read TXRXRST (SPIx_STATUS[23]) to check if reset is accomplished or not.
+     * |        |          |Note: If TX underflow event occurs in SPI Slave mode, this bit can be used to make SPI return to idle state.
+     * |[2]     |RXTHIEN   |Receive FIFO Threshold Interrupt Enable Bit
+     * |        |          |0 = RX FIFO threshold interrupt Disabled.
+     * |        |          |1 = RX FIFO threshold interrupt Enabled.
+     * |[3]     |TXTHIEN   |Transmit FIFO Threshold Interrupt Enable Bit
+     * |        |          |0 = TX FIFO threshold interrupt Disabled.
+     * |        |          |1 = TX FIFO threshold interrupt Enabled.
+     * |[4]     |RXTOIEN   |Slave Receive Time-out Interrupt Enable Bit
+     * |        |          |0 = Receive time-out interrupt Disabled.
+     * |        |          |1 = Receive time-out interrupt Enabled.
+     * |[5]     |RXOVIEN   |Receive FIFO Overrun Interrupt Enable Bit
+     * |        |          |0 = Receive FIFO overrun interrupt Disabled.
+     * |        |          |1 = Receive FIFO overrun interrupt Enabled.
+     * |[6]     |TXUFPOL   |TX Underflow Data Polarity
+     * |        |          |0 = The SPI data out is keep 0 if there is TX underflow event in Slave mode.
+     * |        |          |1 = The SPI data out is keep 1 if there is TX underflow event in Slave mode.
+     * |        |          |Note:
+     * |        |          |1
+     * |        |          |The TX underflow event occurs if there is no any data in TX FIFO when the slave selection signal is active.
+     * |        |          |2. This bit should be set as 0 in I2S mode.
+     * |        |          |3
+     * |        |          |When TX underflow event occurs, SPIx_MISO pin state will be determined by this setting even though TX FIFO is not empty afterward
+     * |        |          |Data stored in TX FIFO will be sent through SPIx_MISO pin in the next transfer frame.
+     * |[7]     |TXUFIEN   |TX Underflow Interrupt Enable Bit
+     * |        |          |When TX underflow event occurs in Slave mode, TXUFIF (SPIx_STATUS[19]) will be set to 1
+     * |        |          |This bit is used to enable the TX underflow interrupt.
+     * |        |          |0 = Slave TX underflow interrupt Disabled.
+     * |        |          |1 = Slave TX underflow interrupt Enabled.
+     * |[8]     |RXFBCLR   |Receive FIFO Buffer Clear
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear receive FIFO pointer
+     * |        |          |The RXFULL bit will be cleared to 0 and the RXEMPTY bit will be set to 1
+     * |        |          |This bit will be cleared to 0 by hardware about 1 system clock after it is set to 1.
+     * |        |          |Note: The RX shift register will not be cleared.
+     * |[9]     |TXFBCLR   |Transmit FIFO Buffer Clear
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear transmit FIFO pointer
+     * |        |          |The TXFULL bit will be cleared to 0 and the TXEMPTY bit will be set to 1
+     * |        |          |This bit will be cleared to 0 by hardware about 1 system clock after it is set to 1.
+     * |        |          |Note: The TX shift register will not be cleared.
+     * |[10]    |SLVBERX   |RX FIFO Write Data Enable Bit When Slave Mode Bit Count Error (SPI Slave mode Only)
+     * |        |          |0 =  Uncompleted RX data will be dropped from RX FIFO when bit count error event happen in SPI slave mode.
+     * |        |          |1 = Uncompleted RX data will be written into RX FIFO when bit count error event happen in SPI slave mode. User can read SLVBENUM (SPIx_STATUS2[29:24]) to know that the effective bit number of uncompleted RX data when SPI slave bit count error happened.
+     * |[26:24] |RXTH      |Receive FIFO Threshold
+     * |        |          |If the valid data count of the receive FIFO buffer is larger than the RXTH setting, the RXTHIF bit will be set to 1, else the RXTHIF bit will be cleared to 0
+     * |        |          |For SPI1, the MSB of this bit field is only meaningful while SPI mode 8~16 bits of data length.
+     * |[30:28] |TXTH      |Transmit FIFO Threshold
+     * |        |          |If the valid data count of the transmit FIFO buffer is less than or equal to the TXTH setting, the TXTHIF bit will be set to 1, else the TXTHIF bit will be cleared to 0
+     * |        |          |For SPI1, the MSB of this bit field is only meaningful while SPI mode 8~16 bits of data length
+     * @var SPI_T::STATUS
+     * Offset: 0x14  SPI Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BUSY      |Busy Status (Read Only)
+     * |        |          |0 = SPI controller is in idle state.
+     * |        |          |1 = SPI controller is in busy state.
+     * |        |          |The following lists the bus busy conditions:
+     * |        |          |a. SPIx_CTL[0] = 1 and TXEMPTY = 0.
+     * |        |          |b
+     * |        |          |For SPI Master mode, SPIx_CTL[0] = 1 and TXEMPTY = 1 but the current transaction is not finished yet.
+     * |        |          |c. For SPI Master mode, SPIx_CTL[0] = 1 and RXONLY = 1.
+     * |        |          |d
+     * |        |          |For SPI Slave mode, the SPIx_CTL[0] = 1 and there is serial clock input into the SPI core logic when slave select is active.
+     * |        |          |For SPI Slave mode, the SPIx_CTL[0] = 1 and the transmit buffer or transmit shift register is not empty even if the slave select is inactive.
+     * |[1]     |UNITIF    |Unit Transfer Interrupt Flag
+     * |        |          |0 = No transaction has been finished since this bit was cleared to 0.
+     * |        |          |1 = SPI controller has finished one unit transfer.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[2]     |SSACTIF   |Slave Select Active Interrupt Flag
+     * |        |          |0 = Slave select active interrupt was cleared or not occurred.
+     * |        |          |1 = Slave select active interrupt event occurred.
+     * |        |          |Note: Only available in Slave mode. This bit will be cleared by writing 1 to it.
+     * |[3]     |SSINAIF   |Slave Select Inactive Interrupt Flag
+     * |        |          |0 = Slave select inactive interrupt was cleared or not occurred.
+     * |        |          |1 = Slave select inactive interrupt event occurred.
+     * |        |          |Note: Only available in Slave mode. This bit will be cleared by writing 1 to it.
+     * |[4]     |SSLINE    |Slave Select Line Bus Status (Read Only)
+     * |        |          |0 = The slave select line status is 0.
+     * |        |          |1 = The slave select line status is 1.
+     * |        |          |Note: This bit is only available in Slave mode
+     * |        |          |If SSACTPOL (SPIx_SSCTL[2]) is set 0, and the SSLINE is 1, the SPI slave select is in inactive status.
+     * |[5]     |SLVTOIF   |Slave Time-out Interrupt Flag (Only Supported in SPI0)
+     * |        |          |When the slave select is active and the value of SLVTOCNT is not 0, as the bus clock is detected, the slave time-out counter in SPI controller logic will be started
+     * |        |          |When the value of time-out counter is greater than or equal to the value of SLVTOCNT (SPI_SSCTL[31:16]) before one transaction is done, the slave time-out interrupt event will be asserted.
+     * |        |          |0 = Slave time-out is not active.
+     * |        |          |1 = Slave time-out is active.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[6]     |SLVBEIF   |Slave Mode Bit Count Error Interrupt Flag
+     * |        |          |In Slave mode, when the slave select line goes to inactive state, if bit counter is mismatch with DWIDTH, this interrupt flag will be set to 1.
+     * |        |          |0 = No Slave mode bit count error event.
+     * |        |          |1 = Slave mode bit count error event occurred.
+     * |        |          |Note: If the slave select active but there is no any bus clock input, the SLVBEIF also active when the slave select goes to inactive state
+     * |        |          |This bit will be cleared by writing 1 to it.
+     * |[7]     |SLVURIF   |Slave Mode TX Under Run Interrupt Flag
+     * |        |          |In Slave mode, if TX underflow event occurs and the slave select line goes to inactive state, this interrupt flag will be set to 1.
+     * |        |          |0 = No Slave TX under run event.
+     * |        |          |1 = Slave TX under run event occurred.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[8]     |RXEMPTY   |Receive FIFO Buffer Empty Indicator (Read Only)
+     * |        |          |0 = Receive FIFO buffer is not empty.
+     * |        |          |1 = Receive FIFO buffer is empty.
+     * |[9]     |RXFULL    |Receive FIFO Buffer Full Indicator (Read Only)
+     * |        |          |0 = Receive FIFO buffer is not full.
+     * |        |          |1 = Receive FIFO buffer is full.
+     * |[10]    |RXTHIF    |Receive FIFO Threshold Interrupt Flag (Read Only)
+     * |        |          |0 = The valid data count within the receive FIFO buffer is smaller than or equal to the setting value of RXTH.
+     * |        |          |1 = The valid data count within the receive FIFO buffer is larger than the setting value of RXTH.
+     * |[11]    |RXOVIF    |Receive FIFO Overrun Interrupt Flag
+     * |        |          |When the receive FIFO buffer is full, the follow-up data will be dropped and this bit will be set to 1.
+     * |        |          |0 = No FIFO is overrun.
+     * |        |          |1 = Receive FIFO is overrun.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[12]    |RXTOIF    |Receive Time-out Interrupt Flag
+     * |        |          |0 = No receive FIFO time-out event.
+     * |        |          |1 = Receive FIFO buffer is not empty and no read operation on receive FIFO buffer over 64 SPI peripheral clock periods in Master mode or over 576 SPI peripheral clock periods in Slave mode
+     * |        |          |When the received FIFO buffer is read by software, the time-out status will be cleared automatically.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[15]    |SPIENSTS  |SPI Enable Status (Read Only)
+     * |        |          |0 = SPI controller Disabled.
+     * |        |          |1 = SPI controller Enabled.
+     * |        |          |Note: The SPI peripheral clock is asynchronous with the system clock
+     * |        |          |In order to make sure the SPI control logic is disabled, this bit indicates the real status of SPI controller.
+     * |[16]    |TXEMPTY   |Transmit FIFO Buffer Empty Indicator (Read Only)
+     * |        |          |0 = Transmit FIFO buffer is not empty.
+     * |        |          |1 = Transmit FIFO buffer is empty.
+     * |[17]    |TXFULL    |Transmit FIFO Buffer Full Indicator (Read Only)
+     * |        |          |0 = Transmit FIFO buffer is not full.
+     * |        |          |1 = Transmit FIFO buffer is full.
+     * |[18]    |TXTHIF    |Transmit FIFO Threshold Interrupt Flag (Read Only)
+     * |        |          |0 = The valid data count within the transmit FIFO buffer is larger than the setting value of TXTH.
+     * |        |          |1 = The valid data count within the transmit FIFO buffer is less than or equal to the setting value of TXTH.
+     * |[19]    |TXUFIF    |TX Underflow Interrupt Flag
+     * |        |          |When the TX underflow event occurs, this bit will be set to 1, the state of data output pin depends on the setting of TXUFPOL.
+     * |        |          |0 = No effect.
+     * |        |          |1 = No data in Transmit FIFO and TX shift register when the slave selection signal is active.
+     * |        |          |Note 1: This bit will be cleared by writing 1 to it.
+     * |        |          |Note 2: If reset slave's transmission circuit when slave selection signal is active, this flag will be set to 1 after 2 peripheral clock cycles + 3 system clock cycles since the reset operation is done.
+     * |[23]    |TXRXRST   |TX or RX Reset Status (Read Only)
+     * |        |          |0 = The reset function of TXRST or RXRST is done.
+     * |        |          |1 = Doing the reset function of TXRST or RXRST.
+     * |        |          |Note: Both the reset operations of TXRST and RXRST need 3 system clock cycles + 2 peripheral clock cycles
+     * |        |          |User can check the status of this bit to monitor the reset function is doing or done.
+     * |[27:24] |RXCNT     |Receive FIFO Data Count (Read Only)
+     * |        |          |This bit field indicates the valid data count of receive FIFO buffer.
+     * |[31:28] |TXCNT     |Transmit FIFO Data Count (Read Only)
+     * |        |          |This bit field indicates the valid data count of transmit FIFO buffer.
+     * @var SPI_T::STATUS2
+     * Offset: 0x18  SPI2 Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[29:24] |SLVBENUM  |Effective Bit Number of Uncompleted RX data (SPI Slave mode Only)
+     * |        |          |This status register indicates that effective bit number of uncompleted RX data when SLVBERX (SPIx_FIFOCTL[10]) is enabled and RX bit count error event happen in SPI slave mode.
+     * |        |          |This status register will be fixed to 0x0 when SLVBERX (SPIx_FIFOCTL[10]) is disabled.
+     * |        |          |Note: This register will be cleared to 0x0 when user write 0x1 to SLVBEIF (SPIx_STATUS[6]).
+     * @var SPI_T::TX
+     * Offset: 0x20  SPI Data Transmit Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |TX        |Data Transmit Register
+     * |        |          |The data transmit registers pass through the transmitted data into the 4-level transmit FIFO buffers
+     * |        |          |The number of valid bits depends on the setting of DWIDTH (SPIx_CTL[12:8]) in SPI mode or WDWIDTH (SPIx_I2SCTL[5:4]) in I2S mode.
+     * |        |          |In SPI mode, if DWIDTH is set to 0x08, the bits TX[7:0] will be transmitted
+     * |        |          |If DWIDTH is set to 0x00, the SPI controller will perform a 32-bit transfer.
+     * |        |          |In I2S mode, if WDWIDTH (SPIx_I2SCTL[5:4]) is set to 0x2, the data width of audio channel is 24-bit and corresponding to TX[23:0]
+     * |        |          |If WDWIDTH is set as 0x0, 0x1, or 0x3, all bits of this field are valid and referred to the data arrangement in I2S mode FIFO operation section
+     * |        |          |Note: In Master mode, SPI controller will start to transfer the SPI bus clock after 1 APB clock and 6 peripheral clock cycles after user writes to this register.
+     * @var SPI_T::RX
+     * Offset: 0x30  SPI Data Receive Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |RX        |Data Receive Register
+     * |        |          |There are 4-level FIFO buffers in this controller
+     * |        |          |The data receive register holds the data received from SPI data input pin
+     * |        |          |If the RXEMPTY (SPIx_STATUS[8] or SPIx_I2SSTS[8]) is not set to 1, the receive FIFO buffers can be accessed through software by reading this register
+     * |        |          |This is a read only register.
+     * @var SPI_T::I2SCTL
+     * Offset: 0x60  I2S Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |I2SEN     |I2S Controller Enable Bit
+     * |        |          |0 = Disabled I2S mode.
+     * |        |          |1 = Enabled I2S mode.
+     * |        |          |Note:
+     * |        |          |1. If enabling this bit, I2Sx_BCLK will start to output in Master mode.
+     * |        |          |2
+     * |        |          |Before changing the configurations of SPIx_I2SCTL, SPIx_I2SCLK, and SPIx_FIFOCTL registers, user shall clear the I2SEN (SPIx_I2SCTL[0]) and confirm the I2SENSTS (SPIx_I2SSTS[15]) is 0.
+     * |[1]     |TXEN      |Transmit Enable Bit
+     * |        |          |0 = Data transmit Disabled.
+     * |        |          |1 = Data transmit Enabled.
+     * |[2]     |RXEN      |Receive Enable Bit
+     * |        |          |0 = Data receive Disabled.
+     * |        |          |1 = Data receive Enabled.
+     * |[3]     |MUTE      |Transmit Mute Enable Bit
+     * |        |          |0 = Transmit data is shifted from buffer.
+     * |        |          |1 = Transmit channel zero.
+     * |[5:4]   |WDWIDTH   |Word Width
+     * |        |          |00 = data size is 8-bit.
+     * |        |          |01 = data size is 16-bit.
+     * |        |          |10 = data size is 24-bit.
+     * |        |          |11 = data size is 32-bit.
+     * |[6]     |MONO      |Monaural Data
+     * |        |          |0 = Data is stereo format.
+     * |        |          |1 = Data is monaural format.
+     * |[7]     |ORDER     |Stereo Data Order in FIFO
+     * |        |          |0 = Left channel data at high byte.
+     * |        |          |1 = Left channel data at low byte.
+     * |[8]     |SLAVE     |Slave Mode
+     * |        |          |I2S can operate as master or slave
+     * |        |          |For Master mode, I2Sx_BCLK and I2Sx_LRCLK pins are output mode and send bit clock from this chip to audio CODEC chip
+     * |        |          |In Slave mode, I2Sx_BCLK and I2Sx_LRCLK pins are input mode and I2Sx_BCLK and I2Sx_LRCLK signals are received from outer audio CODEC chip.
+     * |        |          |0 = Master mode.
+     * |        |          |1 = Slave mode.
+     * |[15]    |MCLKEN    |Master Clock Enable Bit
+     * |        |          |If MCLKEN is set to 1, I2S controller will generate master clock on SPIx_I2SMCLK pin for external audio devices.
+     * |        |          |0 = Master clock Disabled.
+     * |        |          |1 = Master clock Enabled.
+     * |[16]    |RZCEN     |Right Channel Zero Cross Detection Enable Bit
+     * |        |          |If this bit is set to 1, when right channel data sign bit change or next shift data bits are all 0 then RZCIF flag in SPIx_I2SSTS register is set to 1
+     * |        |          |This function is only available in transmit operation.
+     * |        |          |0 = Right channel zero cross detection Disabled.
+     * |        |          |1 = Right channel zero cross detection Enabled.
+     * |[17]    |LZCEN     |Left Channel Zero Cross Detection Enable Bit
+     * |        |          |If this bit is set to 1, when left channel data sign bit changes or next shift data bits are all 0 then LZCIF flag in SPIx_I2SSTS register is set to 1
+     * |        |          |This function is only available in transmit operation.
+     * |        |          |0 = Left channel zero cross detection Disabled.
+     * |        |          |1 = Left channel zero cross detection Enabled.
+     * |[23]    |RXLCH     |Receive Left Channel Enable Bit
+     * |        |          |When monaural format is selected (MONO = 1), I2S controller will receive right channel data if RXLCH is set to 0, and receive left channel data if RXLCH is set to 1.
+     * |        |          |0 = Receive right channel data in Mono mode.
+     * |        |          |1 = Receive left channel data in Mono mode.
+     * |[24]    |RZCIEN    |Right Channel Zero Cross Interrupt Enable Bit
+     * |        |          |Interrupt occurs if this bit is set to 1 and right channel zero cross event occurs.
+     * |        |          |0 = Interrupt Disabled.
+     * |        |          |1 = Interrupt Enabled.
+     * |[25]    |LZCIEN    |Left Channel Zero Cross Interrupt Enable Bit
+     * |        |          |Interrupt occurs if this bit is set to 1 and left channel zero cross event occurs.
+     * |        |          |0 = Interrupt Disabled.
+     * |        |          |1 = Interrupt Enabled.
+     * |[29:28] |FORMAT    |Data Format Selection
+     * |        |          |00 = I2S data format.
+     * |        |          |01 = MSB justified data format.
+     * |        |          |10 = PCM mode A.
+     * |        |          |11 = PCM mode B.
+     * |[31]    |SLVERRIEN |Bit Clock Loss Interrupt Enable Bit for Slave Mode
+     * |        |          |Interrupt occurs if this bit is set to 1 and bit clock loss event occurs.
+     * |        |          |0 = Interrupt Disabled.
+     * |        |          |1 = Interrupt Enabled.
+     * @var SPI_T::I2SCLK
+     * Offset: 0x64  I2S Clock Divider Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[6:0]   |MCLKDIV   |Master Clock Divider
+     * |        |          |If MCLKEN is set to 1, I2S controller will generate master clock for external audio devices
+     * |        |          |The frequency of master clock, fMCLK, is determined by the following expressions:
+     * |        |          |If MCLKDIV >= 1,.
+     * |        |          |If MCLKDIV = 0,.
+     * |        |          |where
+     * |        |          |is the frequency of I2S peripheral clock source, which is defined in the clock control register CLK_CLKSEL2
+     * |        |          |In general, the master clock rate is 256 times sampling clock rate.
+     * |[17:8]  |BCLKDIV   |Bit Clock Divider
+     * |        |          |The I2S controller will generate bit clock in Master mode
+     * |        |          |The clock frequency of bit clock , fBCLK, is determined by the following expression:
+     * |        |          |where
+     * |        |          |is the frequency of I2S peripheral clock source, which is defined in the clock control register CLK_CLKSEL2.
+     * |        |          |In I2S Slave mode, this field is used to define the frequency of peripheral clock and it's determined by .
+     * |        |          |The peripheral clock frequency in I2S Slave mode must be equal to or faster than 6 times of input bit clock.
+     * |[24]    |I2SMODE   |I2S Clock Divider Number Selection for I2S Mode and SPI Mode
+     * |        |          |User sets I2SMODE to set frequency of peripheral clock of I2S mode or SPI mode when BCLKDIV (SPIx_I2SCLK[17:8]) or DIVIDER (SPIx_CLKDIV[8:0]) is set.
+     * |        |          |User needs to set I2SMODE before I2SEN (SPIx_I2SCTL[0]) or SPIEN (SPIx_CTL[0]) is enabled.
+     * |        |          |0 = The frequency of peripheral clock is set to SPI mode.
+     * |        |          |1 = The frequency of peripheral clock is set to I2S mode.
+     * |[25]    |I2SSLAVE  |I2S Clock Divider Number Selection for I2S Slave Mode and I2S Master Mode
+     * |        |          |User sets I2SSLAVE to set frequency of peripheral clock of I2S master mode and I2S slave mode when BCLKDIV (SPIx_I2SCLK[17:8]) is set.
+     * |        |          |I2SSLAVE needs to set before I2SEN (SPIx_I2SCTL[0]) is enabled.
+     * |        |          |0 = The frequency of peripheral clock is set to I2S master mode.
+     * |        |          |1 = The frequency of peripheral clock is set to I2S slave mode.
+     * @var SPI_T::I2SSTS
+     * Offset: 0x68  I2S Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[4]     |RIGHT     |Right Channel (Read Only)
+     * |        |          |This bit indicates the current transmit data is belong to which channel.
+     * |        |          |0 = Left channel.
+     * |        |          |1 = Right channel.
+     * |[8]     |RXEMPTY   |Receive FIFO Buffer Empty Indicator (Read Only)
+     * |        |          |0 = Receive FIFO buffer is not empty.
+     * |        |          |1 = Receive FIFO buffer is empty.
+     * |[9]     |RXFULL    |Receive FIFO Buffer Full Indicator (Read Only)
+     * |        |          |0 = Receive FIFO buffer is not full.
+     * |        |          |1 = Receive FIFO buffer is full.
+     * |[10]    |RXTHIF    |Receive FIFO Threshold Interrupt Flag (Read Only)
+     * |        |          |0 = The valid data count within the receive FIFO buffer is smaller than or equal to the setting value of RXTH.
+     * |        |          |1 = The valid data count within the receive FIFO buffer is larger than the setting value of RXTH.
+     * |        |          |Note: If RXTHIEN = 1 and RXTHIF = 1, the SPI/I2S controller will generate a SPI interrupt request.
+     * |[11]    |RXOVIF    |Receive FIFO Overrun Interrupt Flag
+     * |        |          |When the receive FIFO buffer is full, the follow-up data will be dropped and this bit will be set to 1.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[12]    |RXTOIF    |Receive Time-out Interrupt Flag
+     * |        |          |0 = No receive FIFO time-out event.
+     * |        |          |1 = Receive FIFO buffer is not empty and no read operation on receive FIFO buffer over 64 SPI peripheral clock period in Master mode or over 576 SPI peripheral clock period in Slave mode
+     * |        |          |When the received FIFO buffer is read by software, the time-out status will be cleared automatically.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[15]    |I2SENSTS  |I2S Enable Status (Read Only)
+     * |        |          |0 = The SPI/I2S control logic is disabled.
+     * |        |          |1 = The SPI/I2S control logic is enabled.
+     * |        |          |Note: The SPI peripheral clock is asynchronous with the system clock
+     * |        |          |In order to make sure the SPI/I2S control logic is disabled, this bit indicates the real status of SPI/I2S control logic for user.
+     * |[16]    |TXEMPTY   |Transmit FIFO Buffer Empty Indicator (Read Only)
+     * |        |          |0 = Transmit FIFO buffer is not empty.
+     * |        |          |1 = Transmit FIFO buffer is empty.
+     * |[17]    |TXFULL    |Transmit FIFO Buffer Full Indicator (Read Only)
+     * |        |          |0 = Transmit FIFO buffer is not full.
+     * |        |          |1 = Transmit FIFO buffer is full.
+     * |[18]    |TXTHIF    |Transmit FIFO Threshold Interrupt Flag (Read Only)
+     * |        |          |0 = The valid data count within the transmit FIFO buffer is larger than the setting value of TXTH.
+     * |        |          |1 = The valid data count within the transmit FIFO buffer is less than or equal to the setting value of TXTH.
+     * |        |          |Note: If TXTHIEN = 1 and TXTHIF = 1, the SPI/I2S controller will generate a SPI interrupt request.
+     * |[19]    |TXUFIF    |Transmit FIFO Underflow Interrupt Flag
+     * |        |          |When the transmit FIFO buffer is empty and there is no datum written into the FIFO buffer, if there is more bus clock input, this bit will be set to 1.
+     * |        |          |Note: This bit will be cleared by writing 1 to it.
+     * |[20]    |RZCIF     |Right Channel Zero Cross Interrupt Flag
+     * |        |          |0 = No zero cross event occurred on right channel.
+     * |        |          |1 = Zero cross event occurred on right channel.
+     * |[21]    |LZCIF     |Left Channel Zero Cross Interrupt Flag
+     * |        |          |0 = No zero cross event occurred on left channel.
+     * |        |          |1 = Zero cross event occurred on left channel.
+     * |[22]    |SLVERRIF  |Bit Clock Loss Interrupt Flag for Slave Mode
+     * |        |          |0 = No bit clock loss event occurred.
+     * |        |          |1 = Bit clock loss event occurred.
+     * |        |          |This bit will be cleared by writing 1 to it.
+     * |[23]    |TXRXRST   |TX or RX Reset Status (Read Only)
+     * |        |          |0 = The reset function of TXRST or RXRST is done.
+     * |        |          |1 = Doing the reset function of TXRST or RXRST.
+     * |        |          |Note: Both the reset operations of TXRST and RXRST need 3 system clock cycles + 2 peripheral clock cycles
+     * |        |          |User can check the status of this bit to monitor the reset function is doing or done.
+     * |[26:24] |RXCNT     |Receive FIFO Data Count (Read Only)
+     * |        |          |This bit field indicates the valid data count of receive FIFO buffer.
+     * |[30:28] |TXCNT     |Transmit FIFO Data Count (Read Only)
+     * |        |          |This bit field indicates the valid data count of transmit FIFO buffer.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] SPI Control Register                                             */
+    __IO uint32_t CLKDIV;                /*!< [0x0004] SPI Clock Divider Register                                       */
+    __IO uint32_t SSCTL;                 /*!< [0x0008] SPI Slave Select Control Register                                */
+    __IO uint32_t PDMACTL;               /*!< [0x000c] SPI PDMA Control Register                                        */
+    __IO uint32_t FIFOCTL;               /*!< [0x0010] SPI FIFO Control Register                                        */
+    __IO uint32_t STATUS;                /*!< [0x0014] SPI Status Register                                              */
+    __IO uint32_t STATUS2;               /*!< [0x0018] SPI Status2 Register                                             */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0;
+    /// @endcond //HIDDEN_SYMBOLS
+    __O  uint32_t TX;                    /*!< [0x0020] SPI Data Transmit Register                                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __I  uint32_t RX;                    /*!< [0x0030] SPI Data Receive Register                                        */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[11];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t I2SCTL;                /*!< [0x0060] I2S Control Register                                             */
+    __IO uint32_t I2SCLK;                /*!< [0x0064] I2S Clock Divider Control Register                               */
+    __IO uint32_t I2SSTS;                /*!< [0x0068] I2S Status Register                                              */
+} SPI_T;
+
+/**
+    @addtogroup SPI_CONST SPI Bit Field Definition
+    Constant Definitions for SPI Controller
+@{ */
+
+#define SPI_CTL_SPIEN_Pos                (0)                                               /*!< SPI_T::CTL: SPIEN Position             */
+#define SPI_CTL_SPIEN_Msk                (0x1ul << SPI_CTL_SPIEN_Pos)                      /*!< SPI_T::CTL: SPIEN Mask                 */
+
+#define SPI_CTL_RXNEG_Pos                (1)                                               /*!< SPI_T::CTL: RXNEG Position             */
+#define SPI_CTL_RXNEG_Msk                (0x1ul << SPI_CTL_RXNEG_Pos)                      /*!< SPI_T::CTL: RXNEG Mask                 */
+
+#define SPI_CTL_TXNEG_Pos                (2)                                               /*!< SPI_T::CTL: TXNEG Position             */
+#define SPI_CTL_TXNEG_Msk                (0x1ul << SPI_CTL_TXNEG_Pos)                      /*!< SPI_T::CTL: TXNEG Mask                 */
+
+#define SPI_CTL_CLKPOL_Pos               (3)                                               /*!< SPI_T::CTL: CLKPOL Position            */
+#define SPI_CTL_CLKPOL_Msk               (0x1ul << SPI_CTL_CLKPOL_Pos)                     /*!< SPI_T::CTL: CLKPOL Mask                */
+
+#define SPI_CTL_SUSPITV_Pos              (4)                                               /*!< SPI_T::CTL: SUSPITV Position           */
+#define SPI_CTL_SUSPITV_Msk              (0xful << SPI_CTL_SUSPITV_Pos)                    /*!< SPI_T::CTL: SUSPITV Mask               */
+
+#define SPI_CTL_DWIDTH_Pos               (8)                                               /*!< SPI_T::CTL: DWIDTH Position            */
+#define SPI_CTL_DWIDTH_Msk               (0x1ful << SPI_CTL_DWIDTH_Pos)                    /*!< SPI_T::CTL: DWIDTH Mask                */
+
+#define SPI_CTL_LSB_Pos                  (13)                                              /*!< SPI_T::CTL: LSB Position               */
+#define SPI_CTL_LSB_Msk                  (0x1ul << SPI_CTL_LSB_Pos)                        /*!< SPI_T::CTL: LSB Mask                   */
+
+#define SPI_CTL_HALFDPX_Pos              (14)                                              /*!< SPI_T::CTL: HALFDPX Position           */
+#define SPI_CTL_HALFDPX_Msk              (0x1ul << SPI_CTL_HALFDPX_Pos)                    /*!< SPI_T::CTL: HALFDPX Mask               */
+
+#define SPI_CTL_RXONLY_Pos               (15)                                              /*!< SPI_T::CTL: RXONLY Position            */
+#define SPI_CTL_RXONLY_Msk               (0x1ul << SPI_CTL_RXONLY_Pos)                     /*!< SPI_T::CTL: RXONLY Mask                */
+
+#define SPI_CTL_UNITIEN_Pos              (17)                                              /*!< SPI_T::CTL: UNITIEN Position           */
+#define SPI_CTL_UNITIEN_Msk              (0x1ul << SPI_CTL_UNITIEN_Pos)                    /*!< SPI_T::CTL: UNITIEN Mask               */
+
+#define SPI_CTL_SLAVE_Pos                (18)                                              /*!< SPI_T::CTL: SLAVE Position             */
+#define SPI_CTL_SLAVE_Msk                (0x1ul << SPI_CTL_SLAVE_Pos)                      /*!< SPI_T::CTL: SLAVE Mask                 */
+
+#define SPI_CTL_REORDER_Pos              (19)                                              /*!< SPI_T::CTL: REORDER Position           */
+#define SPI_CTL_REORDER_Msk              (0x1ul << SPI_CTL_REORDER_Pos)                    /*!< SPI_T::CTL: REORDER Mask               */
+
+#define SPI_CTL_DATDIR_Pos               (20)                                              /*!< SPI_T::CTL: DATDIR Position            */
+#define SPI_CTL_DATDIR_Msk               (0x1ul << SPI_CTL_DATDIR_Pos)                     /*!< SPI_T::CTL: DATDIR Mask                */
+
+#define SPI_CLKDIV_DIVIDER_Pos           (0)                                               /*!< SPI_T::CLKDIV: DIVIDER Position        */
+#define SPI_CLKDIV_DIVIDER_Msk           (0x1fful << SPI_CLKDIV_DIVIDER_Pos)               /*!< SPI_T::CLKDIV: DIVIDER Mask            */
+
+#define SPI_SSCTL_SS_Pos                 (0)                                               /*!< SPI_T::SSCTL: SS Position              */
+#define SPI_SSCTL_SS_Msk                 (0x1ul << SPI_SSCTL_SS_Pos)                       /*!< SPI_T::SSCTL: SS Mask                  */
+
+#define SPI_SSCTL_SSACTPOL_Pos           (2)                                               /*!< SPI_T::SSCTL: SSACTPOL Position        */
+#define SPI_SSCTL_SSACTPOL_Msk           (0x1ul << SPI_SSCTL_SSACTPOL_Pos)                 /*!< SPI_T::SSCTL: SSACTPOL Mask            */
+
+#define SPI_SSCTL_AUTOSS_Pos             (3)                                               /*!< SPI_T::SSCTL: AUTOSS Position          */
+#define SPI_SSCTL_AUTOSS_Msk             (0x1ul << SPI_SSCTL_AUTOSS_Pos)                   /*!< SPI_T::SSCTL: AUTOSS Mask              */
+
+#define SPI_SSCTL_SLV3WIRE_Pos           (4)                                               /*!< SPI_T::SSCTL: SLV3WIRE Position        */
+#define SPI_SSCTL_SLV3WIRE_Msk           (0x1ul << SPI_SSCTL_SLV3WIRE_Pos)                 /*!< SPI_T::SSCTL: SLV3WIRE Mask            */
+
+#define SPI_SSCTL_SLVBEIEN_Pos           (8)                                               /*!< SPI_T::SSCTL: SLVBEIEN Position        */
+#define SPI_SSCTL_SLVBEIEN_Msk           (0x1ul << SPI_SSCTL_SLVBEIEN_Pos)                 /*!< SPI_T::SSCTL: SLVBEIEN Mask            */
+
+#define SPI_SSCTL_SLVURIEN_Pos           (9)                                               /*!< SPI_T::SSCTL: SLVURIEN Position        */
+#define SPI_SSCTL_SLVURIEN_Msk           (0x1ul << SPI_SSCTL_SLVURIEN_Pos)                 /*!< SPI_T::SSCTL: SLVURIEN Mask            */
+
+#define SPI_SSCTL_SSACTIEN_Pos           (12)                                              /*!< SPI_T::SSCTL: SSACTIEN Position        */
+#define SPI_SSCTL_SSACTIEN_Msk           (0x1ul << SPI_SSCTL_SSACTIEN_Pos)                 /*!< SPI_T::SSCTL: SSACTIEN Mask            */
+
+#define SPI_SSCTL_SSINAIEN_Pos           (13)                                              /*!< SPI_T::SSCTL: SSINAIEN Position        */
+#define SPI_SSCTL_SSINAIEN_Msk           (0x1ul << SPI_SSCTL_SSINAIEN_Pos)                 /*!< SPI_T::SSCTL: SSINAIEN Mask            */
+
+#define SPI_PDMACTL_TXPDMAEN_Pos         (0)                                               /*!< SPI_T::PDMACTL: TXPDMAEN Position      */
+#define SPI_PDMACTL_TXPDMAEN_Msk         (0x1ul << SPI_PDMACTL_TXPDMAEN_Pos)               /*!< SPI_T::PDMACTL: TXPDMAEN Mask          */
+
+#define SPI_PDMACTL_RXPDMAEN_Pos         (1)                                               /*!< SPI_T::PDMACTL: RXPDMAEN Position      */
+#define SPI_PDMACTL_RXPDMAEN_Msk         (0x1ul << SPI_PDMACTL_RXPDMAEN_Pos)               /*!< SPI_T::PDMACTL: RXPDMAEN Mask          */
+
+#define SPI_PDMACTL_PDMARST_Pos          (2)                                               /*!< SPI_T::PDMACTL: PDMARST Position       */
+#define SPI_PDMACTL_PDMARST_Msk          (0x1ul << SPI_PDMACTL_PDMARST_Pos)                /*!< SPI_T::PDMACTL: PDMARST Mask           */
+
+#define SPI_FIFOCTL_RXRST_Pos            (0)                                               /*!< SPI_T::FIFOCTL: RXRST Position         */
+#define SPI_FIFOCTL_RXRST_Msk            (0x1ul << SPI_FIFOCTL_RXRST_Pos)                  /*!< SPI_T::FIFOCTL: RXRST Mask             */
+
+#define SPI_FIFOCTL_TXRST_Pos            (1)                                               /*!< SPI_T::FIFOCTL: TXRST Position         */
+#define SPI_FIFOCTL_TXRST_Msk            (0x1ul << SPI_FIFOCTL_TXRST_Pos)                  /*!< SPI_T::FIFOCTL: TXRST Mask             */
+
+#define SPI_FIFOCTL_RXTHIEN_Pos          (2)                                               /*!< SPI_T::FIFOCTL: RXTHIEN Position       */
+#define SPI_FIFOCTL_RXTHIEN_Msk          (0x1ul << SPI_FIFOCTL_RXTHIEN_Pos)                /*!< SPI_T::FIFOCTL: RXTHIEN Mask           */
+
+#define SPI_FIFOCTL_TXTHIEN_Pos          (3)                                               /*!< SPI_T::FIFOCTL: TXTHIEN Position       */
+#define SPI_FIFOCTL_TXTHIEN_Msk          (0x1ul << SPI_FIFOCTL_TXTHIEN_Pos)                /*!< SPI_T::FIFOCTL: TXTHIEN Mask           */
+
+#define SPI_FIFOCTL_RXTOIEN_Pos          (4)                                               /*!< SPI_T::FIFOCTL: RXTOIEN Position       */
+#define SPI_FIFOCTL_RXTOIEN_Msk          (0x1ul << SPI_FIFOCTL_RXTOIEN_Pos)                /*!< SPI_T::FIFOCTL: RXTOIEN Mask           */
+
+#define SPI_FIFOCTL_RXOVIEN_Pos          (5)                                               /*!< SPI_T::FIFOCTL: RXOVIEN Position       */
+#define SPI_FIFOCTL_RXOVIEN_Msk          (0x1ul << SPI_FIFOCTL_RXOVIEN_Pos)                /*!< SPI_T::FIFOCTL: RXOVIEN Mask           */
+
+#define SPI_FIFOCTL_TXUFPOL_Pos          (6)                                               /*!< SPI_T::FIFOCTL: TXUFPOL Position       */
+#define SPI_FIFOCTL_TXUFPOL_Msk          (0x1ul << SPI_FIFOCTL_TXUFPOL_Pos)                /*!< SPI_T::FIFOCTL: TXUFPOL Mask           */
+
+#define SPI_FIFOCTL_TXUFIEN_Pos          (7)                                               /*!< SPI_T::FIFOCTL: TXUFIEN Position       */
+#define SPI_FIFOCTL_TXUFIEN_Msk          (0x1ul << SPI_FIFOCTL_TXUFIEN_Pos)                /*!< SPI_T::FIFOCTL: TXUFIEN Mask           */
+
+#define SPI_FIFOCTL_RXFBCLR_Pos          (8)                                               /*!< SPI_T::FIFOCTL: RXFBCLR Position       */
+#define SPI_FIFOCTL_RXFBCLR_Msk          (0x1ul << SPI_FIFOCTL_RXFBCLR_Pos)                /*!< SPI_T::FIFOCTL: RXFBCLR Mask           */
+
+#define SPI_FIFOCTL_TXFBCLR_Pos          (9)                                               /*!< SPI_T::FIFOCTL: TXFBCLR Position       */
+#define SPI_FIFOCTL_TXFBCLR_Msk          (0x1ul << SPI_FIFOCTL_TXFBCLR_Pos)                /*!< SPI_T::FIFOCTL: TXFBCLR Mask           */
+
+#define SPI_FIFOCTL_SLVBERX_Pos          (10)                                              /*!< SPI_T::FIFOCTL: SLVBERX Position       */
+#define SPI_FIFOCTL_SLVBERX_Msk          (0x1ul << SPI_FIFOCTL_SLVBERX_Pos)                /*!< SPI_T::FIFOCTL: SLVBERX Mask           */
+
+#define SPI_FIFOCTL_RXTH_Pos             (24)                                              /*!< SPI_T::FIFOCTL: RXTH Position          */
+#define SPI_FIFOCTL_RXTH_Msk             (0x7ul << SPI_FIFOCTL_RXTH_Pos)                   /*!< SPI_T::FIFOCTL: RXTH Mask              */
+
+#define SPI_FIFOCTL_TXTH_Pos             (28)                                              /*!< SPI_T::FIFOCTL: TXTH Position          */
+#define SPI_FIFOCTL_TXTH_Msk             (0x7ul << SPI_FIFOCTL_TXTH_Pos)                   /*!< SPI_T::FIFOCTL: TXTH Mask              */
+
+#define SPI_STATUS_BUSY_Pos              (0)                                               /*!< SPI_T::STATUS: BUSY Position           */
+#define SPI_STATUS_BUSY_Msk              (0x1ul << SPI_STATUS_BUSY_Pos)                    /*!< SPI_T::STATUS: BUSY Mask               */
+
+#define SPI_STATUS_UNITIF_Pos            (1)                                               /*!< SPI_T::STATUS: UNITIF Position         */
+#define SPI_STATUS_UNITIF_Msk            (0x1ul << SPI_STATUS_UNITIF_Pos)                  /*!< SPI_T::STATUS: UNITIF Mask             */
+
+#define SPI_STATUS_SSACTIF_Pos           (2)                                               /*!< SPI_T::STATUS: SSACTIF Position        */
+#define SPI_STATUS_SSACTIF_Msk           (0x1ul << SPI_STATUS_SSACTIF_Pos)                 /*!< SPI_T::STATUS: SSACTIF Mask            */
+
+#define SPI_STATUS_SSINAIF_Pos           (3)                                               /*!< SPI_T::STATUS: SSINAIF Position        */
+#define SPI_STATUS_SSINAIF_Msk           (0x1ul << SPI_STATUS_SSINAIF_Pos)                 /*!< SPI_T::STATUS: SSINAIF Mask            */
+
+#define SPI_STATUS_SSLINE_Pos            (4)                                               /*!< SPI_T::STATUS: SSLINE Position         */
+#define SPI_STATUS_SSLINE_Msk            (0x1ul << SPI_STATUS_SSLINE_Pos)                  /*!< SPI_T::STATUS: SSLINE Mask             */
+
+#define SPI_STATUS_SLVBEIF_Pos           (6)                                               /*!< SPI_T::STATUS: SLVBEIF Position        */
+#define SPI_STATUS_SLVBEIF_Msk           (0x1ul << SPI_STATUS_SLVBEIF_Pos)                 /*!< SPI_T::STATUS: SLVBEIF Mask            */
+
+#define SPI_STATUS_SLVURIF_Pos           (7)                                               /*!< SPI_T::STATUS: SLVURIF Position        */
+#define SPI_STATUS_SLVURIF_Msk           (0x1ul << SPI_STATUS_SLVURIF_Pos)                 /*!< SPI_T::STATUS: SLVURIF Mask            */
+
+#define SPI_STATUS_RXEMPTY_Pos           (8)                                               /*!< SPI_T::STATUS: RXEMPTY Position        */
+#define SPI_STATUS_RXEMPTY_Msk           (0x1ul << SPI_STATUS_RXEMPTY_Pos)                 /*!< SPI_T::STATUS: RXEMPTY Mask            */
+
+#define SPI_STATUS_RXFULL_Pos            (9)                                               /*!< SPI_T::STATUS: RXFULL Position         */
+#define SPI_STATUS_RXFULL_Msk            (0x1ul << SPI_STATUS_RXFULL_Pos)                  /*!< SPI_T::STATUS: RXFULL Mask             */
+
+#define SPI_STATUS_RXTHIF_Pos            (10)                                              /*!< SPI_T::STATUS: RXTHIF Position         */
+#define SPI_STATUS_RXTHIF_Msk            (0x1ul << SPI_STATUS_RXTHIF_Pos)                  /*!< SPI_T::STATUS: RXTHIF Mask             */
+
+#define SPI_STATUS_RXOVIF_Pos            (11)                                              /*!< SPI_T::STATUS: RXOVIF Position         */
+#define SPI_STATUS_RXOVIF_Msk            (0x1ul << SPI_STATUS_RXOVIF_Pos)                  /*!< SPI_T::STATUS: RXOVIF Mask             */
+
+#define SPI_STATUS_RXTOIF_Pos            (12)                                              /*!< SPI_T::STATUS: RXTOIF Position         */
+#define SPI_STATUS_RXTOIF_Msk            (0x1ul << SPI_STATUS_RXTOIF_Pos)                  /*!< SPI_T::STATUS: RXTOIF Mask             */
+
+#define SPI_STATUS_SPIENSTS_Pos          (15)                                              /*!< SPI_T::STATUS: SPIENSTS Position       */
+#define SPI_STATUS_SPIENSTS_Msk          (0x1ul << SPI_STATUS_SPIENSTS_Pos)                /*!< SPI_T::STATUS: SPIENSTS Mask           */
+
+#define SPI_STATUS_TXEMPTY_Pos           (16)                                              /*!< SPI_T::STATUS: TXEMPTY Position        */
+#define SPI_STATUS_TXEMPTY_Msk           (0x1ul << SPI_STATUS_TXEMPTY_Pos)                 /*!< SPI_T::STATUS: TXEMPTY Mask            */
+
+#define SPI_STATUS_TXFULL_Pos            (17)                                              /*!< SPI_T::STATUS: TXFULL Position         */
+#define SPI_STATUS_TXFULL_Msk            (0x1ul << SPI_STATUS_TXFULL_Pos)                  /*!< SPI_T::STATUS: TXFULL Mask             */
+
+#define SPI_STATUS_TXTHIF_Pos            (18)                                              /*!< SPI_T::STATUS: TXTHIF Position         */
+#define SPI_STATUS_TXTHIF_Msk            (0x1ul << SPI_STATUS_TXTHIF_Pos)                  /*!< SPI_T::STATUS: TXTHIF Mask             */
+
+#define SPI_STATUS_TXUFIF_Pos            (19)                                              /*!< SPI_T::STATUS: TXUFIF Position         */
+#define SPI_STATUS_TXUFIF_Msk            (0x1ul << SPI_STATUS_TXUFIF_Pos)                  /*!< SPI_T::STATUS: TXUFIF Mask             */
+
+#define SPI_STATUS_TXRXRST_Pos           (23)                                              /*!< SPI_T::STATUS: TXRXRST Position        */
+#define SPI_STATUS_TXRXRST_Msk           (0x1ul << SPI_STATUS_TXRXRST_Pos)                 /*!< SPI_T::STATUS: TXRXRST Mask            */
+
+#define SPI_STATUS_RXCNT_Pos             (24)                                              /*!< SPI_T::STATUS: RXCNT Position          */
+#define SPI_STATUS_RXCNT_Msk             (0xful << SPI_STATUS_RXCNT_Pos)                   /*!< SPI_T::STATUS: RXCNT Mask              */
+
+#define SPI_STATUS_TXCNT_Pos             (28)                                              /*!< SPI_T::STATUS: TXCNT Position          */
+#define SPI_STATUS_TXCNT_Msk             (0xful << SPI_STATUS_TXCNT_Pos)                   /*!< SPI_T::STATUS: TXCNT Mask              */
+
+#define SPI_STATUS2_SLVBENUM_Pos         (24)                                              /*!< SPI_T::STATUS2: SLVBENUM Position      */
+#define SPI_STATUS2_SLVBENUM_Msk         (0x3ful << SPI_STATUS2_SLVBENUM_Pos)              /*!< SPI_T::STATUS2: SLVBENUM Mask          */
+
+#define SPI_TX_TX_Pos                    (0)                                               /*!< SPI_T::TX: TX Position                 */
+#define SPI_TX_TX_Msk                    (0xfffffffful << SPI_TX_TX_Pos)                   /*!< SPI_T::TX: TX Mask                     */
+
+#define SPI_RX_RX_Pos                    (0)                                               /*!< SPI_T::RX: RX Position                 */
+#define SPI_RX_RX_Msk                    (0xfffffffful << SPI_RX_RX_Pos)                   /*!< SPI_T::RX: RX Mask                     */
+
+#define SPI_I2SCTL_I2SEN_Pos             (0)                                               /*!< SPI_T::I2SCTL: I2SEN Position          */
+#define SPI_I2SCTL_I2SEN_Msk             (0x1ul << SPI_I2SCTL_I2SEN_Pos)                   /*!< SPI_T::I2SCTL: I2SEN Mask              */
+
+#define SPI_I2SCTL_TXEN_Pos              (1)                                               /*!< SPI_T::I2SCTL: TXEN Position           */
+#define SPI_I2SCTL_TXEN_Msk              (0x1ul << SPI_I2SCTL_TXEN_Pos)                    /*!< SPI_T::I2SCTL: TXEN Mask               */
+
+#define SPI_I2SCTL_RXEN_Pos              (2)                                               /*!< SPI_T::I2SCTL: RXEN Position           */
+#define SPI_I2SCTL_RXEN_Msk              (0x1ul << SPI_I2SCTL_RXEN_Pos)                    /*!< SPI_T::I2SCTL: RXEN Mask               */
+
+#define SPI_I2SCTL_MUTE_Pos              (3)                                               /*!< SPI_T::I2SCTL: MUTE Position           */
+#define SPI_I2SCTL_MUTE_Msk              (0x1ul << SPI_I2SCTL_MUTE_Pos)                    /*!< SPI_T::I2SCTL: MUTE Mask               */
+
+#define SPI_I2SCTL_WDWIDTH_Pos           (4)                                               /*!< SPI_T::I2SCTL: WDWIDTH Position        */
+#define SPI_I2SCTL_WDWIDTH_Msk           (0x3ul << SPI_I2SCTL_WDWIDTH_Pos)                 /*!< SPI_T::I2SCTL: WDWIDTH Mask            */
+
+#define SPI_I2SCTL_MONO_Pos              (6)                                               /*!< SPI_T::I2SCTL: MONO Position           */
+#define SPI_I2SCTL_MONO_Msk              (0x1ul << SPI_I2SCTL_MONO_Pos)                    /*!< SPI_T::I2SCTL: MONO Mask               */
+
+#define SPI_I2SCTL_ORDER_Pos             (7)                                               /*!< SPI_T::I2SCTL: ORDER Position          */
+#define SPI_I2SCTL_ORDER_Msk             (0x1ul << SPI_I2SCTL_ORDER_Pos)                   /*!< SPI_T::I2SCTL: ORDER Mask              */
+
+#define SPI_I2SCTL_SLAVE_Pos             (8)                                               /*!< SPI_T::I2SCTL: SLAVE Position          */
+#define SPI_I2SCTL_SLAVE_Msk             (0x1ul << SPI_I2SCTL_SLAVE_Pos)                   /*!< SPI_T::I2SCTL: SLAVE Mask              */
+
+#define SPI_I2SCTL_MCLKEN_Pos            (15)                                              /*!< SPI_T::I2SCTL: MCLKEN Position         */
+#define SPI_I2SCTL_MCLKEN_Msk            (0x1ul << SPI_I2SCTL_MCLKEN_Pos)                  /*!< SPI_T::I2SCTL: MCLKEN Mask             */
+
+#define SPI_I2SCTL_RZCEN_Pos             (16)                                              /*!< SPI_T::I2SCTL: RZCEN Position          */
+#define SPI_I2SCTL_RZCEN_Msk             (0x1ul << SPI_I2SCTL_RZCEN_Pos)                   /*!< SPI_T::I2SCTL: RZCEN Mask              */
+
+#define SPI_I2SCTL_LZCEN_Pos             (17)                                              /*!< SPI_T::I2SCTL: LZCEN Position          */
+#define SPI_I2SCTL_LZCEN_Msk             (0x1ul << SPI_I2SCTL_LZCEN_Pos)                   /*!< SPI_T::I2SCTL: LZCEN Mask              */
+
+#define SPI_I2SCTL_RXLCH_Pos             (23)                                              /*!< SPI_T::I2SCTL: RXLCH Position          */
+#define SPI_I2SCTL_RXLCH_Msk             (0x1ul << SPI_I2SCTL_RXLCH_Pos)                   /*!< SPI_T::I2SCTL: RXLCH Mask              */
+
+#define SPI_I2SCTL_RZCIEN_Pos            (24)                                              /*!< SPI_T::I2SCTL: RZCIEN Position         */
+#define SPI_I2SCTL_RZCIEN_Msk            (0x1ul << SPI_I2SCTL_RZCIEN_Pos)                  /*!< SPI_T::I2SCTL: RZCIEN Mask             */
+
+#define SPI_I2SCTL_LZCIEN_Pos            (25)                                              /*!< SPI_T::I2SCTL: LZCIEN Position         */
+#define SPI_I2SCTL_LZCIEN_Msk            (0x1ul << SPI_I2SCTL_LZCIEN_Pos)                  /*!< SPI_T::I2SCTL: LZCIEN Mask             */
+
+#define SPI_I2SCTL_FORMAT_Pos            (28)                                              /*!< SPI_T::I2SCTL: FORMAT Position         */
+#define SPI_I2SCTL_FORMAT_Msk            (0x3ul << SPI_I2SCTL_FORMAT_Pos)                  /*!< SPI_T::I2SCTL: FORMAT Mask             */
+
+#define SPI_I2SCTL_SLVERRIEN_Pos         (31)                                              /*!< SPI_T::I2SCTL: SLVERRIEN Position      */
+#define SPI_I2SCTL_SLVERRIEN_Msk         (0x1ul << SPI_I2SCTL_SLVERRIEN_Pos)               /*!< SPI_T::I2SCTL: SLVERRIEN Mask          */
+
+#define SPI_I2SCLK_MCLKDIV_Pos           (0)                                               /*!< SPI_T::I2SCLK: MCLKDIV Position        */
+#define SPI_I2SCLK_MCLKDIV_Msk           (0x7ful << SPI_I2SCLK_MCLKDIV_Pos)                /*!< SPI_T::I2SCLK: MCLKDIV Mask            */
+
+#define SPI_I2SCLK_BCLKDIV_Pos           (8)                                               /*!< SPI_T::I2SCLK: BCLKDIV Position        */
+#define SPI_I2SCLK_BCLKDIV_Msk           (0x3fful << SPI_I2SCLK_BCLKDIV_Pos)               /*!< SPI_T::I2SCLK: BCLKDIV Mask            */
+
+#define SPI_I2SCLK_I2SMODE_Pos           (24)                                              /*!< SPI_T::I2SCLK: I2SMODE Position        */
+#define SPI_I2SCLK_I2SMODE_Msk           (0x1ul << SPI_I2SCLK_I2SMODE_Pos)                 /*!< SPI_T::I2SCLK: I2SMODE Mask            */
+
+#define SPI_I2SCLK_I2SSLAVE_Pos          (25)                                              /*!< SPI_T::I2SCLK: I2SSLAVE Position       */
+#define SPI_I2SCLK_I2SSLAVE_Msk          (0x1ul << SPI_I2SCLK_I2SSLAVE_Pos)                /*!< SPI_T::I2SCLK: I2SSLAVE Mask           */
+
+#define SPI_I2SSTS_RIGHT_Pos             (4)                                               /*!< SPI_T::I2SSTS: RIGHT Position          */
+#define SPI_I2SSTS_RIGHT_Msk             (0x1ul << SPI_I2SSTS_RIGHT_Pos)                   /*!< SPI_T::I2SSTS: RIGHT Mask              */
+
+#define SPI_I2SSTS_RXEMPTY_Pos           (8)                                               /*!< SPI_T::I2SSTS: RXEMPTY Position        */
+#define SPI_I2SSTS_RXEMPTY_Msk           (0x1ul << SPI_I2SSTS_RXEMPTY_Pos)                 /*!< SPI_T::I2SSTS: RXEMPTY Mask            */
+
+#define SPI_I2SSTS_RXFULL_Pos            (9)                                               /*!< SPI_T::I2SSTS: RXFULL Position         */
+#define SPI_I2SSTS_RXFULL_Msk            (0x1ul << SPI_I2SSTS_RXFULL_Pos)                  /*!< SPI_T::I2SSTS: RXFULL Mask             */
+
+#define SPI_I2SSTS_RXTHIF_Pos            (10)                                              /*!< SPI_T::I2SSTS: RXTHIF Position         */
+#define SPI_I2SSTS_RXTHIF_Msk            (0x1ul << SPI_I2SSTS_RXTHIF_Pos)                  /*!< SPI_T::I2SSTS: RXTHIF Mask             */
+
+#define SPI_I2SSTS_RXOVIF_Pos            (11)                                              /*!< SPI_T::I2SSTS: RXOVIF Position         */
+#define SPI_I2SSTS_RXOVIF_Msk            (0x1ul << SPI_I2SSTS_RXOVIF_Pos)                  /*!< SPI_T::I2SSTS: RXOVIF Mask             */
+
+#define SPI_I2SSTS_RXTOIF_Pos            (12)                                              /*!< SPI_T::I2SSTS: RXTOIF Position         */
+#define SPI_I2SSTS_RXTOIF_Msk            (0x1ul << SPI_I2SSTS_RXTOIF_Pos)                  /*!< SPI_T::I2SSTS: RXTOIF Mask             */
+
+#define SPI_I2SSTS_I2SENSTS_Pos          (15)                                              /*!< SPI_T::I2SSTS: I2SENSTS Position       */
+#define SPI_I2SSTS_I2SENSTS_Msk          (0x1ul << SPI_I2SSTS_I2SENSTS_Pos)                /*!< SPI_T::I2SSTS: I2SENSTS Mask           */
+
+#define SPI_I2SSTS_TXEMPTY_Pos           (16)                                              /*!< SPI_T::I2SSTS: TXEMPTY Position        */
+#define SPI_I2SSTS_TXEMPTY_Msk           (0x1ul << SPI_I2SSTS_TXEMPTY_Pos)                 /*!< SPI_T::I2SSTS: TXEMPTY Mask            */
+
+#define SPI_I2SSTS_TXFULL_Pos            (17)                                              /*!< SPI_T::I2SSTS: TXFULL Position         */
+#define SPI_I2SSTS_TXFULL_Msk            (0x1ul << SPI_I2SSTS_TXFULL_Pos)                  /*!< SPI_T::I2SSTS: TXFULL Mask             */
+
+#define SPI_I2SSTS_TXTHIF_Pos            (18)                                              /*!< SPI_T::I2SSTS: TXTHIF Position         */
+#define SPI_I2SSTS_TXTHIF_Msk            (0x1ul << SPI_I2SSTS_TXTHIF_Pos)                  /*!< SPI_T::I2SSTS: TXTHIF Mask             */
+
+#define SPI_I2SSTS_TXUFIF_Pos            (19)                                              /*!< SPI_T::I2SSTS: TXUFIF Position         */
+#define SPI_I2SSTS_TXUFIF_Msk            (0x1ul << SPI_I2SSTS_TXUFIF_Pos)                  /*!< SPI_T::I2SSTS: TXUFIF Mask             */
+
+#define SPI_I2SSTS_RZCIF_Pos             (20)                                              /*!< SPI_T::I2SSTS: RZCIF Position          */
+#define SPI_I2SSTS_RZCIF_Msk             (0x1ul << SPI_I2SSTS_RZCIF_Pos)                   /*!< SPI_T::I2SSTS: RZCIF Mask              */
+
+#define SPI_I2SSTS_LZCIF_Pos             (21)                                              /*!< SPI_T::I2SSTS: LZCIF Position          */
+#define SPI_I2SSTS_LZCIF_Msk             (0x1ul << SPI_I2SSTS_LZCIF_Pos)                   /*!< SPI_T::I2SSTS: LZCIF Mask              */
+
+#define SPI_I2SSTS_SLVERRIF_Pos          (22)                                              /*!< SPI_T::I2SSTS: SLVERRIF Position       */
+#define SPI_I2SSTS_SLVERRIF_Msk          (0x1ul << SPI_I2SSTS_SLVERRIF_Pos)                /*!< SPI_T::I2SSTS: SLVERRIF Mask           */
+
+#define SPI_I2SSTS_TXRXRST_Pos           (23)                                              /*!< SPI_T::I2SSTS: TXRXRST Position        */
+#define SPI_I2SSTS_TXRXRST_Msk           (0x1ul << SPI_I2SSTS_TXRXRST_Pos)                 /*!< SPI_T::I2SSTS: TXRXRST Mask            */
+
+#define SPI_I2SSTS_RXCNT_Pos             (24)                                              /*!< SPI_T::I2SSTS: RXCNT Position          */
+#define SPI_I2SSTS_RXCNT_Msk             (0x7ul << SPI_I2SSTS_RXCNT_Pos)                   /*!< SPI_T::I2SSTS: RXCNT Mask              */
+
+#define SPI_I2SSTS_TXCNT_Pos             (28)                                              /*!< SPI_T::I2SSTS: TXCNT Position          */
+#define SPI_I2SSTS_TXCNT_Msk             (0x7ul << SPI_I2SSTS_TXCNT_Pos)                   /*!< SPI_T::I2SSTS: TXCNT Mask              */
+
+/** @} SPI_CONST */
+/** @} end of SPI register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __SPI_REG_H__ */

--- a/hal/m258ke/nuvoton/startup_M251.S
+++ b/hal/m258ke/nuvoton/startup_M251.S
@@ -1,0 +1,391 @@
+/****************************************************************************//**
+ * @file     startup_M251.S
+ * @version  V1.00
+ * @brief    CMSIS Cortex-M23 Core Device Startup File for M251
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+	.syntax	unified
+	.arch	armv8-m.base
+
+	.section .stack
+	.align	3
+#ifdef __STACK_SIZE
+	.equ	Stack_Size, __STACK_SIZE
+#else
+	.equ	Stack_Size, 0x00000400
+#endif
+	.globl	__StackTop
+	.globl	__StackLimit
+__StackLimit:
+	.space	Stack_Size
+	.size	__StackLimit, . - __StackLimit
+__StackTop:
+	.size	__StackTop, . - __StackTop
+
+	.section .heap
+	.align	3
+#ifdef __HEAP_SIZE
+	.equ	Heap_Size, __HEAP_SIZE
+#else
+	.equ	Heap_Size, 0x00000100
+#endif
+	.globl	__HeapBase
+	.globl	__HeapLimit
+__HeapBase:
+	.if	Heap_Size
+	.space	Heap_Size
+	.endif
+	.size	__HeapBase, . - __HeapBase
+__HeapLimit:
+	.size	__HeapLimit, . - __HeapLimit
+
+	.section .vectors
+	.align	2
+	.globl	__Vectors
+__Vectors:
+	.long	__StackTop            /* Top of Stack                  */
+	.long	Reset_Handler         /* Reset Handler                 */
+	.long	NMI_Handler           /* NMI Handler                   */
+	.long	HardFault_Handler     /* Hard Fault Handler            */
+	.long	0                     /* Reserved                      */
+	.long	0                     /* Reserved                      */
+	.long	0                     /* Reserved                      */
+	.long	0                     /* Reserved                      */
+	.long	0                     /* Reserved                      */
+	.long	0                     /* Reserved                      */
+	.long	0                     /* Reserved                      */
+	.long	SVC_Handler           /* SVCall Handler                */
+	.long	0                     /* Reserved                      */
+	.long	0                     /* Reserved                      */
+	.long	PendSV_Handler        /* PendSV Handler                */
+	.long	SysTick_Handler       /* SysTick Handler               */
+
+	/* External interrupts */
+	.long	BOD_IRQHandler        /*  0: BOD                        */
+	.long	IRCTRIM_IRQHandler    /*  1: IRC                        */
+	.long	PWRWU_IRQHandler      /*  2: PWRWU                      */
+	.long	Default_Handler       /*  3: Reserved                   */
+	.long	CLKFAIL_IRQHandler    /*  4: CKFAIL                     */
+	.long	Default_Handler       /*  5: Reserved                   */
+	.long	RTC_IRQHandler        /*  6: RTC                        */
+	.long	TAMPER_IRQHandler     /*  7: TAMPER                     */
+	.long	WDT_IRQHandler        /*  8: WDT                        */
+	.long	WWDT_IRQHandler       /*  9: WWDT                       */
+	.long	EINT0_IRQHandler      /* 10: EINT0                      */
+	.long	EINT1_IRQHandler      /* 11: EINT1                      */
+	.long	EINT2_IRQHandler      /* 12: EINT2                      */
+	.long	EINT3_IRQHandler      /* 13: EINT3                      */
+	.long	EINT4_IRQHandler      /* 14: EINT4                      */
+	.long	EINT5_IRQHandler      /* 15: EINT5                      */
+	.long	GPA_IRQHandler        /* 16: GPA                        */
+	.long	GPB_IRQHandler        /* 17: GPB                        */
+	.long	GPC_IRQHandler        /* 18: GPC                        */
+	.long	GPD_IRQHandler        /* 19: GPD                        */
+	.long	GPE_IRQHandler        /* 20: GPE                        */
+	.long	GPF_IRQHandler        /* 21: GPF                        */
+	.long	QSPI0_IRQHandler      /* 22: QSPI0                      */
+	.long	SPI0_IRQHandler       /* 23: SPI0                       */
+	.long	BRAKE0_IRQHandler     /* 24: BRAKE0                     */
+	.long	PWM0_P0_IRQHandler    /* 25: EPWM0P0                    */
+	.long	PWM0_P1_IRQHandler    /* 26: EPWM0P1                    */
+	.long	PWM0_P2_IRQHandler    /* 27: EPWM0P2                    */
+	.long	BRAKE1_IRQHandler     /* 28: BRAKE1                     */
+	.long	PWM1_P0_IRQHandler    /* 29: EPWM1P0                    */
+	.long	PWM1_P1_IRQHandler    /* 30: EPWM1P1                    */
+	.long	PWM1_P2_IRQHandler    /* 31: EPWM1P2                    */
+	.long	TMR0_IRQHandler       /* 32: TIMER0                     */
+	.long	TMR1_IRQHandler       /* 33: TIMER1                     */
+	.long	TMR2_IRQHandler       /* 34: TIMER2                     */
+	.long	TMR3_IRQHandler       /* 35: TIMER3                     */
+	.long	UART0_IRQHandler      /* 36: UART0                      */
+	.long	UART1_IRQHandler      /* 37: UART1                      */
+	.long	I2C0_IRQHandler       /* 38: I2C0                       */
+	.long	I2C1_IRQHandler       /* 39: I2C1                       */
+	.long	PDMA_IRQHandler       /* 40: PDMA                       */
+	.long	DAC_IRQHandler        /* 41: DAC                        */
+	.long	EADC_INT0_IRQHandler  /* 42: EADC00                     */
+	.long	EADC_INT1_IRQHandler  /* 43: EADC01                     */
+	.long	ACMP01_IRQHandler     /* 44: ACMP                       */
+	.long	BPWM0_IRQHandler      /* 45: BPWM0                      */
+	.long	EADC_INT2_IRQHandler  /* 46: EADC02                     */
+	.long	EADC_INT3_IRQHandler  /* 47: EADC03                     */
+	.long	UART2_IRQHandler      /* 48: UART2                      */
+	.long	Default_Handler       /* 49: Reserved                   */
+	.long	USCI0_IRQHandler      /* 50: UCSI0                      */
+	.long	SPI1_IRQHandler       /* 51: SPI1                       */
+	.long	USCI1_IRQHandler      /* 52: USCI1                      */
+	.long	USBD_IRQHandler       /* 53: USBD                       */
+	.long	BPWM1_IRQHandler      /* 54: BPWM1                      */
+	.long	PSIO_IRQHandler       /* 55: PSIO                       */
+	.long	Default_Handler       /* 56: Reserved                   */
+	.long	CRPT_IRQHandler       /* 57: CRPT                       */
+	.long	SC0_IRQHandler        /* 58: SC0                        */
+	.long	Default_Handler       /* 59: Reserved                   */
+	.long	USCI2_IRQHandler      /* 60: USCI2                      */
+	.long	LCD_IRQHandler        /* 61: LCD                        */
+	.long	OPA_IRQHandler        /* 62: OPA                        */
+	.long	TK_IRQHandler         /* 63: TK                         */
+
+	.size	__Vectors, . - __Vectors
+
+	.text
+	.thumb
+	.thumb_func
+	.align	2
+	.globl	Reset_Handler
+	.type	Reset_Handler, %function
+Reset_Handler:
+/*  Firstly it copies data from read only memory to RAM. There are two schemes
+ *  to copy. One can copy more than one sections. Another can only copy
+ *  one section.  The former scheme needs more instructions and read-only
+ *  data to implement than the latter.
+ *  Macro __STARTUP_COPY_MULTIPLE is used to choose between two schemes.  */
+
+#ifdef __STARTUP_COPY_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of triplets, each of which specify:
+ *    offset 0: LMA of start of a section to copy from
+ *    offset 4: VMA of start of a section to copy to
+ *    offset 8: size of the section to copy. Must be multiply of 4
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r4, =__copy_table_start__
+	ldr	r5, =__copy_table_end__
+
+.L_loop0:
+	cmp	r4, r5
+	bge	.L_loop0_done
+	ldr	r1, [r4]
+	ldr	r2, [r4, #4]
+	ldr	r3, [r4, #8]
+
+.L_loop0_0:
+	subs	r3, #4
+	blt	.L_loop0_0_done
+	ldr	r0, [r1,r3]
+	str	r0, [r2,r3]
+	b	.L_loop0_0
+
+.L_loop0_0_done:
+	adds	r4, #12
+	b	.L_loop0
+
+.L_loop0_done:
+#else
+/*  Single section scheme.
+ *
+ *  The ranges of copy from/to are specified by following symbols
+ *    __etext: LMA of start of the section to copy from. Usually end of text
+ *    __data_start__: VMA of start of the section to copy to
+ *    __data_end__: VMA of end of the section to copy to
+ *
+ *  All addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__etext
+	ldr	r2, =__data_start__
+	ldr	r3, =__data_end__
+
+	subs	r3, r2
+	ble	.L_loop1_done
+
+.L_loop1:
+	subs	r3, #4
+	ldr	r0, [r1,r3]
+	str	r0, [r2,r3]
+	bgt	.L_loop1
+
+.L_loop1_done:
+
+#endif /*__STARTUP_COPY_MULTIPLE */
+
+/*  This part of work usually is done in C library startup code. Otherwise,
+ *  define this macro to enable it in this startup.
+ *
+ *  There are two schemes too. One can clear multiple BSS sections. Another
+ *  can only clear one section. The former is more size expensive than the
+ *  latter.
+ *
+ *  Define macro __STARTUP_CLEAR_BSS_MULTIPLE to choose the former.
+ *  Otherwise define macro __STARTUP_CLEAR_BSS to choose the later.
+ */
+#ifdef __STARTUP_CLEAR_BSS_MULTIPLE
+/*  Multiple sections scheme.
+ *
+ *  Between symbol address __copy_table_start__ and __copy_table_end__,
+ *  there are array of tuples specifying:
+ *    offset 0: Start of a BSS section
+ *    offset 4: Size of this BSS section. Must be multiply of 4
+ */
+	ldr	r3, =__zero_table_start__
+	ldr	r4, =__zero_table_end__
+
+.L_loop2:
+	cmp	r3, r4
+	bge	.L_loop2_done
+	ldr	r1, [r3]
+	ldr	r2, [r3, #4]
+	movs	r0, 0
+
+.L_loop2_0:
+	subs	r2, #4
+	str 	r0, [r1, r2]
+	bgt	.L_loop2_0
+
+	adds	r3, #8
+	b	.L_loop2
+.L_loop2_done:
+
+#elif defined (__STARTUP_CLEAR_BSS)
+/*  Single BSS section scheme.
+ *
+ *  The BSS section is specified by following symbols
+ *    __bss_start__: start of the BSS section.
+ *    __bss_end__: end of the BSS section.
+ *
+ *  Both addresses must be aligned to 4 bytes boundary.
+ */
+	ldr	r1, =__bss_start__
+	ldr	r2, =__bss_end__
+
+    movs    r0, 0
+
+    subs    r2, r1
+    ble .L_loop3_done
+
+.L_loop3:
+    subs    r2, #4
+    str r0, [r1, r2]
+    bgt .L_loop3
+.L_loop3_done:
+#endif /* __STARTUP_CLEAR_BSS_MULTIPLE || __STARTUP_CLEAR_BSS */
+
+
+
+
+/*  Unlock Register */
+	ldr	r0, =0x40000100
+	movw r1, 0x00000059
+	str	r1, [r0]
+	movw r1, 0x00000016
+	str	r1, [r0]
+	movw r1, 0x00000088
+	str	r1, [r0]
+
+
+#ifndef __NO_SYSTEM_INIT
+	bl	SystemInit
+#endif
+
+/* Init POR */
+#if 1
+
+	ldr	r0, =0x40000024
+	movw r1, 0x00005AA5
+	str	r1, [r0]
+
+	ldr	r0, =0x400001EC
+	str	r1, [r0]
+#endif
+
+/* Lock register */
+	ldr	r0, =0x40000100
+	movw r1, 0x00000000
+	str	r1, [r0]
+
+#ifndef __START
+#define __START _start
+#endif
+	bl	__START
+
+	.pool
+	.size	Reset_Handler, . - Reset_Handler
+
+	.align	1
+	.thumb_func
+	.weak	Default_Handler
+	.type	Default_Handler, %function
+Default_Handler:
+	b	.
+	.size	Default_Handler, . - Default_Handler
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+	.macro	def_irq_handler	handler_name
+	.weak	\handler_name
+	.set	\handler_name, Default_Handler
+	.endm
+
+	def_irq_handler	NMI_Handler
+    def_irq_handler	HardFault_Handler
+    def_irq_handler	SVC_Handler
+    def_irq_handler	PendSV_Handler
+    def_irq_handler	SysTick_Handler
+    def_irq_handler	BOD_IRQHandler
+    def_irq_handler	IRCTRIM_IRQHandler
+    def_irq_handler	PWRWU_IRQHandler
+    def_irq_handler	CLKFAIL_IRQHandler
+    def_irq_handler	RTC_IRQHandler
+    def_irq_handler	TAMPER_IRQHandler
+    def_irq_handler	WDT_IRQHandler
+    def_irq_handler	WWDT_IRQHandler
+    def_irq_handler	EINT0_IRQHandler
+    def_irq_handler	EINT1_IRQHandler
+    def_irq_handler	EINT2_IRQHandler
+    def_irq_handler	EINT3_IRQHandler
+    def_irq_handler	EINT4_IRQHandler
+    def_irq_handler	EINT5_IRQHandler
+    def_irq_handler	GPA_IRQHandler
+    def_irq_handler	GPB_IRQHandler
+    def_irq_handler	GPC_IRQHandler
+    def_irq_handler	GPD_IRQHandler
+    def_irq_handler	GPE_IRQHandler
+    def_irq_handler	GPF_IRQHandler
+    def_irq_handler	QSPI0_IRQHandler
+    def_irq_handler	SPI0_IRQHandler
+    def_irq_handler	BRAKE0_IRQHandler
+    def_irq_handler	PWM0_P0_IRQHandler
+    def_irq_handler	PWM0_P1_IRQHandler
+    def_irq_handler	PWM0_P2_IRQHandler
+    def_irq_handler	BRAKE1_IRQHandler
+    def_irq_handler	PWM1_P0_IRQHandler
+    def_irq_handler	PWM1_P1_IRQHandler
+    def_irq_handler	PWM1_P2_IRQHandler
+    def_irq_handler	TMR0_IRQHandler
+    def_irq_handler	TMR1_IRQHandler
+    def_irq_handler	TMR2_IRQHandler
+    def_irq_handler	TMR3_IRQHandler
+    def_irq_handler	UART0_IRQHandler
+    def_irq_handler	UART1_IRQHandler
+    def_irq_handler	I2C0_IRQHandler
+    def_irq_handler	I2C1_IRQHandler
+    def_irq_handler	PDMA_IRQHandler
+    def_irq_handler	DAC_IRQHandler
+    def_irq_handler	EADC_INT0_IRQHandler
+    def_irq_handler	EADC_INT1_IRQHandler
+    def_irq_handler	ACMP01_IRQHandler
+    def_irq_handler	BPWM0_IRQHandler
+    def_irq_handler	EADC_INT2_IRQHandler
+    def_irq_handler	EADC_INT3_IRQHandler
+    def_irq_handler	UART2_IRQHandler
+    def_irq_handler	USCI0_IRQHandler
+    def_irq_handler	SPI1_IRQHandler
+    def_irq_handler	USCI1_IRQHandler
+    def_irq_handler	USBD_IRQHandler
+    def_irq_handler	BPWM1_IRQHandler
+    def_irq_handler	PSIO_IRQHandler
+    def_irq_handler	CRPT_IRQHandler
+    def_irq_handler	SC0_IRQHandler
+    def_irq_handler	USCI2_IRQHandler
+    def_irq_handler	LCD_IRQHandler
+    def_irq_handler	OPA_IRQHandler
+    def_irq_handler	TK_IRQHandler
+
+
+    .end

--- a/hal/m258ke/nuvoton/startup_M251.S
+++ b/hal/m258ke/nuvoton/startup_M251.S
@@ -204,6 +204,8 @@ Reset_Handler:
 
 #endif /*__STARTUP_COPY_MULTIPLE */
 
+#define __STARTUP_CLEAR_BSS
+
 /*  This part of work usually is done in C library startup code. Otherwise,
  *  define this macro to enable it in this startup.
  *
@@ -298,6 +300,7 @@ Reset_Handler:
 	movw r1, 0x00000000
 	str	r1, [r0]
 
+#define __START main
 #ifndef __START
 #define __START _start
 #endif

--- a/hal/m258ke/nuvoton/sys_reg.h
+++ b/hal/m258ke/nuvoton/sys_reg.h
@@ -1,0 +1,2474 @@
+/**************************************************************************//**
+ * @file     sys_reg.h
+ * @version  V1.00
+ * @brief    SYS register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __SYS_REG_H__
+#define __SYS_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup SYS System Manger Controller (SYS)
+    Memory Mapped Structure for SYS Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var SYS_T::PDID
+     * Offset: 0x00  Part Device Identification Number Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |PDID      |Part Device Identification Number (Read Only)
+     * |        |          |This register reflects device part number code
+     * |        |          |Software can read this register to identify which device is used.
+     * @var SYS_T::RSTSTS
+     * Offset: 0x04  System Reset Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PORF      |POR Reset Flag
+     * |        |          |The POR reset flag is set by the "Reset Signal" from the Power-on Reset (POR) Controller or bit CHIPRST (SYS_IPRST0[0]) to indicate the previous reset source.
+     * |        |          |0 = No reset from POR or CHIPRST.
+     * |        |          |1 = Power-on Reset (POR) or CHIPRST had issued the reset signal to reset the system.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[1]     |PINRF     |NRESET Pin Reset Flag
+     * |        |          |The nRESET pin reset flag is set by the "Reset Signal" from the nRESET Pin to indicate the previous reset source.
+     * |        |          |0 = No reset from nRESET pin.
+     * |        |          |1 = Pin nRESET had issued the reset signal to reset the system.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[2]     |WDTRF     |WDT Reset Flag
+     * |        |          |The WDT reset flag is set by the "Reset Signal" from the Watchdog Timer or Window Watchdog Timer to indicate the previous reset source.
+     * |        |          |0 = No reset from watchdog timer or window watchdog timer.
+     * |        |          |1 = The watchdog timer or window watchdog timer had issued the reset signal to reset the system.
+     * |        |          |Note1: Write 1 to clear this bit to 0.
+     * |        |          |Note2: Watchdog Timer register RSTF(WDT_CTL[2]) bit is set if the system has been reset by WDT time-out reset
+     * |        |          |Window Watchdog Timer register WWDTRF(WWDT_STATUS[1]) bit is set if the system has been reset by WWDT time-out reset.
+     * |[3]     |LVRF      |LVR Reset Flag
+     * |        |          |The LVR reset flag is set by the "Reset Signal" from the Low Voltage Reset Controller to indicate the previous reset source.
+     * |        |          |0 = No reset from LVR.
+     * |        |          |1 = LVR controller had issued the reset signal to reset the system.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[4]     |BODRF     |BOD Reset Flag
+     * |        |          |The BOD reset flag is set by the "Reset Signal" from the Brown-Out Detector to indicate the previous reset source.
+     * |        |          |0 = No reset from BOD.
+     * |        |          |1 = The BOD had issued the reset signal to reset the system.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[5]     |SYSRF     |System Reset Flag
+     * |        |          |The system reset flag is set by the "Reset Signal" from the Cortex-M23 Core to indicate the previous reset source.
+     * |        |          |0 = No reset from Cortex-M23.
+     * |        |          |1 = The Cortex-M23 had issued the reset signal to reset the system by writing 1 to the bit SYSRESETREQ(AIRCR[2], Application Interrupt and Reset Control Register, address = 0xE000ED0C) in system control registers of Cortex-M23 core.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[6]     |PMURF     |PMU reset flag
+     * |        |          |The PMU reset flag is set by any reset  signal when MCU is in power down state.
+     * |        |          |0 = No reset in power down state.
+     * |        |          |1 = Any reset signal happens in power down  state.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[7]     |CPURF     |CPU Reset Flag
+     * |        |          |The CPU reset flag is set by hardware if software writes CPURST (SYS_IPRST0[1]) 1 to reset Cortex-M23 Core and Flash Memory Controller (FMC).
+     * |        |          |0 = No reset from CPU.
+     * |        |          |1 = The Cortex-M23 Core and FMC are reset by software setting CPURST to 1.
+     * |        |          |Note: Write to clear this bit to 0.
+     * |[8]     |CPULKRF   |CPU Lockup Reset Flag
+     * |        |          |0 = No reset from CPU lockup happened.
+     * |        |          |1 = The Cortex-M23 lockup happened and chip is reset.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |        |          |Note2: When CPU lockup happened under ICE is connected, This flag will set to 1 but chip will not reset.
+     * |[9]     |VBATLVRF  |VBAT LVR Reset Flag
+     * |        |          |The VBAT LVR reset flag is set by the Reset Signal from the VBAT Low Voltage Reset Controller to indicate the previous reset source.
+     * |        |          |0 = No reset from VBAT LVR.
+     * |        |          |1 = VBAT LVR controller had issued the reset signal to reset the system.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * @var SYS_T::IPRST0
+     * Offset: 0x08  Peripheral  Reset Control Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CHIPRST   |Chip One-shot Reset (Write Protect)
+     * |        |          |Setting this bit will reset the whole chip, including Processor core and all peripherals, and this bit will automatically return to 0 after the 2 clock cycles.
+     * |        |          |The CHIPRST is same as the POR reset, all the chip controllers is reset and the chip setting from flash are also reload.
+     * |        |          |About the difference between CHIPRST and SYSRESETREQ(AIRCR[2]), please refer to section 6.2.2
+     * |        |          |0 = Chip normal operation.
+     * |        |          |1 = Chip one-shot reset.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[1]     |CPURST    |Processor Core One-shot Reset (Write Protect)
+     * |        |          |Setting this bit will only reset the processor core and Flash Memory Controller(FMC), and this bit will automatically return to 0 after the 2 clock cycles.
+     * |        |          |0 = Processor core normal operation.
+     * |        |          |1 = Processor core one-shot reset.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[2]     |PDMARST   |PDMA Controller Reset (Write Protect)
+     * |        |          |Setting this bit to 1 will generate a reset signal to the PDMA
+     * |        |          |User needs to set this bit to 0 to release from reset state.
+     * |        |          |0 = PDMA controller normal operation.
+     * |        |          |1 = PDMA controller reset.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[3]     |EBIRST    |EBI Controller Reset (Write Protect)
+     * |        |          |Set this bit to 1 will generate a reset signal to the EBI
+     * |        |          |User needs to set this bit to 0 to release from the reset state.
+     * |        |          |0 = EBI controller normal operation.
+     * |        |          |1 = EBI controller reset.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[7]     |CRCRST    |CRC Calculation Controller Reset (Write Protect)
+     * |        |          |Set this bit to 1 will generate a reset signal to the CRC calculation controller
+     * |        |          |User needs to set this bit to 0 to release from the reset state.
+     * |        |          |0 = CRC calculation controller normal operation.
+     * |        |          |1 = CRC calculation controller reset.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var SYS_T::IPRST1
+     * Offset: 0x0C  Peripheral Reset Control Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |GPIORST   |GPIO Controller Reset
+     * |        |          |0 = GPIO controller normal operation.
+     * |        |          |1 = GPIO controller reset.
+     * |[2]     |TMR0RST   |Timer0 Controller Reset
+     * |        |          |0 = Timer0 controller normal operation.
+     * |        |          |1 = Timer0 controller reset.
+     * |[3]     |TMR1RST   |Timer1 Controller Reset
+     * |        |          |0 = Timer1 controller normal operation.
+     * |        |          |1 = Timer1 controller reset.
+     * |[4]     |TMR2RST   |Timer2 Controller Reset
+     * |        |          |0 = Timer2 controller normal operation.
+     * |        |          |1 = Timer2 controller reset.
+     * |[5]     |TMR3RST   |Timer3 Controller Reset
+     * |        |          |0 = Timer3 controller normal operation.
+     * |        |          |1 = Timer3 controller reset.
+     * |[7]     |ACMP01RST |Analog Comparator 0/1 Controller Reset
+     * |        |          |0 = Analog Comparator 0/1 controller normal operation.
+     * |        |          |1 = Analog Comparator 0/1 controller reset.
+     * |[8]     |I2C0RST   |I2C0 Controller Reset
+     * |        |          |0 = I2C0 controller normal operation.
+     * |        |          |1 = I2C0 controller reset.
+     * |[9]     |I2C1RST   |I2C1 Controller Reset
+     * |        |          |0 = I2C1 controller normal operation.
+     * |        |          |1 = I2C1 controller reset.
+     * |[12]    |QSPI0RST   |QSPI0 Controller Reset
+     * |        |          |0 = QSPI0 controller normal operation.
+     * |        |          |1 = QSPI0 controller reset.
+     * |[13]    |SPI0RST   |SPI0 Controller Reset
+     * |        |          |0 = SPI0 controller normal operation.
+     * |        |          |1 = SPI0 controller reset.
+     * |[16]    |UART0RST  |UART0 Controller Reset
+     * |        |          |0 = UART0 controller normal operation.
+     * |        |          |1 = UART0 controller reset.
+     * |[17]    |UART1RST  |UART1 Controller Reset
+     * |        |          |0 = UART1 controller normal operation.
+     * |        |          |1 = UART1 controller reset.
+     * |[18]    |UART2RST  |UART2 Controller Reset
+     * |        |          |0 = UART2 controller normal operation.
+     * |        |          |1 = UART2 controller reset.
+     * |[27]    |USBDRST   |USBD Controller Reset
+     * |        |          |0 = USBD controller normal operation.
+     * |        |          |1 = USBD controller reset.
+     * |[28]    |EADCRST   |EADC Controller Reset
+     * |        |          |0 = EADC controller normal operation.
+     * |        |          |1 = EADC controller reset.
+     * @var SYS_T::IPRST2
+     * Offset: 0x10  Peripheral Reset Control Register 2
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SC0RST    |SC0 Controller Reset
+     * |        |          |0 = SC0 controller normal operation.
+     * |        |          |1 = SC0 controller reset.
+     * |[8]     |USCI0RST  |USCI0 Controller Reset
+     * |        |          |0 = USCI0 controller normal operation.
+     * |        |          |1 = USCI0 controller reset.
+     * |[9]     |USCI1RST  |USCI1 Controller Reset
+     * |        |          |0 = USCI1 controller normal operation.
+     * |        |          |1 = USCI1 controller reset.
+     * |[10]    |USCI2RST  |USCI2 Controller Reset
+     * |        |          |0 = USCI2 controller normal operation.
+     * |        |          |1 = USCI2 controller reset.
+     * |[12]    |DACRST    |DAC Controller Reset
+     * |        |          |0 = DAC controller normal operation.
+     * |        |          |1 = DAC controller reset.
+     * |[16]    |PWM0RST   |PWM0 Controller Reset
+     * |        |          |0 = PWM0 controller normal operation.
+     * |        |          |1 = PWM0 controller reset.
+     * |[17]    |PWM1RST   |PWM1 Controller Reset
+     * |        |          |0 = PWM1 controller normal operation.
+     * |        |          |1 = PWM1 controller reset.
+     * |[18]    |BPWM0RST  |BPWM0 Controller Reset
+     * |        |          |0 = BPWM0 controller normal operation.
+     * |        |          |1 = BPWM0 controller reset.
+     * |[19]    |BPWM1RST  |BPWM1 Controller Reset
+     * |        |          |0 = BPWM1 controller normal operation.
+     * |        |          |1 = BPWM1 controller reset.
+     * |[30]    |OPARST    |OP Amplifier (OPA) Controller Reset
+     * |        |          |0 = OPA controller normal operation.
+     * |        |          |1 = OPA controller reset.
+     * |[31]    |PSIORST   |PSIORST
+     * @var SYS_T::BODCTL
+     * Offset: 0x18  Brown-out Detector Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BODEN     |Brown-out Detector Enable Bit (Write Protect)
+     * |        |          |The default value is set by flash controller user configuration register CBODEN (CONFIG0 [19]).
+     * |        |          |0 = Brown-out Detector function Disabled.
+     * |        |          |1 = Brown-out Detector function Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[3]     |BODRSTEN  |Brown-out Reset Enable Bit (Write Protect)
+     * |        |          |The default value is set by flash controller user configuration register CBORST(CONFIG0[20]) bit .
+     * |        |          |0 = Brown-out "INTERRUPT" function Enabled.
+     * |        |          |1 = Brown-out "RESET" function Enabled.
+     * |        |          |Note1:
+     * |        |          |While the Brown-out Detector function is enabled (BODEN high) and BOD reset function is enabled (BODRSTEN high), BOD will assert a signal to reset chip when the detected voltage is lower than the threshold (BODOUT high).
+     * |        |          |While the BOD function is enabled (BODEN high) and BOD interrupt function is enabled (BODRSTEN low), BOD will assert an interrupt if BODOUT is high
+     * |        |          |BOD interrupt will keep till to the BODEN set to 0
+     * |        |          |BOD interrupt can be blocked by disabling the NVIC BOD interrupt or disabling BOD function (set BODEN low).
+     * |        |          |Note2: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[4]     |BODIF     |Brown-out Detector Interrupt Flag
+     * |        |          |0 = Brown-out Detector does not detect any voltage draft at VDD down through or up through the voltage of BODVL setting.
+     * |        |          |1 = When Brown-out Detector detects the VDD is dropped down through the voltage of BODVL setting or the VDD is raised up through the voltage of BODVL setting, this bit is set to 1 and the brown-out interrupt is requested if brown-out interrupt is enabled.
+     * |        |          |Note: Write 1 to clear this bit to 0.
+     * |[5]     |BODLPM    |Brown-out Detector Low Power Mode (Write Protect)
+     * |        |          |0 = BOD operate in normal mode (default).
+     * |        |          |1 = BOD Low Power mode Enabled.
+     * |        |          |Note1: The BOD consumes about 100uA in normal mode, the low power mode can reduce the current to about 1/10 but slow the BOD response.
+     * |        |          |Note2: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[6]     |BODOUT    |Brown-out Detector Output Status
+     * |        |          |0 = Brown-out Detector output status is 0.
+     * |        |          |It means the detected voltage is higher than BODVL setting or BODEN is 0.
+     * |        |          |1 = Brown-out Detector output status is 1.
+     * |        |          |It means the detected voltage is lower than BODVL setting
+     * |        |          |If the BODEN is 0, BOD function disabled , this bit always responds 0000.
+     * |[7]     |LVREN     |Low Voltage Reset Enable Bit (Write Protect)
+     * |        |          |The LVR function resets the chip when the input power voltage is lower than LVR circuit setting
+     * |        |          |LVR function is enabled by default.
+     * |        |          |0 = Low Voltage Reset function Disabled.
+     * |        |          |1 = Low Voltage Reset function Enabled.
+     * |        |          |Note1: After enabling the bit, the LVR function will be active with 100us delay for LVR output stable (default).
+     * |        |          |Note2: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[10:8]  |BODDGSEL  |Brown-out Detector Output De-glitch Time Select (Write Protect)
+     * |        |          |000 = BOD output is sampled by LIRC.
+     * |        |          |001 = 4 system clock (HCLK).
+     * |        |          |010 = 8 system clock (HCLK).
+     * |        |          |011 = 16 system clock (HCLK).
+     * |        |          |100 = 32 system clock (HCLK).
+     * |        |          |101 = 64 system clock (HCLK).
+     * |        |          |110 = 128 system clock (HCLK).
+     * |        |          |111 = 256 system clock (HCLK).
+     * |        |          |Note: These bits are write protected. Refer to the SYS_REGLCTL register.
+     * |[14:12] |LVRDGSEL  |LVR Output De-glitch Time Select (Write Protect)
+     * |        |          |000 = Without de-glitch function.
+     * |        |          |001 = 4 MIRC clock (4.032 MHz), 1 us.
+     * |        |          |010 = 8 MIRC clock (4.032 MHz), 2 us.
+     * |        |          |011 = 16 MIRC clock (4.032 MHz), 4 us.
+     * |        |          |100 = 32 MIRC clock (4.032 MHz), 8 us.
+     * |        |          |101 = 64 MIRC clock (4.032 MHz), 16 us.
+     * |        |          |110 = 128 MIRC clock (4.032 MHz), 32 us.
+     * |        |          |111 = 256 MIRC clock (4.032 MHz), 64 us.
+     * |        |          |Note: These bits are write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note: The MIRC enabled automatically when LVRDGSEL is not 000 and LVREN is 1.
+     * |[18:16] |BODVL     |Brown-out Detector Threshold Voltage Selection (Write Protect)
+     * |        |          |The default value is set by flash controller user configuration register CBOV (CONFIG0 [23:21]).
+     * |        |          |000 = Reserved.
+     * |        |          |001 = Brown-Out Detector threshold voltage is 1.8V.
+     * |        |          |010 = Brown-Out Detector threshold voltage is 2.0V.
+     * |        |          |011 = Brown-Out Detector threshold voltage is 2.4V.
+     * |        |          |100 = Brown-Out Detector threshold voltage is 2.7V.
+     * |        |          |101 = Brown-Out Detector threshold voltage is 3.0V.
+     * |        |          |110 = Brown-Out Detector threshold voltage is 3.7V.
+     * |        |          |111 = Brown-Out Detector threshold voltage is 4.4V.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var SYS_T::IVSCTL
+     * Offset: 0x1C  Internal Voltage Source Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |VTEMPEN   |Temperature Sensor Enable Bit
+     * |        |          |This bit is used to enable/disable temperature sensor function.
+     * |        |          |0 = Temperature sensor function Disabled (default).
+     * |        |          |1 = Temperature sensor function Enabled.
+     * |[1]     |VBATUGEN  |VBAT Unity Gain Buffer Enable Bit
+     * |        |          |This bit is used to enable/disable VBAT unity gain buffer function.
+     * |        |          |0 = VBAT unity gain buffer function Disabled (default).
+     * |        |          |1 = VBAT unity gain buffer function Enabled.
+     * |        |          |Note: After this bit is set to 1, the value of VBAT unity gain buffer output voltage can be obtained from ADC conversion result
+     * @var SYS_T::PORCTL0
+     * Offset: 0x24  Power-On-reset Controller Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |PORMASK   |Power-on Reset Enable Bit (Write Protect)
+     * |        |          |When powered on, the POR circuit generates a reset signal to reset the whole chip function, but noise on the power may cause the POR active again
+     * |        |          |User can disable internal POR circuit to avoid unpredictable noise to cause chip reset by writing 0x5AA5 to this field.
+     * |        |          |The POR function will be active again when this field is set to another value or chip is reset by other reset source, including:
+     * |        |          |nRESET, Watchdog, LVR reset, BOD reset, ICE reset command and the software-chip reset function.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var SYS_T::VREFCTL
+     * Offset: 0x28  VREF Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |IVRS      |Internal Voltage Reference Scale (Write Protect)
+     * |        |          |0 = Internal voltage reference(INT_VREF) set to 1.536V.
+     * |        |          |1 = Internal voltage reference(INT_VREF) set to 2.048V.
+     * |        |          |2 = Internal voltage reference(INT_VREF) set to 2.56V.
+     * |        |          |3 = Internal voltage reference(INT_VREF) set to 3.072V.
+     * |        |          |4 = Internal voltage reference(INT_VREF) set to 4.096V.
+     * |        |          |Others = Reserved.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[3]     |IVREN     |Internal Voltage Reference Module Enable(Write Protect)
+     * |        |          |0 = Internal voltage reference module is disabled.
+     * |        |          |1 = Internal voltage reference module is enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[10]    |PRELOAD   |1. Preload Active
+     * |        |          |2. Preload inactive
+     * @var SYS_T::GPA_MFPL
+     * Offset: 0x30  GPIOA Low Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PA0MFP    |PA.0 Multi-function Pin Selection
+     * |[7:4]   |PA1MFP    |PA.1 Multi-function Pin Selection
+     * |[11:8]  |PA2MFP    |PA.2 Multi-function Pin Selection
+     * |[15:12] |PA3MFP    |PA.3 Multi-function Pin Selection
+     * |[19:16] |PA4MFP    |PA.4 Multi-function Pin Selection
+     * |[23:20] |PA5MFP    |PA.5 Multi-function Pin Selection
+     * |[27:24] |PA6MFP    |PA.6 Multi-function Pin Selection
+     * |[31:28] |PA7MFP    |PA.7 Multi-function Pin Selection
+     * @var SYS_T::GPA_MFPH
+     * Offset: 0x34  GPIOA High Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PA8MFP    |PA.8 Multi-function Pin Selection
+     * |[7:4]   |PA9MFP    |PA.9 Multi-function Pin Selection
+     * |[11:8]  |PA10MFP   |PA.10 Multi-function Pin Selection
+     * |[15:12] |PA11MFP   |PA.11 Multi-function Pin Selection
+     * |[19:16] |PA12MFP   |PA.12 Multi-function Pin Selection
+     * |[23:20] |PA13MFP   |PA.13 Multi-function Pin Selection
+     * |[27:24] |PA14MFP   |PA.14 Multi-function Pin Selection
+     * |[31:28] |PA15MFP   |PA.15 Multi-function Pin Selection
+     * @var SYS_T::GPB_MFPL
+     * Offset: 0x38  GPIOB Low Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PB0MFP    |PB.0 Multi-function Pin Selection
+     * |[7:4]   |PB1MFP    |PB.1 Multi-function Pin Selection
+     * |[11:8]  |PB2MFP    |PB.2 Multi-function Pin Selection
+     * |[15:12] |PB3MFP    |PB.3 Multi-function Pin Selection
+     * |[19:16] |PB4MFP    |PB.4 Multi-function Pin Selection
+     * |[23:20] |PB5MFP    |PB.5 Multi-function Pin Selection
+     * |[27:24] |PB6MFP    |PB.6 Multi-function Pin Selection
+     * |[31:28] |PB7MFP    |PB.7 Multi-function Pin Selection
+     * @var SYS_T::GPB_MFPH
+     * Offset: 0x3C  GPIOB High Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PB8MFP    |PB.8 Multi-function Pin Selection
+     * |[7:4]   |PB9MFP    |PB.9 Multi-function Pin Selection
+     * |[11:8]  |PB10MFP   |PB.10 Multi-function Pin Selection
+     * |[15:12] |PB11MFP   |PB.11 Multi-function Pin Selection
+     * |[19:16] |PB12MFP   |PB.12 Multi-function Pin Selection
+     * |[23:20] |PB13MFP   |PB.13 Multi-function Pin Selection
+     * |[27:24] |PB14MFP   |PB.14 Multi-function Pin Selection
+     * |[31:28] |PB15MFP   |PB.15 Multi-function Pin Selection
+     * @var SYS_T::GPC_MFPL
+     * Offset: 0x40  GPIOC Low Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PC0MFP    |PC.0 Multi-function Pin Selection
+     * |[7:4]   |PC1MFP    |PC.1 Multi-function Pin Selection
+     * |[11:8]  |PC2MFP    |PC.2 Multi-function Pin Selection
+     * |[15:12] |PC3MFP    |PC.3 Multi-function Pin Selection
+     * |[19:16] |PC4MFP    |PC.4 Multi-function Pin Selection
+     * |[23:20] |PC5MFP    |PC.5 Multi-function Pin Selection
+     * |[27:24] |PC6MFP    |PC.6 Multi-function Pin Selection
+     * |[31:28] |PC7MFP    |PC.7 Multi-function Pin Selection
+     * @var SYS_T::GPC_MFPH
+     * Offset: 0x44  GPIOC High Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PC8MFP    |PC.8 Multi-function Pin Selection
+     * |[7:4]   |PC9MFP    |PC.9 Multi-function Pin Selection
+     * |[11:8]  |PC10MFP   |PC.10 Multi-function Pin Selection
+     * |[15:12] |PC11MFP   |PC.11 Multi-function Pin Selection
+     * |[19:16] |PC12MFP   |PC.12 Multi-function Pin Selection
+     * |[23:20] |PC13MFP   |PC.13 Multi-function Pin Selection
+     * |[27:24] |PC14MFP   |PC.14 Multi-function Pin Selection
+     * |[31:28] |PC15MFP   |PC.15 Multi-function Pin Selection
+     * @var SYS_T::GPD_MFPL
+     * Offset: 0x48  GPIOD Low Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PD0MFP    |PD.0 Multi-function Pin Selection
+     * |[7:4]   |PD1MFP    |PD.1 Multi-function Pin Selection
+     * |[11:8]  |PD2MFP    |PD.2 Multi-function Pin Selection
+     * |[15:12] |PD3MFP    |PD.3 Multi-function Pin Selection
+     * |[19:16] |PD4MFP    |PD.4 Multi-function Pin Selection
+     * |[23:20] |PD5MFP    |PD.5 Multi-function Pin Selection
+     * |[27:24] |PD6MFP    |PD.6 Multi-function Pin Selection
+     * |[31:28] |PD7MFP    |PD.7 Multi-function Pin Selection
+     * @var SYS_T::GPD_MFPH
+     * Offset: 0x4C  GPIOD High Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PD8MFP    |PD.8 Multi-function Pin Selection
+     * |[7:4]   |PD9MFP    |PD.9 Multi-function Pin Selection
+     * |[11:8]  |PD10MFP   |PD.10 Multi-function Pin Selection
+     * |[15:12] |PD11MFP   |PD.11 Multi-function Pin Selection
+     * |[19:16] |PD12MFP   |PD.12 Multi-function Pin Selection
+     * |[23:20] |PD13MFP   |PD.13 Multi-function Pin Selection
+     * |[27:24] |PD14MFP   |PD.14 Multi-function Pin Selection
+     * |[31:28] |PD15MFP   |PD.15 Multi-function Pin Selection
+     * @var SYS_T::GPE_MFPL
+     * Offset: 0x50  GPIOE Low Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PE0MFP    |PE.0 Multi-function Pin Selection
+     * |[7:4]   |PE1MFP    |PE.1 Multi-function Pin Selection
+     * |[11:8]  |PE2MFP    |PE.2 Multi-function Pin Selection
+     * |[15:12] |PE3MFP    |PE.3 Multi-function Pin Selection
+     * |[19:16] |PE4MFP    |PE.4 Multi-function Pin Selection
+     * |[23:20] |PE5MFP    |PE.5 Multi-function Pin Selection
+     * |[27:24] |PE6MFP    |PE.6 Multi-function Pin Selection
+     * |[31:28] |PE7MFP    |PE.7 Multi-function Pin Selection
+     * @var SYS_T::GPE_MFPH
+     * Offset: 0x54  GPIOE High Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PE8MFP    |PE.8 Multi-function Pin Selection
+     * |[7:4]   |PE9MFP    |PE.9 Multi-function Pin Selection
+     * |[11:8]  |PE10MFP   |PE.10 Multi-function Pin Selection
+     * |[15:12] |PE11MFP   |PE.11 Multi-function Pin Selection
+     * |[19:16] |PE12MFP   |PE.12 Multi-function Pin Selection
+     * |[23:20] |PE13MFP   |PE.13 Multi-function Pin Selection
+     * |[27:24] |PE14_MFP  |PE.14 Multi-function Pin Selection
+     * |[31:28] |PE15_MFP  |PE.15 Multi-function Pin Selection
+     * @var SYS_T::GPF_MFPL
+     * Offset: 0x58  GPIOF Low Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PF0MFP    |PF.0 Multi-function Pin Selection
+     * |[7:4]   |PF1MFP    |PF.1 Multi-function Pin Selection
+     * |[11:8]  |PF2MFP    |PF.2 Multi-function Pin Selection
+     * |[15:12] |PF3MFP    |PF.3 Multi-function Pin Selection
+     * |[19:16] |PF4MFP    |PF.4 Multi-function Pin Selection
+     * |[23:20] |PF5MFP    |PF.5 Multi-function Pin Selection
+     * |[27:24] |PF6MFP    |PF.6 Multi-function Pin Selection
+     * |[31:28] |PF7MFP    |PF.7 Multi-function Pin Selection
+     * @var SYS_T::GPF_MFPH
+     * Offset: 0x5C  GPIOF High Byte Multiple Function Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |PF8MFP    |PF.8 Multi-function Pin Selection
+     * |[7:4]   |PF9MFP    |PF.9 Multi-function Pin Selection
+     * |[11:8]  |PF10MFP   |PF.10 Multi-function Pin Selection
+     * |[15:12] |PF11MFP   |PF.11 Multi-function Pin Selection
+     * |[19:16] |PF12MFP   |PF.12 Multi-function Pin Selection
+     * |[23:20] |PF13MFP   |PF.13 Multi-function Pin Selection
+     * |[27:24] |PF14MFP   |PF.14 Multi-function Pin Selection
+     * |[31:28] |PF15MFP   |PF.15 Multi-function Pin Selection
+     * @var SYS_T::GPA_MFOS
+     * Offset: 0x80  GPIOA Multiple Function Output Select Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MFOS0     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[1]     |MFOS1     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[2]     |MFOS2     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[3]     |MFOS3     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[4]     |MFOS4     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[5]     |MFOS5     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[6]     |MFOS6     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[7]     |MFOS7     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[8]     |MFOS8     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[9]     |MFOS9     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[10]    |MFOS10    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[11]    |MFOS11    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[12]    |MFOS12    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[13]    |MFOS13    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[14]    |MFOS14    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[15]    |MFOS15    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * @var SYS_T::GPB_MFOS
+     * Offset: 0x84  GPIOB Multiple Function Output Select Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MFOS0     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[1]     |MFOS1     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[2]     |MFOS2     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[3]     |MFOS3     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[4]     |MFOS4     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[5]     |MFOS5     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[6]     |MFOS6     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[7]     |MFOS7     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[8]     |MFOS8     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[9]     |MFOS9     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[10]    |MFOS10    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[11]    |MFOS11    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[12]    |MFOS12    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[13]    |MFOS13    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[14]    |MFOS14    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[15]    |MFOS15    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * @var SYS_T::GPC_MFOS
+     * Offset: 0x88  GPIOC Multiple Function Output Select Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MFOS0     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[1]     |MFOS1     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[2]     |MFOS2     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[3]     |MFOS3     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[4]     |MFOS4     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[5]     |MFOS5     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[6]     |MFOS6     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[7]     |MFOS7     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[8]     |MFOS8     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[9]     |MFOS9     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[10]    |MFOS10    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[11]    |MFOS11    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[12]    |MFOS12    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[13]    |MFOS13    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[14]    |MFOS14    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[15]    |MFOS15    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * @var SYS_T::GPD_MFOS
+     * Offset: 0x8C  GPIOD Multiple Function Output Select Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MFOS0     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[1]     |MFOS1     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[2]     |MFOS2     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[3]     |MFOS3     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[4]     |MFOS4     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[5]     |MFOS5     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[6]     |MFOS6     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[7]     |MFOS7     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[8]     |MFOS8     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[9]     |MFOS9     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[10]    |MFOS10    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[11]    |MFOS11    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[12]    |MFOS12    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[13]    |MFOS13    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[14]    |MFOS14    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[15]    |MFOS15    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * @var SYS_T::GPE_MFOS
+     * Offset: 0x90  GPIOE Multiple Function Output Select Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MFOS0     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[1]     |MFOS1     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[2]     |MFOS2     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[3]     |MFOS3     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[4]     |MFOS4     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[5]     |MFOS5     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[6]     |MFOS6     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[7]     |MFOS7     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[8]     |MFOS8     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[9]     |MFOS9     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[10]    |MFOS10    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[11]    |MFOS11    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[12]    |MFOS12    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[13]    |MFOS13    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[14]    |MFOS14    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[15]    |MFOS15    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * @var SYS_T::GPF_MFOS
+     * Offset: 0x94  GPIOF Multiple Function Output Select Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MFOS0     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[1]     |MFOS1     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[2]     |MFOS2     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[3]     |MFOS3     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[4]     |MFOS4     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[5]     |MFOS5     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[6]     |MFOS6     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[7]     |MFOS7     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[8]     |MFOS8     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[9]     |MFOS9     |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[10]    |MFOS10    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[11]    |MFOS11    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[12]    |MFOS12    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[13]    |MFOS13    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[14]    |MFOS14    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * |[15]    |MFOS15    |GPIOA-f Pin[n] Multiple Function Pin Output Mode Select
+     * |        |          |This bit used to select multiple function pin output mode type for Px.n pin
+     * |        |          |0 = Multiple function pin output mode type is Push-pull mode.
+     * |        |          |1 = Multiple function pin output mode type is Open-drain mode.
+     * |        |          |Note:
+     * |        |          |Max. n=15.
+     * @var SYS_T::MODCTL
+     * Offset: 0xC0  Modulation Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |MODEN     |Modulation Function Enable Bit
+     * |        |          |This bit enables modulation function by modulating with PWM0 channel output and USCI0(USCI0_DAT0) or UART0(UART0_TXD) output.
+     * |        |          |0 = Modulation Function Disabled.
+     * |        |          |1 = Modulation Function Enabled.
+     * |[1]     |MODH      |Modulation at Data High
+     * |        |          |Select modulation pulse(PWM0) at high or low of UART0_TXD or USCI0_DAT0
+     * |        |          |0: Modulation pulse at UART0_TXD low or USCI0_DAT0 low.
+     * |        |          |1: Modulation pulse at UART0_TXD high or USCI0_DAT0 high.
+     * |[7:4]   |MODPWMSEL |PWM0 Channel Select for Modulation
+     * |        |          |Select the PWM0 channel to modulate with the UART0_TXD or USCI0_DAT0.
+     * |        |          |0000: PWM0 Channel 0 modulate with UART0_TXD.
+     * |        |          |0001: PWM0 Channel 1 modulate with UART0_TXD.
+     * |        |          |0010: PWM0 Channel 2 modulate with UART0_TXD.
+     * |        |          |0011: PWM0 Channel 3 modulate with UART0_TXD.
+     * |        |          |0100: PWM0 Channel 4 modulate with UART0_TXD.
+     * |        |          |0101: PWM0 Channel 5 modulate with UART0_TXD.
+     * |        |          |0110: Reserved.
+     * |        |          |0111: Reserved.
+     * |        |          |1000: PWM0 Channel 0 modulate with USCI0_DAT0.
+     * |        |          |1001: PWM0 Channel 1 modulate with USCI0_DAT0.
+     * |        |          |1010: PWM0 Channel 2 modulate with USCI0_DAT0.
+     * |        |          |1011: PWM0 Channel 3 modulate with USCI0_DAT0.
+     * |        |          |1100: PWM0 Channel 4 modulate with USCI0_DAT0.
+     * |        |          |1101: PWM0 Channel 5 modulate with USCI0_DAT0.
+     * |        |          |1110: Reserved.
+     * |        |          |1111: Reserved.
+     * |        |          |Note: This bis is valid while MODEN (SYS_MODCTL[0]) is set to 1.
+     * @var SYS_T::SRAM_BISTCTL
+     * Offset: 0xD0  System SRAM BIST Test Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SRBIST    |SRAM Bank0 BIST Enable Bit (Write Protect)
+     * |        |          |This bit enables BIST test for SRAM bank0.
+     * |        |          |0 = system SRAM BIST Disabled.
+     * |        |          |1 = system SRAM BIST Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[2]     |FMCBIST   |FMC CACHE BIST Enable Bit (Write Protect)
+     * |        |          |This bit enables BIST test for CACHE RAM
+     * |        |          |0 = system CACHE BIST Disabled.
+     * |        |          |1 = system CACHE BIST Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[4]     |USBBIST   |USB BIST Enable Bit (Write Protect)
+     * |        |          |This bit enables BIST test for USB RAM
+     * |        |          |0 = system USB BIST Disabled.
+     * |        |          |1 = system USB BIST Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[7]     |PDMABIST  |PDMA BIST Enable Bit (Write Protect)
+     * |        |          |This bit enables BIST test for PDMA RAM
+     * |        |          |0 = system PDMA BIST Disabled.
+     * |        |          |1 = system PDMA BIST Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var SYS_T::SRAM_BISTSTS
+     * Offset: 0xD4  System SRAM BIST Test Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SRBISTEF  |1st System SRAM BIST Fail Flag
+     * |        |          |0 = 1st system SRAM BIST test pass.
+     * |        |          |1 = 1st system SRAM BIST test fail.
+     * |[1]     |CR0BISTEF |CACHE0 SRAM BIST Fail Flag
+     * |        |          |0 = System CACHE RAM BIST test pass.
+     * |        |          |1 = System CACHE RAM BIST test fail.
+     * |[2]     |CR1BISTEF |CACHE1 SRAM BIST Fail Flag
+     * |        |          |0 = System CACHE RAM BIST test pass.
+     * |        |          |1 = System CACHE RAM BIST test fail.
+     * |[4]     |USBBEF    |USB SRAM BIST Fail Flag
+     * |        |          |0 = USB SRAM BIST test pass.
+     * |        |          |1 = USB SRAM BIST test fail.
+     * |[7]     |PDMABISTF |PDMA SRAM BIST Failed Flag
+     * |        |          |0 = 1st PDMA SRAM BIST pass.
+     * |        |          |1 =1st PDMA SRAM BIST failed.
+     * |[16]    |SRBEND    |1st SRAM BIST Test Finish
+     * |        |          |0 = 1st system SRAM BIST active.
+     * |        |          |1 =1st system SRAM BIST finish.
+     * |[17]    |CR0BEND   |CACHE 0 SRAM BIST Test Finish
+     * |        |          |0 = System CACHE RAM BIST is active.
+     * |        |          |1 = System CACHE RAM BIST test finish.
+     * |[18]    |CR1BEND   |CACHE 1 SRAM BIST Test Finish
+     * |        |          |0 = System CACHE RAM BIST is active.
+     * |        |          |1 = System CACHE RAM BIST test finish.
+     * |[20]    |USBBEND   |USB SRAM BIST Test Finish
+     * |        |          |0 = USB SRAM BIST is active.
+     * |        |          |1 = USB SRAM BIST test finish.
+     * |[23]    |PDMAEND   |PDMA SRAM BIST Test Finish
+     * |        |          |0 = PDMA SRAM BIST is active.
+     * |        |          |1 = PDMA SRAM BIST test finish.
+     * @var SYS_T::HIRCTRIMCTL
+     * Offset: 0xF0  HIRC Trim Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |FREQSEL   |Trim Frequency Selection
+     * |        |          |This field indicates the target frequency of 48 MHz internal high speed RC oscillator (HIRC) auto trim.
+     * |        |          |During auto trim operation, if clock error detected with CESTOPEN is set to 1 or trim retry limitation count reached, this field will be cleared to 00 automatically.
+     * |        |          |00 = Disable HIRC auto trim function.
+     * |        |          |01 = Enable HIRC auto trim function and trim HIRC to 48 MHz.
+     * |        |          |10 = Reserved..
+     * |        |          |11 = Reserved.
+     * |[5:4]   |LOOPSEL   |Trim Calculation Loop Selection
+     * |        |          |This field defines that trim value calculation is based on how many reference clocks.
+     * |        |          |00 = Trim value calculation is based on average difference in 4 clocks of reference clock.
+     * |        |          |01 = Trim value calculation is based on average difference in 8 clocks of reference clock.
+     * |        |          |10 = Trim value calculation is based on average difference in 16 clocks of reference clock.
+     * |        |          |11 = Trim value calculation is based on average difference in 32 clocks of reference clock.
+     * |        |          |Note: For example, if LOOPSEL is set as 00, auto trim circuit will calculate trim value based on the average frequency difference in 4 clocks of reference clock.
+     * |[7:6]   |RETRYCNT  |Trim Value Update Limitation Count
+     * |        |          |This field defines that how many times the auto trim circuit will try to update the HIRC trim value before the frequency of HIRC locked.
+     * |        |          |Once the HIRC locked, the internal trim value update counter will be reset.
+     * |        |          |If the trim value update counter reached this limitation value and frequency of HIRC still doesn't lock, the auto trim operation will be disabled and FREQSEL will be cleared to 00.
+     * |        |          |00 = Trim retry count limitation is 64 loops.
+     * |        |          |01 = Trim retry count limitation is 128 loops.
+     * |        |          |10 = Trim retry count limitation is 256 loops.
+     * |        |          |11 = Trim retry count limitation is 512 loops.
+     * |[8]     |CESTOPEN  |Clock Error Stop Enable Bit
+     * |        |          |0 = The trim operation is keep going if clock is inaccuracy.
+     * |        |          |1 = The trim operation is stopped if clock is inaccuracy.
+     * |[9]     |BOUNDEN   |Boundary Enable
+     * |        |          |0 = Boundary function is disable.
+     * |        |          |1 = Boundary function is enable.
+     * |[10]    |REFCKSEL  |Reference Clock Selection
+     * |        |          |0 = HIRC trim reference from external 32.768 kHz crystal oscillator.
+     * |        |          |1 = HIRC trim reference from internal USB synchronous mode.
+     * |[20:16] |BOUNDARY  |Boundary Selection
+     * |        |          |Fill the boundary range from 0x1 to 0x1F, 0x0 is reserved.
+     * |        |          |Note: This field is effective only when the BOUNDEN(SYS_HIRCTRIMCTL[9]) is enable
+     * @var SYS_T::HIRCTRIMIEN
+     * Offset: 0xF4  HIRC Trim Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |TFALIEN   |Trim Failure Interrupt Enable Bit
+     * |        |          |This bit controls if an interrupt will be triggered while HIRC trim value update limitation count reached and HIRC frequency still not locked on target frequency set by FREQSEL(SYS_HIRCCTL[1:0]).
+     * |        |          |If this bit is high and TFAILIF(SYS_HIRCSTS[1]) is set during auto trim operation, an interrupt will be triggered to notify that HIRC trim value update limitation count was reached.
+     * |        |          |0 = Disable TFAILIF(SYS_HIRCSTS[1]) status to trigger an interrupt to CPU.
+     * |        |          |1 = Enable TFAILIF(SYS_HIRCSTS[1]) status to trigger an interrupt to CPU.
+     * |[2]     |CLKEIEN   |Clock Error Interrupt Enable Bit
+     * |        |          |This bit controls if CPU would get an interrupt while clock is inaccuracy during auto trim operation.
+     * |        |          |If this bit is set to1, and CLKERRIF(SYS_HIRCSTS[2]) is set during auto trim operation, an interrupt will be triggered to notify the clock frequency is inaccuracy.
+     * |        |          |0 = Disable CLKERRIF(SYS_HIRCSTS[2]) status to trigger an interrupt to CPU.
+     * |        |          |1 = Enable CLKERRIF(SYS_HIRCSTS[2]) status to trigger an interrupt to CPU.
+     * @var SYS_T::HIRCTRIMSTS
+     * Offset: 0xF8  HIRC Trim Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |FREQLOCK  |HIRC Frequency Lock Status
+     * |        |          |This bit indicates the HIRC frequency is locked.
+     * |        |          |This is a status bit and doesn't trigger any interrupt
+     * |        |          |Write 1 to clear this to 0
+     * |        |          |This bit will be set automatically, if the frequency is lock and the RC_TRIM is enabled.
+     * |        |          |0 = The internal high-speed oscillator frequency doesn't lock at 48 MHz yet.
+     * |        |          |1 = The internal high-speed oscillator frequency locked at 48 MHz.
+     * |[1]     |TFAILIF   |Trim Failure Interrupt Status
+     * |        |          |This bit indicates that HIRC trim value update limitation count reached and the HIRC clock frequency still doesn't be locked
+     * |        |          |Once this bit is set, the auto trim operation stopped and FREQSEL(SYS_HIRCCTL[1:0]) will be cleared to 00 by hardware automatically.
+     * |        |          |If this bit is set and TFAILIEN(SYS_HIRCIEN[1]) is high, an interrupt will be triggered to notify that HIRC trim value update limitation count was reached
+     * |        |          |Write 1 to clear this to 0.
+     * |        |          |0 = Trim value update limitation count does not reach.
+     * |        |          |1 = Trim value update limitation count reached and HIRC frequency still not locked.
+     * |[2]     |CLKERIF   |Clock Error Interrupt Status
+     * |        |          |When the frequency of 32.768 kHz external low speed crystal oscillator (LXT) or 48MHz internal high speed RC oscillator (HIRC) is shift larger to unreasonable value, this bit will be set and to be an indicate that clock frequency is inaccuracy
+     * |        |          |Once this bit is set to 1, the auto trim operation stopped and FREQSEL(SYS_HIRCCTL[1:0]) will be cleared to 00 by hardware automatically if CESTOPEN(SYS_HIRCCTL[8]) is set to 1.
+     * |        |          |If this bit is set and CLKEIEN(SYS_HIRCTIEN[2]) is high, an interrupt will be triggered to notify the clock frequency is inaccuracy
+     * |        |          |Write 1 to clear this to 0.
+     * |        |          |0 = Clock frequency is accuracy.
+     * |        |          |1 = Clock frequency is inaccuracy.
+     * |[3]     |OVBDIF    |Over Boundary Status
+     * |        |          |When the over boundary function is set, if there occurs the over boundary condition, this flag will be set.
+     * |        |          |0 = Over boundary condition did not occur.
+     * |        |          |1 = Over boundary condition occurred.
+     * |        |          |Note: Write 1 to clear this flag.
+     * @var SYS_T::REGLCTL
+     * Offset: 0x100  Register Lock Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |REGLCTL   |Register Lock Control Code (Write Only)
+     * |        |          |Some registers have write-protection function
+     * |        |          |Writing these registers have to disable the protected function by writing the sequence value "59h", "16h", "88h" to this field
+     * |        |          |After this sequence is completed, the REGLCTL bit will be set to 1 and write-protection registers can be normal write.
+     * |        |          |Register Lock Control Disable Index (Read Only)
+     * |        |          |0 = Write-protection Enabled for writing protected registers
+     * |        |          |Any write to the protected register is ignored.
+     * |        |          |1 = Write-protection Disabled for writing protected registers.
+     * |        |          |The Protected registers are:
+     * |        |          |NMIEN address 0x4000_0300
+     * |        |          |FMC_ISPCTL address 0x4000_C000 (Flash ISP Control register)
+     * |        |          |FMC_ISPTRG address 0x4000_C010 (ISP Trigger Control register)
+     * |        |          |FMC_ISPSTS address 0x4000_C040
+     * |        |          |WDT_CTL address 0x4004_0000
+     * |        |          |FMC_FTCTL address 0x4000_5018
+     * |        |          |FMC_ICPCMD address 0x4000_501C
+     * |        |          |EADC_TEST address 0x4004_3200
+     * |        |          |AHBMCTL address 0x40000400
+     * |        |          |SYS_IPRST0 address 0x4000_0008
+     * |        |          |SYS_BODCTL address 0x4000_0018
+     * |        |          |SYS_PORCTL address  0x4000_0024
+     * |        |          |SYS_SRAM_BISTCTL address 0x4000_00D0
+     * |        |          |SYS_PORCTL1 address 0x4000_01EC
+     * |        |          |CLK_PWRCTL address 0x4000_0200
+     * |        |          |CLK_APBCLK0[0] address 0x4000_0208
+     * |        |          |CLK_CLKSEL0 address 0x4000_0210
+     * |        |          |CLK_CLKSEL1[3:0] address 0x4000_0214
+     * |        |          |CLK_PLLCTL address 0x40000240
+     * |        |          |CLK_PMUCTL address 0x4000_0290
+     * |        |          |CLK_HXTFSEL address 0x4000_02B4
+     * |        |          |PWM_CTL0 address 0x4005_8000
+     * |        |          |PWM_CTL0 address 0x4005_9000
+     * |        |          |PWM_DTCTL0_1 address 0x4005_8070
+     * |        |          |PWM_DTCTL0_1 address 0x4005_9070
+     * |        |          |PWM_DTCTL2_3 address 0x4005_8074
+     * |        |          |PWM_DTCTL2_3 address 0x4005_9074
+     * |        |          |PWM_DTCTL4_5 address 0x4005_8078
+     * |        |          |PWM_DTCTL4_5 address 0x4005_9078
+     * |        |          |PWM_BRKCTL0_1 address 0x4005_80C8
+     * |        |          |PWM_BRKCTL0_1 address 0x4005_90C8
+     * |        |          |PWM_BRKCTL2_3 address0x4005_80CC
+     * |        |          |PWM_BRKCTL2_3 address0x4005_90CC
+     * |        |          |PWM_BRKCTL4_5 address0x4005_80D0
+     * |        |          |PWM_BRKCTL4_5 address0x4005_90D0
+     * |        |          |PWM_INTEN1 address0x4005_80E4
+     * |        |          |PWM_INTEN1 address0x4005_90E4
+     * |        |          |PWM_INTSTS1 address0x4005_80EC
+     * |        |          |PWM_INTSTS1 address0x4005_90EC
+     * @var SYS_T::MIRCTRIMCTL
+     * Offset: 0x104  MIRC Trim Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |FREQSEL   |Trim Frequency Selection
+     * |        |          |This field indicates the target frequency of medium speed RC oscillator (MIRC) auto trim.
+     * |        |          |During auto trim operation, if clock error detected with CESTOPEN is set to 1 or trim retry limitation count reached, this field will be cleared to 00 automatically.
+     * |        |          |00 = Disable HIRC auto trim function.
+     * |        |          |01 = Reserved.
+     * |        |          |10 = Enable HIRC auto trim function and trim MIRC to 4.032 MHz.
+     * |[5:4]   |LOOPSEL   |Trim Calculation Loop Selection
+     * |        |          |This field defines that trim value calculation is based on how many reference clocks.
+     * |        |          |00 = Reserved.
+     * |        |          |01 = Trim value calculation is based on average difference in 8 clocks of reference clock.
+     * |        |          |10 = Trim value calculation is based on average difference in 16 clocks of reference clock.
+     * |        |          |11 = Trim value calculation is based on average difference in 32 clocks of reference clock.
+     * |        |          |Note: For example, if LOOPSEL is set as 00, auto trim circuit will calculate trim value based on the average frequency difference in 4 clocks of reference clock.
+     * |[7:6]   |RETRYCNT  |Trim Value Update Limitation Count
+     * |        |          |This field defines that how many times the auto trim circuit will try to update the MIRC trim value before the frequency of MIRC locked.
+     * |        |          |Once the MIRC locked, the internal trim value update counter will be reset.
+     * |        |          |If the trim value update counter reached this limitation value and frequency of MIRC still doesn't lock, the auto trim operation will be disabled and FREQSEL will be cleared to 00.
+     * |        |          |00 = Trim retry count limitation is 64 loops.
+     * |        |          |01 = Trim retry count limitation is 128 loops.
+     * |        |          |10 = Trim retry count limitation is 256 loops.
+     * |        |          |11 = Trim retry count limitation is 512 loops.
+     * |[8]     |CESTOPEN  |Clock Error Stop Enable Bit
+     * |        |          |0 = The trim operation is keep going if clock is inaccuracy.
+     * |        |          |1 = The trim operation is stopped if clock is inaccuracy.
+     * |[9]     |BOUNDEN   |Boundary Enable
+     * |        |          |0 = Boundary function is disable.
+     * |        |          |1 = Boundary function is enable.
+     * |[10]    |REFCKSEL  |Reference Clock Selection
+     * |        |          |0 = MIRC trim reference from external 32.768 kHz crystal oscillator.
+     * |        |          |1 = MIRC trim reference from internal USB synchronous mode.
+     * |[20:16] |BOUNDARY  |Boundary Selection
+     * |        |          |Fill the boundary range from 0x1 to 0x1F, 0x0 is reserved.
+     * |        |          |Note: This field is effective only when the BOUNDEN(SYS_MIRCTRIMCTL[9]) is enable
+     * @var SYS_T::MIRCTRIMIEN
+     * Offset: 0x108  MIRC Trim Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |TFALIEN   |Trim Failure Interrupt Enable Bit
+     * |        |          |This bit controls if an interrupt will be triggered while MIRC trim value update limitation count reached and MIRC frequency still not locked on target frequency set by FREQSEL(SYS_ MIRCCTL[1:0]).
+     * |        |          |If this bit is high and TFAILIF(SYS_ MIRCSTS[1]) is set during auto trim operation, an interrupt will be triggered to notify that MIRC trim value update limitation count was reached.
+     * |        |          |0 = Disable TFAILIF(SYS_MIRCSTS[1]) status to trigger an interrupt to CPU.
+     * |        |          |1 = Enable TFAILIF(SYS_MIRCSTS[1]) status to trigger an interrupt to CPU.
+     * |[2]     |CLKEIEN   |Clock Error Interrupt Enable Bit
+     * |        |          |This bit controls if CPU would get an interrupt while clock is inaccuracy during auto trim operation.
+     * |        |          |If this bit is set to1, and CLKERRIF(SYS_MIRCSTS[2]) is set during auto trim operation, an interrupt will be triggered to notify the clock frequency is inaccuracy.
+     * |        |          |0 = Disable CLKERRIF(SYS_MIRCSTS[2]) status to trigger an interrupt to CPU.
+     * |        |          |1 = Enable CLKERRIF(SYS_MIRCSTS[2]) status to trigger an interrupt to CPU.
+     * @var SYS_T::MIRCTRIMSTS
+     * Offset: 0x10C  MIRC Trim Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |FREQLOCK  |MIRC Frequency Lock Status
+     * |        |          |This bit indicates the MIRC frequency is locked.
+     * |        |          |This is a status bit and doesn't trigger any interrupt
+     * |        |          |Write 1 to clear this to 0
+     * |        |          |This bit will be set automatically, if the frequency is lock and the RC_TRIM is enabled.
+     * |        |          |0 = The internal medium-speed oscillator frequency doesn't lock yet.
+     * |        |          |1 = The internal medium-speed oscillator frequency locked.
+     * |[1]     |TFAILIF   |Trim Failure Interrupt Status
+     * |        |          |This bit indicates that MIRC trim value update limitation count reached and the MIRC clock frequency still doesn't be locked
+     * |        |          |Once this bit is set, the auto trim operation stopped and FREQSEL(SYS_MIRCCTL[1:0]) will be cleared to 00 by hardware automatically.
+     * |        |          |If this bit is set and TFAILIEN(SYS_MIRCIEN[1]) is high, an interrupt will be triggered to notify that MIRC trim value update limitation count was reached
+     * |        |          |Write 1 to clear this to 0.
+     * |        |          |0 = Trim value update limitation count does not reach.
+     * |        |          |1 = Trim value update limitation count reached and MIRC frequency still not locked.
+     * |[2]     |CLKERIF   |Clock Error Interrupt Status
+     * |        |          |When the frequency of 32.768 kHz external low speed crystal oscillator (LXT) or internal medium speed RC oscillator (MIRC) is shift larger to unreasonable value, this bit will be set and to be an indicate that clock frequency is inaccuracy
+     * |        |          |Once this bit is set to 1, the auto trim operation stopped and FREQSEL(SYS_MIRCCTL[1:0]) will be cleared to 00 by hardware automatically if CESTOPEN(SYS_MIRCCTL[8]) is set to 1.
+     * |        |          |If this bit is set and CLKEIEN(SYS_MIRCIEN[2]) is high, an interrupt will be triggered to notify the clock frequency is inaccuracy
+     * |        |          |Write 1 to clear this to 0.
+     * |        |          |0 = Clock frequency is accuracy.
+     * |        |          |1 = Clock frequency is inaccuracy.
+     * |[3]     |OVBDIF    |Over Boundary Status
+     * |        |          |When the over boundary function is set, if there occurs the over boundary condition, this flag will be set.
+     * |        |          |0 = Over boundary condition did not occur.
+     * |        |          |1 = Over boundary condition occurred.
+     * |        |          |Note: Write 1 to clear this flag.
+     * @var SYS_T::RTCLVRIEN
+     * Offset: 0x144  RTC LVR interrupt control register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |IE        |RTC LVR interrupt enable(Write Protect)
+     * |        |          |0 : disable (default)
+     * |        |          |1: enable
+     * |        |          |Note: These bits are write protected. Refer to the SYS_REGLCTL register.
+     * @var SYS_T::RTCLVRSTS
+     * Offset: 0x148  RTC LVR interrupt status register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |IF        |RTC LVR interrupt flag(Write Protect)
+     * |        |          |When a positive edge of RTCLVR is detected, this bit will be set to 1 and will be cleared when a 1 is set to this bit.
+     * |        |          |Note: These bits are write protected. Refer to the SYS_REGLCTL register.
+     * |[8]     |RTCLVR    |RTCLVR value (read only)
+     * @var SYS_T::PORCTL1
+     * Offset: 0x1EC  Power-On-reset Controller Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |POROFF    |Power-on Reset Enable Bit (Write Protect)
+     * |        |          |After powered on, User can turn off internal analog POR circuit to save power by writing 0x5AA5 to this field.
+     * |        |          |The analog POR circuit will be active again when this field is set to another value or chip is reset by other reset source, including:
+     * |        |          |nRESET, Watchdog, LVR reset, BOD reset, ICE reset command and the software-chip reset function.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var SYS_T::PLCTL
+     * Offset: 0x1F8  Power Level Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |PLSEL     |Power Level Select(Write Protect)
+     * |        |          |00 = Set to power level 0 (PL0)
+     * |        |          |01 = Reserved
+     * |        |          |10 = Reserved
+     * |        |          |11 = Set to power level 3 (PL3)
+     * |        |          |Note : When at PL3, HCLK has to be lower than 4Mhz
+     * @var SYS_T::PLSTS
+     * Offset: 0x1FC  Power Level Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PLCBUSY   |Power Level Change Busy Bit (Read Only)
+     * |        |          |This bit is set by hardware when power level is changing . After power level change is completed, this bit will be cleared automatically by hardware.
+     * |        |          |0 = Power level change is completed.
+     * |        |          |1 = Power level change is ongoing.
+     * |[9:8]   |CURPL     |Current Power Level (Read Only)
+     * |        |          |This bit field reflect the current power level.
+     * |        |          |00 = Current power level is PL0.
+     * |        |          |01 = Reserved.
+     * |        |          |10 = Reserved.
+     * |        |          |11 = Current power level is PL3.
+     * |        |          |Others = Reserved.
+     */
+    __I  uint32_t PDID;                  /*!< [0x0000] Part Device Identification Number Register                       */
+    __IO uint32_t RSTSTS;                /*!< [0x0004] System Reset Status Register                                     */
+    __IO uint32_t IPRST0;                /*!< [0x0008] Peripheral  Reset Control Register 0                             */
+    __IO uint32_t IPRST1;                /*!< [0x000c] Peripheral Reset Control Register 1                              */
+    __IO uint32_t IPRST2;                /*!< [0x0010] Peripheral Reset Control Register 2                              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t BODCTL;                /*!< [0x0018] Brown-out Detector Control Register                              */
+    __IO uint32_t IVSCTL;                /*!< [0x001c] Internal Voltage Source Control Register                         */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PORCTL0;               /*!< [0x0024] Power-On-reset Controller Register 0                             */
+    __IO uint32_t VREFCTL;               /*!< [0x0028] VREF Control Register                                            */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t GPA_MFPL;              /*!< [0x0030] GPIOA Low Byte Multiple Function Control Register                */
+    __IO uint32_t GPA_MFPH;              /*!< [0x0034] GPIOA High Byte Multiple Function Control Register               */
+    __IO uint32_t GPB_MFPL;              /*!< [0x0038] GPIOB Low Byte Multiple Function Control Register                */
+    __IO uint32_t GPB_MFPH;              /*!< [0x003c] GPIOB High Byte Multiple Function Control Register               */
+    __IO uint32_t GPC_MFPL;              /*!< [0x0040] GPIOC Low Byte Multiple Function Control Register                */
+    __IO uint32_t GPC_MFPH;              /*!< [0x0044] GPIOC High Byte Multiple Function Control Register               */
+    __IO uint32_t GPD_MFPL;              /*!< [0x0048] GPIOD Low Byte Multiple Function Control Register                */
+    __IO uint32_t GPD_MFPH;              /*!< [0x004c] GPIOD High Byte Multiple Function Control Register               */
+    __IO uint32_t GPE_MFPL;              /*!< [0x0050] GPIOE Low Byte Multiple Function Control Register                */
+    __IO uint32_t GPE_MFPH;              /*!< [0x0054] GPIOE High Byte Multiple Function Control Register               */
+    __IO uint32_t GPF_MFPL;              /*!< [0x0058] GPIOF Low Byte Multiple Function Control Register                */
+    __IO uint32_t GPF_MFPH;              /*!< [0x005c] GPIOF High Byte Multiple Function Control Register               */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[8];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t GPA_MFOS;              /*!< [0x0080] GPIOA Multiple Function Output Select Register                   */
+    __IO uint32_t GPB_MFOS;              /*!< [0x0084] GPIOB Multiple Function Output Select Register                   */
+    __IO uint32_t GPC_MFOS;              /*!< [0x0088] GPIOC Multiple Function Output Select Register                   */
+    __IO uint32_t GPD_MFOS;              /*!< [0x008c] GPIOD Multiple Function Output Select Register                   */
+    __IO uint32_t GPE_MFOS;              /*!< [0x0090] GPIOE Multiple Function Output Select Register                   */
+    __IO uint32_t GPF_MFOS;              /*!< [0x0094] GPIOF Multiple Function Output Select Register                   */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE4[10];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t MODCTL;                /*!< [0x00c0] Modulation Control Register                                      */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE5[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t SRAM_BISTCTL;          /*!< [0x00d0] System SRAM BIST Test Control Register                           */
+    __I  uint32_t SRAM_BISTSTS;          /*!< [0x00d4] System SRAM BIST Test Status Register                            */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE6[6];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t HIRCTRIMCTL;           /*!< [0x00f0] HIRC Trim Control Register                                       */
+    __IO uint32_t HIRCTRIMIEN;           /*!< [0x00f4] HIRC Trim Interrupt Enable Register                              */
+    __IO uint32_t HIRCTRIMSTS;           /*!< [0x00f8] HIRC Trim Interrupt Status Register                              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE7[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __O  uint32_t REGLCTL;               /*!< [0x0100] Register Lock Control Register                                   */
+    __IO uint32_t MIRCTRIMCTL;           /*!< [0x0104] MIRC Trim Control Register                                       */
+    __IO uint32_t MIRCTRIMIEN;           /*!< [0x0108] MIRC Trim Interrupt Enable Register                              */
+    __IO uint32_t MIRCTRIMSTS;           /*!< [0x010c] MIRC Trim Interrupt Status Register                              */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE8[13];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t RTCLVRIEN;             /*!< [0x0144] RTC LVR interrupt control register                               */
+    __IO uint32_t RTCLVRSTS;             /*!< [0x0148] RTC LVR interrupt status register                                */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE9[40];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PORCTL1;               /*!< [0x01ec] Power-On-reset Controller Register 1                             */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE10[2];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PLCTL;                 /*!< [0x01F8] Power Level Control Register                                     */
+    __I  uint32_t PLSTS;                 /*!< [0x01Fc] Power Level Status Register                                      */
+} SYS_T;
+
+/**
+    @addtogroup SYS_CONST SYS Bit Field Definition
+    Constant Definitions for SYS Controller
+@{ */
+
+#define SYS_PDID_PDID_Pos                (0)                                               /*!< SYS_T::PDID: PDID Position             */
+#define SYS_PDID_PDID_Msk                (0xfffffffful << SYS_PDID_PDID_Pos)               /*!< SYS_T::PDID: PDID Mask                 */
+
+#define SYS_RSTSTS_PORF_Pos              (0)                                               /*!< SYS_T::RSTSTS: PORF Position           */
+#define SYS_RSTSTS_PORF_Msk              (0x1ul << SYS_RSTSTS_PORF_Pos)                    /*!< SYS_T::RSTSTS: PORF Mask               */
+
+#define SYS_RSTSTS_PINRF_Pos             (1)                                               /*!< SYS_T::RSTSTS: PINRF Position          */
+#define SYS_RSTSTS_PINRF_Msk             (0x1ul << SYS_RSTSTS_PINRF_Pos)                   /*!< SYS_T::RSTSTS: PINRF Mask              */
+
+#define SYS_RSTSTS_WDTRF_Pos             (2)                                               /*!< SYS_T::RSTSTS: WDTRF Position          */
+#define SYS_RSTSTS_WDTRF_Msk             (0x1ul << SYS_RSTSTS_WDTRF_Pos)                   /*!< SYS_T::RSTSTS: WDTRF Mask              */
+
+#define SYS_RSTSTS_LVRF_Pos              (3)                                               /*!< SYS_T::RSTSTS: LVRF Position           */
+#define SYS_RSTSTS_LVRF_Msk              (0x1ul << SYS_RSTSTS_LVRF_Pos)                    /*!< SYS_T::RSTSTS: LVRF Mask               */
+
+#define SYS_RSTSTS_BODRF_Pos             (4)                                               /*!< SYS_T::RSTSTS: BODRF Position          */
+#define SYS_RSTSTS_BODRF_Msk             (0x1ul << SYS_RSTSTS_BODRF_Pos)                   /*!< SYS_T::RSTSTS: BODRF Mask              */
+
+#define SYS_RSTSTS_SYSRF_Pos             (5)                                               /*!< SYS_T::RSTSTS: SYSRF Position          */
+#define SYS_RSTSTS_SYSRF_Msk             (0x1ul << SYS_RSTSTS_SYSRF_Pos)                   /*!< SYS_T::RSTSTS: SYSRF Mask              */
+
+#define SYS_RSTSTS_PMURF_Pos             (6)                                               /*!< SYS_T::RSTSTS: PMURF Position          */
+#define SYS_RSTSTS_PMURF_Msk             (0x1ul << SYS_RSTSTS_PMURF_Pos)                   /*!< SYS_T::RSTSTS: PMURF Mask              */
+
+#define SYS_RSTSTS_CPURF_Pos             (7)                                               /*!< SYS_T::RSTSTS: CPURF Position          */
+#define SYS_RSTSTS_CPURF_Msk             (0x1ul << SYS_RSTSTS_CPURF_Pos)                   /*!< SYS_T::RSTSTS: CPURF Mask              */
+
+#define SYS_RSTSTS_CPULKRF_Pos           (8)                                               /*!< SYS_T::RSTSTS: CPULKRF Position        */
+#define SYS_RSTSTS_CPULKRF_Msk           (0x1ul << SYS_RSTSTS_CPULKRF_Pos)                 /*!< SYS_T::RSTSTS: CPULKRF Mask            */
+
+#define SYS_RSTSTS_VBATLVRF_Pos          (9)                                               /*!< SYS_T::RSTSTS: VBATLVRF Position        */
+#define SYS_RSTSTS_VBATLVRF_Msk          (0x1ul << SYS_RSTSTS_VBATLVRF_Pos)                /*!< SYS_T::RSTSTS: VBATLVRF Mask            */
+
+#define SYS_IPRST0_CHIPRST_Pos           (0)                                               /*!< SYS_T::IPRST0: CHIPRST Position        */
+#define SYS_IPRST0_CHIPRST_Msk           (0x1ul << SYS_IPRST0_CHIPRST_Pos)                 /*!< SYS_T::IPRST0: CHIPRST Mask            */
+
+#define SYS_IPRST0_CPURST_Pos            (1)                                               /*!< SYS_T::IPRST0: CPURST Position         */
+#define SYS_IPRST0_CPURST_Msk            (0x1ul << SYS_IPRST0_CPURST_Pos)                  /*!< SYS_T::IPRST0: CPURST Mask             */
+
+#define SYS_IPRST0_PDMARST_Pos           (2)                                               /*!< SYS_T::IPRST0: PDMARST Position        */
+#define SYS_IPRST0_PDMARST_Msk           (0x1ul << SYS_IPRST0_PDMARST_Pos)                 /*!< SYS_T::IPRST0: PDMARST Mask            */
+
+#define SYS_IPRST0_EBIRST_Pos            (3)                                               /*!< SYS_T::IPRST0: EBIRST Position         */
+#define SYS_IPRST0_EBIRST_Msk            (0x1ul << SYS_IPRST0_EBIRST_Pos)                  /*!< SYS_T::IPRST0: EBIRST Mask             */
+
+#define SYS_IPRST0_CRCRST_Pos            (7)                                               /*!< SYS_T::IPRST0: CRCRST Position         */
+#define SYS_IPRST0_CRCRST_Msk            (0x1ul << SYS_IPRST0_CRCRST_Pos)                  /*!< SYS_T::IPRST0: CRCRST Mask             */
+
+#define SYS_IPRST0_CRYPTRST_Pos          (12)                                              /*!< SYS_T::IPRST0: CRYPTRST Position       */
+#define SYS_IPRST0_CRYPTRST_Msk          (0x1ul << SYS_IPRST0_CRYPTRST_Pos)                /*!< SYS_T::IPRST0: CRYPTRST Mask           */
+
+#define SYS_IPRST1_GPIORST_Pos           (1)                                               /*!< SYS_T::IPRST1: GPIORST Position        */
+#define SYS_IPRST1_GPIORST_Msk           (0x1ul << SYS_IPRST1_GPIORST_Pos)                 /*!< SYS_T::IPRST1: GPIORST Mask            */
+
+#define SYS_IPRST1_TMR0RST_Pos           (2)                                               /*!< SYS_T::IPRST1: TMR0RST Position        */
+#define SYS_IPRST1_TMR0RST_Msk           (0x1ul << SYS_IPRST1_TMR0RST_Pos)                 /*!< SYS_T::IPRST1: TMR0RST Mask            */
+
+#define SYS_IPRST1_TMR1RST_Pos           (3)                                               /*!< SYS_T::IPRST1: TMR1RST Position        */
+#define SYS_IPRST1_TMR1RST_Msk           (0x1ul << SYS_IPRST1_TMR1RST_Pos)                 /*!< SYS_T::IPRST1: TMR1RST Mask            */
+
+#define SYS_IPRST1_TMR2RST_Pos           (4)                                               /*!< SYS_T::IPRST1: TMR2RST Position        */
+#define SYS_IPRST1_TMR2RST_Msk           (0x1ul << SYS_IPRST1_TMR2RST_Pos)                 /*!< SYS_T::IPRST1: TMR2RST Mask            */
+
+#define SYS_IPRST1_TMR3RST_Pos           (5)                                               /*!< SYS_T::IPRST1: TMR3RST Position        */
+#define SYS_IPRST1_TMR3RST_Msk           (0x1ul << SYS_IPRST1_TMR3RST_Pos)                 /*!< SYS_T::IPRST1: TMR3RST Mask            */
+
+#define SYS_IPRST1_ACMP01RST_Pos         (7)                                               /*!< SYS_T::IPRST1: ACMP01RST Position      */
+#define SYS_IPRST1_ACMP01RST_Msk         (0x1ul << SYS_IPRST1_ACMP01RST_Pos)               /*!< SYS_T::IPRST1: ACMP01RST Mask          */
+
+#define SYS_IPRST1_I2C0RST_Pos           (8)                                               /*!< SYS_T::IPRST1: I2C0RST Position        */
+#define SYS_IPRST1_I2C0RST_Msk           (0x1ul << SYS_IPRST1_I2C0RST_Pos)                 /*!< SYS_T::IPRST1: I2C0RST Mask            */
+
+#define SYS_IPRST1_I2C1RST_Pos           (9)                                               /*!< SYS_T::IPRST1: I2C1RST Position        */
+#define SYS_IPRST1_I2C1RST_Msk           (0x1ul << SYS_IPRST1_I2C1RST_Pos)                 /*!< SYS_T::IPRST1: I2C1RST Mask            */
+
+#define SYS_IPRST1_QSPI0RST_Pos          (12)                                              /*!< SYS_T::IPRST1: QSPI0RST Position       */
+#define SYS_IPRST1_QSPI0RST_Msk          (0x1ul << SYS_IPRST1_QSPI0RST_Pos)                /*!< SYS_T::IPRST1: QSPI0RST Mask           */
+
+#define SYS_IPRST1_SPI0RST_Pos           (13)                                              /*!< SYS_T::IPRST1: SPI0RST Position        */
+#define SYS_IPRST1_SPI0RST_Msk           (0x1ul << SYS_IPRST1_SPI0RST_Pos)                 /*!< SYS_T::IPRST1: SPI0RST Mask            */
+
+#define SYS_IPRST1_SPI1RST_Pos           (14)                                              /*!< SYS_T::IPRST1: SPI1RST Position        */
+#define SYS_IPRST1_SPI1RST_Msk           (0x1ul << SYS_IPRST1_SPI1RST_Pos)                 /*!< SYS_T::IPRST1: SPI1RST Mask            */
+
+#define SYS_IPRST1_UART0RST_Pos          (16)                                              /*!< SYS_T::IPRST1: UART0RST Position       */
+#define SYS_IPRST1_UART0RST_Msk          (0x1ul << SYS_IPRST1_UART0RST_Pos)                /*!< SYS_T::IPRST1: UART0RST Mask           */
+
+#define SYS_IPRST1_UART1RST_Pos          (17)                                              /*!< SYS_T::IPRST1: UART1RST Position       */
+#define SYS_IPRST1_UART1RST_Msk          (0x1ul << SYS_IPRST1_UART1RST_Pos)                /*!< SYS_T::IPRST1: UART1RST Mask           */
+
+#define SYS_IPRST1_UART2RST_Pos          (18)                                              /*!< SYS_T::IPRST1: UART2RST Position       */
+#define SYS_IPRST1_UART2RST_Msk          (0x1ul << SYS_IPRST1_UART2RST_Pos)                /*!< SYS_T::IPRST1: UART2RST Mask           */
+
+#define SYS_IPRST1_UART3RST_Pos          (19)                                              /*!< SYS_T::IPRST1: UART3RST Position       */
+#define SYS_IPRST1_UART3RST_Msk          (0x1ul << SYS_IPRST1_UART3RST_Pos)                /*!< SYS_T::IPRST1: UART3RST Mask           */
+
+#define SYS_IPRST1_USBDRST_Pos           (27)                                              /*!< SYS_T::IPRST1: USBDRST Position        */
+#define SYS_IPRST1_USBDRST_Msk           (0x1ul << SYS_IPRST1_USBDRST_Pos)                 /*!< SYS_T::IPRST1: USBDRST Mask            */
+
+#define SYS_IPRST1_EADCRST_Pos           (28)                                              /*!< SYS_T::IPRST1: EADCRST Position        */
+#define SYS_IPRST1_EADCRST_Msk           (0x1ul << SYS_IPRST1_EADCRST_Pos)                 /*!< SYS_T::IPRST1: EADCRST Mask            */
+
+#define SYS_IPRST2_SC0RST_Pos            (0)                                               /*!< SYS_T::IPRST2: SC0RST Position         */
+#define SYS_IPRST2_SC0RST_Msk            (0x1ul << SYS_IPRST2_SC0RST_Pos)                  /*!< SYS_T::IPRST2: SC0RST Mask             */
+
+#define SYS_IPRST2_USCI0RST_Pos          (8)                                               /*!< SYS_T::IPRST2: USCI0RST Position       */
+#define SYS_IPRST2_USCI0RST_Msk          (0x1ul << SYS_IPRST2_USCI0RST_Pos)                /*!< SYS_T::IPRST2: USCI0RST Mask           */
+
+#define SYS_IPRST2_USCI1RST_Pos          (9)                                               /*!< SYS_T::IPRST2: USCI1RST Position       */
+#define SYS_IPRST2_USCI1RST_Msk          (0x1ul << SYS_IPRST2_USCI1RST_Pos)                /*!< SYS_T::IPRST2: USCI1RST Mask           */
+
+#define SYS_IPRST2_USCI2RST_Pos          (10)                                              /*!< SYS_T::IPRST2: USCI2RST Position       */
+#define SYS_IPRST2_USCI2RST_Msk          (0x1ul << SYS_IPRST2_USCI2RST_Pos)                /*!< SYS_T::IPRST2: USCI2RST Mask           */
+
+#define SYS_IPRST2_DACRST_Pos            (12)                                              /*!< SYS_T::IPRST2: DACRST Position         */
+#define SYS_IPRST2_DACRST_Msk            (0x1ul << SYS_IPRST2_DACRST_Pos)                  /*!< SYS_T::IPRST2: DACRST Mask             */
+
+#define SYS_IPRST2_LCDRST_Pos            (14)                                              /*!< SYS_T::IPRST2: LCDRST Position         */
+#define SYS_IPRST2_LCDRST_Msk            (0x1ul << SYS_IPRST2_LCDRST_Pos)                  /*!< SYS_T::IPRST2: LCDRST Mask             */
+
+#define SYS_IPRST2_TKRST_Pos             (15)                                              /*!< SYS_T::IPRST2: TKRST Position          */
+#define SYS_IPRST2_TKRST_Msk             (0x1ul << SYS_IPRST2_TKRST_Pos)                   /*!< SYS_T::IPRST2: TKRST Mask              */
+
+#define SYS_IPRST2_PWM0RST_Pos           (16)                                              /*!< SYS_T::IPRST2: PWM0RST Position        */
+#define SYS_IPRST2_PWM0RST_Msk           (0x1ul << SYS_IPRST2_PWM0RST_Pos)                 /*!< SYS_T::IPRST2: PWM0RST Mask            */
+
+#define SYS_IPRST2_PWM1RST_Pos           (17)                                              /*!< SYS_T::IPRST2: PWM1RST Position        */
+#define SYS_IPRST2_PWM1RST_Msk           (0x1ul << SYS_IPRST2_PWM1RST_Pos)                 /*!< SYS_T::IPRST2: PWM1RST Mask            */
+
+#define SYS_IPRST2_BPWM0RST_Pos          (18)                                              /*!< SYS_T::IPRST2: BPWM0RST Position       */
+#define SYS_IPRST2_BPWM0RST_Msk          (0x1ul << SYS_IPRST2_BPWM0RST_Pos)                /*!< SYS_T::IPRST2: BPWM0RST Mask           */
+
+#define SYS_IPRST2_BPWM1RST_Pos          (19)                                              /*!< SYS_T::IPRST2: BPWM1RST Position       */
+#define SYS_IPRST2_BPWM1RST_Msk          (0x1ul << SYS_IPRST2_BPWM1RST_Pos)                /*!< SYS_T::IPRST2: BPWM1RST Mask           */
+
+#define SYS_IPRST2_OPARST_Pos            (30)                                              /*!< SYS_T::IPRST2: OPARST Position         */
+#define SYS_IPRST2_OPARST_Msk            (0x1ul << SYS_IPRST2_OPARST_Pos)                  /*!< SYS_T::IPRST2: OPARST Mask             */
+
+#define SYS_IPRST2_PSIORST_Pos           (31)                                              /*!< SYS_T::IPRST2: PSIORST Position        */
+#define SYS_IPRST2_PSIORST_Msk           (0x1ul << SYS_IPRST2_PSIORST_Pos)                 /*!< SYS_T::IPRST2: PSIORST Mask            */
+
+#define SYS_BODCTL_BODEN_Pos             (0)                                               /*!< SYS_T::BODCTL: BODEN Position          */
+#define SYS_BODCTL_BODEN_Msk             (0x1ul << SYS_BODCTL_BODEN_Pos)                   /*!< SYS_T::BODCTL: BODEN Mask              */
+
+#define SYS_BODCTL_BODRSTEN_Pos          (3)                                               /*!< SYS_T::BODCTL: BODRSTEN Position       */
+#define SYS_BODCTL_BODRSTEN_Msk          (0x1ul << SYS_BODCTL_BODRSTEN_Pos)                /*!< SYS_T::BODCTL: BODRSTEN Mask           */
+
+#define SYS_BODCTL_BODIF_Pos             (4)                                               /*!< SYS_T::BODCTL: BODIF Position          */
+#define SYS_BODCTL_BODIF_Msk             (0x1ul << SYS_BODCTL_BODIF_Pos)                   /*!< SYS_T::BODCTL: BODIF Mask              */
+
+#define SYS_BODCTL_BODLPM_Pos            (5)                                               /*!< SYS_T::BODCTL: BODLPM Position         */
+#define SYS_BODCTL_BODLPM_Msk            (0x1ul << SYS_BODCTL_BODLPM_Pos)                  /*!< SYS_T::BODCTL: BODLPM Mask             */
+
+#define SYS_BODCTL_BODOUT_Pos            (6)                                               /*!< SYS_T::BODCTL: BODOUT Position         */
+#define SYS_BODCTL_BODOUT_Msk            (0x1ul << SYS_BODCTL_BODOUT_Pos)                  /*!< SYS_T::BODCTL: BODOUT Mask             */
+
+#define SYS_BODCTL_LVREN_Pos             (7)                                               /*!< SYS_T::BODCTL: LVREN Position          */
+#define SYS_BODCTL_LVREN_Msk             (0x1ul << SYS_BODCTL_LVREN_Pos)                   /*!< SYS_T::BODCTL: LVREN Mask              */
+
+#define SYS_BODCTL_BODDGSEL_Pos          (8)                                               /*!< SYS_T::BODCTL: BODDGSEL Position       */
+#define SYS_BODCTL_BODDGSEL_Msk          (0x7ul << SYS_BODCTL_BODDGSEL_Pos)                /*!< SYS_T::BODCTL: BODDGSEL Mask           */
+
+#define SYS_BODCTL_LVRDGSEL_Pos          (12)                                              /*!< SYS_T::BODCTL: LVRDGSEL Position       */
+#define SYS_BODCTL_LVRDGSEL_Msk          (0x7ul << SYS_BODCTL_LVRDGSEL_Pos)                /*!< SYS_T::BODCTL: LVRDGSEL Mask           */
+
+#define SYS_BODCTL_BODVL_Pos             (16)                                              /*!< SYS_T::BODCTL: BODVL Position          */
+#define SYS_BODCTL_BODVL_Msk             (0x7ul << SYS_BODCTL_BODVL_Pos)                   /*!< SYS_T::BODCTL: BODVL Mask              */
+
+#define SYS_IVSCTL_VTEMPEN_Pos           (0)                                               /*!< SYS_T::IVSCTL: VTEMPEN Position        */
+#define SYS_IVSCTL_VTEMPEN_Msk           (0x1ul << SYS_IVSCTL_VTEMPEN_Pos)                 /*!< SYS_T::IVSCTL: VTEMPEN Mask            */
+
+#define SYS_IVSCTL_VBATUGEN_Pos          (1)                                               /*!< SYS_T::IVSCTL: VBATUGEN Position       */
+#define SYS_IVSCTL_VBATUGEN_Msk          (0x1ul << SYS_IVSCTL_VBATUGEN_Pos)                /*!< SYS_T::IVSCTL: VBATUGEN Mask           */
+
+#define SYS_PORCTL0_PORMASK_Pos          (0)                                               /*!< SYS_T::PORCTL0: PORMASK Position         */
+#define SYS_PORCTL0_PORMASK_Msk          (0xfffful << SYS_PORCTL0_PORMASK_Pos)             /*!< SYS_T::PORCTL0: PORMASK Mask             */
+
+#define SYS_VREFCTL_IVRS_Pos             (0)                                               /*!< SYS_T::VREFCTL: IVRS Position          */
+#define SYS_VREFCTL_IVRS_Msk             (0x7ul << SYS_VREFCTL_IVRS_Pos)                   /*!< SYS_T::VREFCTL: IVRS Mask              */
+
+#define SYS_VREFCTL_IVREN_Pos            (3)                                               /*!< SYS_T::VREFCTL: IVREN Position         */
+#define SYS_VREFCTL_IVREN_Msk            (0x1ul << SYS_VREFCTL_IVREN_Pos)                  /*!< SYS_T::VREFCTL: IVREN Mask             */
+
+#define SYS_VREFCTL_PRELOAD_Pos          (10)                                              /*!< SYS_T::VREFCTL: PRELOAD Position       */
+#define SYS_VREFCTL_PRELOAD_Msk          (0x1ul << SYS_VREFCTL_PRELOAD_Pos)                /*!< SYS_T::VREFCTL: PRELOAD Mask           */
+
+#define SYS_GPA_MFPL_PA0MFP_Pos          (0)                                               /*!< SYS_T::GPA_MFPL: PA0MFP Position       */
+#define SYS_GPA_MFPL_PA0MFP_Msk          (0xful << SYS_GPA_MFPL_PA0MFP_Pos)                /*!< SYS_T::GPA_MFPL: PA0MFP Mask           */
+
+#define SYS_GPA_MFPL_PA1MFP_Pos          (4)                                               /*!< SYS_T::GPA_MFPL: PA1MFP Position       */
+#define SYS_GPA_MFPL_PA1MFP_Msk          (0xful << SYS_GPA_MFPL_PA1MFP_Pos)                /*!< SYS_T::GPA_MFPL: PA1MFP Mask           */
+
+#define SYS_GPA_MFPL_PA2MFP_Pos          (8)                                               /*!< SYS_T::GPA_MFPL: PA2MFP Position       */
+#define SYS_GPA_MFPL_PA2MFP_Msk          (0xful << SYS_GPA_MFPL_PA2MFP_Pos)                /*!< SYS_T::GPA_MFPL: PA2MFP Mask           */
+
+#define SYS_GPA_MFPL_PA3MFP_Pos          (12)                                              /*!< SYS_T::GPA_MFPL: PA3MFP Position       */
+#define SYS_GPA_MFPL_PA3MFP_Msk          (0xful << SYS_GPA_MFPL_PA3MFP_Pos)                /*!< SYS_T::GPA_MFPL: PA3MFP Mask           */
+
+#define SYS_GPA_MFPL_PA4MFP_Pos          (16)                                              /*!< SYS_T::GPA_MFPL: PA4MFP Position       */
+#define SYS_GPA_MFPL_PA4MFP_Msk          (0xful << SYS_GPA_MFPL_PA4MFP_Pos)                /*!< SYS_T::GPA_MFPL: PA4MFP Mask           */
+
+#define SYS_GPA_MFPL_PA5MFP_Pos          (20)                                              /*!< SYS_T::GPA_MFPL: PA5MFP Position       */
+#define SYS_GPA_MFPL_PA5MFP_Msk          (0xful << SYS_GPA_MFPL_PA5MFP_Pos)                /*!< SYS_T::GPA_MFPL: PA5MFP Mask           */
+
+#define SYS_GPA_MFPL_PA6MFP_Pos          (24)                                              /*!< SYS_T::GPA_MFPL: PA6MFP Position       */
+#define SYS_GPA_MFPL_PA6MFP_Msk          (0xful << SYS_GPA_MFPL_PA6MFP_Pos)                /*!< SYS_T::GPA_MFPL: PA6MFP Mask           */
+
+#define SYS_GPA_MFPL_PA7MFP_Pos          (28)                                              /*!< SYS_T::GPA_MFPL: PA7MFP Position       */
+#define SYS_GPA_MFPL_PA7MFP_Msk          (0xful << SYS_GPA_MFPL_PA7MFP_Pos)                /*!< SYS_T::GPA_MFPL: PA7MFP Mask           */
+
+#define SYS_GPA_MFPH_PA8MFP_Pos          (0)                                               /*!< SYS_T::GPA_MFPH: PA8MFP Position       */
+#define SYS_GPA_MFPH_PA8MFP_Msk          (0xful << SYS_GPA_MFPH_PA8MFP_Pos)                /*!< SYS_T::GPA_MFPH: PA8MFP Mask           */
+
+#define SYS_GPA_MFPH_PA9MFP_Pos          (4)                                               /*!< SYS_T::GPA_MFPH: PA9MFP Position       */
+#define SYS_GPA_MFPH_PA9MFP_Msk          (0xful << SYS_GPA_MFPH_PA9MFP_Pos)                /*!< SYS_T::GPA_MFPH: PA9MFP Mask           */
+
+#define SYS_GPA_MFPH_PA10MFP_Pos         (8)                                               /*!< SYS_T::GPA_MFPH: PA10MFP Position      */
+#define SYS_GPA_MFPH_PA10MFP_Msk         (0xful << SYS_GPA_MFPH_PA10MFP_Pos)               /*!< SYS_T::GPA_MFPH: PA10MFP Mask          */
+
+#define SYS_GPA_MFPH_PA11MFP_Pos         (12)                                              /*!< SYS_T::GPA_MFPH: PA11MFP Position      */
+#define SYS_GPA_MFPH_PA11MFP_Msk         (0xful << SYS_GPA_MFPH_PA11MFP_Pos)               /*!< SYS_T::GPA_MFPH: PA11MFP Mask          */
+
+#define SYS_GPA_MFPH_PA12MFP_Pos         (16)                                              /*!< SYS_T::GPA_MFPH: PA12MFP Position      */
+#define SYS_GPA_MFPH_PA12MFP_Msk         (0xful << SYS_GPA_MFPH_PA12MFP_Pos)               /*!< SYS_T::GPA_MFPH: PA12MFP Mask          */
+
+#define SYS_GPA_MFPH_PA13MFP_Pos         (20)                                              /*!< SYS_T::GPA_MFPH: PA13MFP Position      */
+#define SYS_GPA_MFPH_PA13MFP_Msk         (0xful << SYS_GPA_MFPH_PA13MFP_Pos)               /*!< SYS_T::GPA_MFPH: PA13MFP Mask          */
+
+#define SYS_GPA_MFPH_PA14MFP_Pos         (24)                                              /*!< SYS_T::GPA_MFPH: PA14MFP Position      */
+#define SYS_GPA_MFPH_PA14MFP_Msk         (0xful << SYS_GPA_MFPH_PA14MFP_Pos)               /*!< SYS_T::GPA_MFPH: PA14MFP Mask          */
+
+#define SYS_GPA_MFPH_PA15MFP_Pos         (28)                                              /*!< SYS_T::GPA_MFPH: PA15MFP Position      */
+#define SYS_GPA_MFPH_PA15MFP_Msk         (0xful << SYS_GPA_MFPH_PA15MFP_Pos)               /*!< SYS_T::GPA_MFPH: PA15MFP Mask          */
+
+#define SYS_GPB_MFPL_PB0MFP_Pos          (0)                                               /*!< SYS_T::GPB_MFPL: PB0MFP Position       */
+#define SYS_GPB_MFPL_PB0MFP_Msk          (0xful << SYS_GPB_MFPL_PB0MFP_Pos)                /*!< SYS_T::GPB_MFPL: PB0MFP Mask           */
+
+#define SYS_GPB_MFPL_PB1MFP_Pos          (4)                                               /*!< SYS_T::GPB_MFPL: PB1MFP Position       */
+#define SYS_GPB_MFPL_PB1MFP_Msk          (0xful << SYS_GPB_MFPL_PB1MFP_Pos)                /*!< SYS_T::GPB_MFPL: PB1MFP Mask           */
+
+#define SYS_GPB_MFPL_PB2MFP_Pos          (8)                                               /*!< SYS_T::GPB_MFPL: PB2MFP Position       */
+#define SYS_GPB_MFPL_PB2MFP_Msk          (0xful << SYS_GPB_MFPL_PB2MFP_Pos)                /*!< SYS_T::GPB_MFPL: PB2MFP Mask           */
+
+#define SYS_GPB_MFPL_PB3MFP_Pos          (12)                                              /*!< SYS_T::GPB_MFPL: PB3MFP Position       */
+#define SYS_GPB_MFPL_PB3MFP_Msk          (0xful << SYS_GPB_MFPL_PB3MFP_Pos)                /*!< SYS_T::GPB_MFPL: PB3MFP Mask           */
+
+#define SYS_GPB_MFPL_PB4MFP_Pos          (16)                                              /*!< SYS_T::GPB_MFPL: PB4MFP Position       */
+#define SYS_GPB_MFPL_PB4MFP_Msk          (0xful << SYS_GPB_MFPL_PB4MFP_Pos)                /*!< SYS_T::GPB_MFPL: PB4MFP Mask           */
+
+#define SYS_GPB_MFPL_PB5MFP_Pos          (20)                                              /*!< SYS_T::GPB_MFPL: PB5MFP Position       */
+#define SYS_GPB_MFPL_PB5MFP_Msk          (0xful << SYS_GPB_MFPL_PB5MFP_Pos)                /*!< SYS_T::GPB_MFPL: PB5MFP Mask           */
+
+#define SYS_GPB_MFPL_PB6MFP_Pos          (24)                                              /*!< SYS_T::GPB_MFPL: PB6MFP Position       */
+#define SYS_GPB_MFPL_PB6MFP_Msk          (0xful << SYS_GPB_MFPL_PB6MFP_Pos)                /*!< SYS_T::GPB_MFPL: PB6MFP Mask           */
+
+#define SYS_GPB_MFPL_PB7MFP_Pos          (28)                                              /*!< SYS_T::GPB_MFPL: PB7MFP Position       */
+#define SYS_GPB_MFPL_PB7MFP_Msk          (0xful << SYS_GPB_MFPL_PB7MFP_Pos)                /*!< SYS_T::GPB_MFPL: PB7MFP Mask           */
+
+#define SYS_GPB_MFPH_PB8MFP_Pos          (0)                                               /*!< SYS_T::GPB_MFPH: PB8MFP Position       */
+#define SYS_GPB_MFPH_PB8MFP_Msk          (0xful << SYS_GPB_MFPH_PB8MFP_Pos)                /*!< SYS_T::GPB_MFPH: PB8MFP Mask           */
+
+#define SYS_GPB_MFPH_PB9MFP_Pos          (4)                                               /*!< SYS_T::GPB_MFPH: PB9MFP Position       */
+#define SYS_GPB_MFPH_PB9MFP_Msk          (0xful << SYS_GPB_MFPH_PB9MFP_Pos)                /*!< SYS_T::GPB_MFPH: PB9MFP Mask           */
+
+#define SYS_GPB_MFPH_PB10MFP_Pos         (8)                                               /*!< SYS_T::GPB_MFPH: PB10MFP Position      */
+#define SYS_GPB_MFPH_PB10MFP_Msk         (0xful << SYS_GPB_MFPH_PB10MFP_Pos)               /*!< SYS_T::GPB_MFPH: PB10MFP Mask          */
+
+#define SYS_GPB_MFPH_PB11MFP_Pos         (12)                                              /*!< SYS_T::GPB_MFPH: PB11MFP Position      */
+#define SYS_GPB_MFPH_PB11MFP_Msk         (0xful << SYS_GPB_MFPH_PB11MFP_Pos)               /*!< SYS_T::GPB_MFPH: PB11MFP Mask          */
+
+#define SYS_GPB_MFPH_PB12MFP_Pos         (16)                                              /*!< SYS_T::GPB_MFPH: PB12MFP Position      */
+#define SYS_GPB_MFPH_PB12MFP_Msk         (0xful << SYS_GPB_MFPH_PB12MFP_Pos)               /*!< SYS_T::GPB_MFPH: PB12MFP Mask          */
+
+#define SYS_GPB_MFPH_PB13MFP_Pos         (20)                                              /*!< SYS_T::GPB_MFPH: PB13MFP Position      */
+#define SYS_GPB_MFPH_PB13MFP_Msk         (0xful << SYS_GPB_MFPH_PB13MFP_Pos)               /*!< SYS_T::GPB_MFPH: PB13MFP Mask          */
+
+#define SYS_GPB_MFPH_PB14MFP_Pos         (24)                                              /*!< SYS_T::GPB_MFPH: PB14MFP Position      */
+#define SYS_GPB_MFPH_PB14MFP_Msk         (0xful << SYS_GPB_MFPH_PB14MFP_Pos)               /*!< SYS_T::GPB_MFPH: PB14MFP Mask          */
+
+#define SYS_GPB_MFPH_PB15MFP_Pos         (28)                                              /*!< SYS_T::GPB_MFPH: PB15MFP Position      */
+#define SYS_GPB_MFPH_PB15MFP_Msk         (0xful << SYS_GPB_MFPH_PB15MFP_Pos)               /*!< SYS_T::GPB_MFPH: PB15MFP Mask          */
+
+#define SYS_GPC_MFPL_PC0MFP_Pos          (0)                                               /*!< SYS_T::GPC_MFPL: PC0MFP Position       */
+#define SYS_GPC_MFPL_PC0MFP_Msk          (0xful << SYS_GPC_MFPL_PC0MFP_Pos)                /*!< SYS_T::GPC_MFPL: PC0MFP Mask           */
+
+#define SYS_GPC_MFPL_PC1MFP_Pos          (4)                                               /*!< SYS_T::GPC_MFPL: PC1MFP Position       */
+#define SYS_GPC_MFPL_PC1MFP_Msk          (0xful << SYS_GPC_MFPL_PC1MFP_Pos)                /*!< SYS_T::GPC_MFPL: PC1MFP Mask           */
+
+#define SYS_GPC_MFPL_PC2MFP_Pos          (8)                                               /*!< SYS_T::GPC_MFPL: PC2MFP Position       */
+#define SYS_GPC_MFPL_PC2MFP_Msk          (0xful << SYS_GPC_MFPL_PC2MFP_Pos)                /*!< SYS_T::GPC_MFPL: PC2MFP Mask           */
+
+#define SYS_GPC_MFPL_PC3MFP_Pos          (12)                                              /*!< SYS_T::GPC_MFPL: PC3MFP Position       */
+#define SYS_GPC_MFPL_PC3MFP_Msk          (0xful << SYS_GPC_MFPL_PC3MFP_Pos)                /*!< SYS_T::GPC_MFPL: PC3MFP Mask           */
+
+#define SYS_GPC_MFPL_PC4MFP_Pos          (16)                                              /*!< SYS_T::GPC_MFPL: PC4MFP Position       */
+#define SYS_GPC_MFPL_PC4MFP_Msk          (0xful << SYS_GPC_MFPL_PC4MFP_Pos)                /*!< SYS_T::GPC_MFPL: PC4MFP Mask           */
+
+#define SYS_GPC_MFPL_PC5MFP_Pos          (20)                                              /*!< SYS_T::GPC_MFPL: PC5MFP Position       */
+#define SYS_GPC_MFPL_PC5MFP_Msk          (0xful << SYS_GPC_MFPL_PC5MFP_Pos)                /*!< SYS_T::GPC_MFPL: PC5MFP Mask           */
+
+#define SYS_GPC_MFPL_PC6MFP_Pos          (24)                                              /*!< SYS_T::GPC_MFPL: PC6MFP Position       */
+#define SYS_GPC_MFPL_PC6MFP_Msk          (0xful << SYS_GPC_MFPL_PC6MFP_Pos)                /*!< SYS_T::GPC_MFPL: PC6MFP Mask           */
+
+#define SYS_GPC_MFPL_PC7MFP_Pos          (28)                                              /*!< SYS_T::GPC_MFPL: PC7MFP Position       */
+#define SYS_GPC_MFPL_PC7MFP_Msk          (0xful << SYS_GPC_MFPL_PC7MFP_Pos)                /*!< SYS_T::GPC_MFPL: PC7MFP Mask           */
+
+#define SYS_GPC_MFPH_PC8MFP_Pos          (0)                                               /*!< SYS_T::GPC_MFPH: PC8MFP Position       */
+#define SYS_GPC_MFPH_PC8MFP_Msk          (0xful << SYS_GPC_MFPH_PC8MFP_Pos)                /*!< SYS_T::GPC_MFPH: PC8MFP Mask           */
+
+#define SYS_GPC_MFPH_PC9MFP_Pos          (4)                                               /*!< SYS_T::GPC_MFPH: PC9MFP Position       */
+#define SYS_GPC_MFPH_PC9MFP_Msk          (0xful << SYS_GPC_MFPH_PC9MFP_Pos)                /*!< SYS_T::GPC_MFPH: PC9MFP Mask           */
+
+#define SYS_GPC_MFPH_PC10MFP_Pos         (8)                                               /*!< SYS_T::GPC_MFPH: PC10MFP Position      */
+#define SYS_GPC_MFPH_PC10MFP_Msk         (0xful << SYS_GPC_MFPH_PC10MFP_Pos)               /*!< SYS_T::GPC_MFPH: PC10MFP Mask          */
+
+#define SYS_GPC_MFPH_PC11MFP_Pos         (12)                                              /*!< SYS_T::GPC_MFPH: PC11MFP Position      */
+#define SYS_GPC_MFPH_PC11MFP_Msk         (0xful << SYS_GPC_MFPH_PC11MFP_Pos)               /*!< SYS_T::GPC_MFPH: PC11MFP Mask          */
+
+#define SYS_GPC_MFPH_PC12MFP_Pos         (16)                                              /*!< SYS_T::GPC_MFPH: PC12MFP Position      */
+#define SYS_GPC_MFPH_PC12MFP_Msk         (0xful << SYS_GPC_MFPH_PC12MFP_Pos)               /*!< SYS_T::GPC_MFPH: PC12MFP Mask          */
+
+#define SYS_GPC_MFPH_PC13MFP_Pos         (20)                                              /*!< SYS_T::GPC_MFPH: PC13MFP Position      */
+#define SYS_GPC_MFPH_PC13MFP_Msk         (0xful << SYS_GPC_MFPH_PC13MFP_Pos)               /*!< SYS_T::GPC_MFPH: PC13MFP Mask          */
+
+#define SYS_GPC_MFPH_PC14MFP_Pos         (24)                                              /*!< SYS_T::GPC_MFPH: PC14MFP Position      */
+#define SYS_GPC_MFPH_PC14MFP_Msk         (0xful << SYS_GPC_MFPH_PC14MFP_Pos)               /*!< SYS_T::GPC_MFPH: PC14MFP Mask          */
+
+#define SYS_GPC_MFPH_PC15MFP_Pos         (28)                                              /*!< SYS_T::GPC_MFPH: PC15MFP Position      */
+#define SYS_GPC_MFPH_PC15MFP_Msk         (0xful << SYS_GPC_MFPH_PC15MFP_Pos)               /*!< SYS_T::GPC_MFPH: PC15MFP Mask          */
+
+#define SYS_GPD_MFPL_PD0MFP_Pos          (0)                                               /*!< SYS_T::GPD_MFPL: PD0MFP Position       */
+#define SYS_GPD_MFPL_PD0MFP_Msk          (0xful << SYS_GPD_MFPL_PD0MFP_Pos)                /*!< SYS_T::GPD_MFPL: PD0MFP Mask           */
+
+#define SYS_GPD_MFPL_PD1MFP_Pos          (4)                                               /*!< SYS_T::GPD_MFPL: PD1MFP Position       */
+#define SYS_GPD_MFPL_PD1MFP_Msk          (0xful << SYS_GPD_MFPL_PD1MFP_Pos)                /*!< SYS_T::GPD_MFPL: PD1MFP Mask           */
+
+#define SYS_GPD_MFPL_PD2MFP_Pos          (8)                                               /*!< SYS_T::GPD_MFPL: PD2MFP Position       */
+#define SYS_GPD_MFPL_PD2MFP_Msk          (0xful << SYS_GPD_MFPL_PD2MFP_Pos)                /*!< SYS_T::GPD_MFPL: PD2MFP Mask           */
+
+#define SYS_GPD_MFPL_PD3MFP_Pos          (12)                                              /*!< SYS_T::GPD_MFPL: PD3MFP Position       */
+#define SYS_GPD_MFPL_PD3MFP_Msk          (0xful << SYS_GPD_MFPL_PD3MFP_Pos)                /*!< SYS_T::GPD_MFPL: PD3MFP Mask           */
+
+#define SYS_GPD_MFPL_PD4MFP_Pos          (16)                                              /*!< SYS_T::GPD_MFPL: PD4MFP Position       */
+#define SYS_GPD_MFPL_PD4MFP_Msk          (0xful << SYS_GPD_MFPL_PD4MFP_Pos)                /*!< SYS_T::GPD_MFPL: PD4MFP Mask           */
+
+#define SYS_GPD_MFPL_PD5MFP_Pos          (20)                                              /*!< SYS_T::GPD_MFPL: PD5MFP Position       */
+#define SYS_GPD_MFPL_PD5MFP_Msk          (0xful << SYS_GPD_MFPL_PD5MFP_Pos)                /*!< SYS_T::GPD_MFPL: PD5MFP Mask           */
+
+#define SYS_GPD_MFPL_PD6MFP_Pos          (24)                                              /*!< SYS_T::GPD_MFPL: PD6MFP Position       */
+#define SYS_GPD_MFPL_PD6MFP_Msk          (0xful << SYS_GPD_MFPL_PD6MFP_Pos)                /*!< SYS_T::GPD_MFPL: PD6MFP Mask           */
+
+#define SYS_GPD_MFPL_PD7MFP_Pos          (28)                                              /*!< SYS_T::GPD_MFPL: PD7MFP Position       */
+#define SYS_GPD_MFPL_PD7MFP_Msk          (0xful << SYS_GPD_MFPL_PD7MFP_Pos)                /*!< SYS_T::GPD_MFPL: PD7MFP Mask           */
+
+#define SYS_GPD_MFPH_PD8MFP_Pos          (0)                                               /*!< SYS_T::GPD_MFPH: PD8MFP Position       */
+#define SYS_GPD_MFPH_PD8MFP_Msk          (0xful << SYS_GPD_MFPH_PD8MFP_Pos)                /*!< SYS_T::GPD_MFPH: PD8MFP Mask           */
+
+#define SYS_GPD_MFPH_PD9MFP_Pos          (4)                                               /*!< SYS_T::GPD_MFPH: PD9MFP Position       */
+#define SYS_GPD_MFPH_PD9MFP_Msk          (0xful << SYS_GPD_MFPH_PD9MFP_Pos)                /*!< SYS_T::GPD_MFPH: PD9MFP Mask           */
+
+#define SYS_GPD_MFPH_PD10MFP_Pos         (8)                                               /*!< SYS_T::GPD_MFPH: PD10MFP Position      */
+#define SYS_GPD_MFPH_PD10MFP_Msk         (0xful << SYS_GPD_MFPH_PD10MFP_Pos)               /*!< SYS_T::GPD_MFPH: PD10MFP Mask          */
+
+#define SYS_GPD_MFPH_PD11MFP_Pos         (12)                                              /*!< SYS_T::GPD_MFPH: PD11MFP Position      */
+#define SYS_GPD_MFPH_PD11MFP_Msk         (0xful << SYS_GPD_MFPH_PD11MFP_Pos)               /*!< SYS_T::GPD_MFPH: PD11MFP Mask          */
+
+#define SYS_GPD_MFPH_PD12MFP_Pos         (16)                                              /*!< SYS_T::GPD_MFPH: PD12MFP Position      */
+#define SYS_GPD_MFPH_PD12MFP_Msk         (0xful << SYS_GPD_MFPH_PD12MFP_Pos)               /*!< SYS_T::GPD_MFPH: PD12MFP Mask          */
+
+#define SYS_GPD_MFPH_PD13MFP_Pos         (20)                                              /*!< SYS_T::GPD_MFPH: PD13MFP Position      */
+#define SYS_GPD_MFPH_PD13MFP_Msk         (0xful << SYS_GPD_MFPH_PD13MFP_Pos)               /*!< SYS_T::GPD_MFPH: PD13MFP Mask          */
+
+#define SYS_GPD_MFPH_PD14MFP_Pos         (24)                                              /*!< SYS_T::GPD_MFPH: PD14MFP Position      */
+#define SYS_GPD_MFPH_PD14MFP_Msk         (0xful << SYS_GPD_MFPH_PD14MFP_Pos)               /*!< SYS_T::GPD_MFPH: PD14MFP Mask          */
+
+#define SYS_GPD_MFPH_PD15MFP_Pos         (28)                                              /*!< SYS_T::GPD_MFPH: PD15MFP Position      */
+#define SYS_GPD_MFPH_PD15MFP_Msk         (0xful << SYS_GPD_MFPH_PD15MFP_Pos)               /*!< SYS_T::GPD_MFPH: PD15MFP Mask          */
+
+#define SYS_GPE_MFPL_PE0MFP_Pos          (0)                                               /*!< SYS_T::GPE_MFPL: PE0MFP Position       */
+#define SYS_GPE_MFPL_PE0MFP_Msk          (0xful << SYS_GPE_MFPL_PE0MFP_Pos)                /*!< SYS_T::GPE_MFPL: PE0MFP Mask           */
+
+#define SYS_GPE_MFPL_PE1MFP_Pos          (4)                                               /*!< SYS_T::GPE_MFPL: PE1MFP Position       */
+#define SYS_GPE_MFPL_PE1MFP_Msk          (0xful << SYS_GPE_MFPL_PE1MFP_Pos)                /*!< SYS_T::GPE_MFPL: PE1MFP Mask           */
+
+#define SYS_GPE_MFPL_PE2MFP_Pos          (8)                                               /*!< SYS_T::GPE_MFPL: PE2MFP Position       */
+#define SYS_GPE_MFPL_PE2MFP_Msk          (0xful << SYS_GPE_MFPL_PE2MFP_Pos)                /*!< SYS_T::GPE_MFPL: PE2MFP Mask           */
+
+#define SYS_GPE_MFPL_PE3MFP_Pos          (12)                                              /*!< SYS_T::GPE_MFPL: PE3MFP Position       */
+#define SYS_GPE_MFPL_PE3MFP_Msk          (0xful << SYS_GPE_MFPL_PE3MFP_Pos)                /*!< SYS_T::GPE_MFPL: PE3MFP Mask           */
+
+#define SYS_GPE_MFPL_PE4MFP_Pos          (16)                                              /*!< SYS_T::GPE_MFPL: PE4MFP Position       */
+#define SYS_GPE_MFPL_PE4MFP_Msk          (0xful << SYS_GPE_MFPL_PE4MFP_Pos)                /*!< SYS_T::GPE_MFPL: PE4MFP Mask           */
+
+#define SYS_GPE_MFPL_PE5MFP_Pos          (20)                                              /*!< SYS_T::GPE_MFPL: PE5MFP Position       */
+#define SYS_GPE_MFPL_PE5MFP_Msk          (0xful << SYS_GPE_MFPL_PE5MFP_Pos)                /*!< SYS_T::GPE_MFPL: PE5MFP Mask           */
+
+#define SYS_GPE_MFPL_PE6MFP_Pos          (24)                                              /*!< SYS_T::GPE_MFPL: PE6MFP Position       */
+#define SYS_GPE_MFPL_PE6MFP_Msk          (0xful << SYS_GPE_MFPL_PE6MFP_Pos)                /*!< SYS_T::GPE_MFPL: PE6MFP Mask           */
+
+#define SYS_GPE_MFPL_PE7MFP_Pos          (28)                                              /*!< SYS_T::GPE_MFPL: PE7MFP Position       */
+#define SYS_GPE_MFPL_PE7MFP_Msk          (0xful << SYS_GPE_MFPL_PE7MFP_Pos)                /*!< SYS_T::GPE_MFPL: PE7MFP Mask           */
+
+#define SYS_GPE_MFPH_PE8MFP_Pos          (0)                                               /*!< SYS_T::GPE_MFPH: PE8MFP Position       */
+#define SYS_GPE_MFPH_PE8MFP_Msk          (0xful << SYS_GPE_MFPH_PE8MFP_Pos)                /*!< SYS_T::GPE_MFPH: PE8MFP Mask           */
+
+#define SYS_GPE_MFPH_PE9MFP_Pos          (4)                                               /*!< SYS_T::GPE_MFPH: PE9MFP Position       */
+#define SYS_GPE_MFPH_PE9MFP_Msk          (0xful << SYS_GPE_MFPH_PE9MFP_Pos)                /*!< SYS_T::GPE_MFPH: PE9MFP Mask           */
+
+#define SYS_GPE_MFPH_PE10MFP_Pos         (8)                                               /*!< SYS_T::GPE_MFPH: PE10MFP Position      */
+#define SYS_GPE_MFPH_PE10MFP_Msk         (0xful << SYS_GPE_MFPH_PE10MFP_Pos)               /*!< SYS_T::GPE_MFPH: PE10MFP Mask          */
+
+#define SYS_GPE_MFPH_PE11MFP_Pos         (12)                                              /*!< SYS_T::GPE_MFPH: PE11MFP Position      */
+#define SYS_GPE_MFPH_PE11MFP_Msk         (0xful << SYS_GPE_MFPH_PE11MFP_Pos)               /*!< SYS_T::GPE_MFPH: PE11MFP Mask          */
+
+#define SYS_GPE_MFPH_PE12MFP_Pos         (16)                                              /*!< SYS_T::GPE_MFPH: PE12MFP Position      */
+#define SYS_GPE_MFPH_PE12MFP_Msk         (0xful << SYS_GPE_MFPH_PE12MFP_Pos)               /*!< SYS_T::GPE_MFPH: PE12MFP Mask          */
+
+#define SYS_GPE_MFPH_PE13MFP_Pos         (20)                                              /*!< SYS_T::GPE_MFPH: PE13MFP Position      */
+#define SYS_GPE_MFPH_PE13MFP_Msk         (0xful << SYS_GPE_MFPH_PE13MFP_Pos)               /*!< SYS_T::GPE_MFPH: PE13MFP Mask          */
+
+#define SYS_GPE_MFPH_PE14MFP_Pos        (24)                                              /*!< SYS_T::GPE_MFPH: PE14_MFP Position     */
+#define SYS_GPE_MFPH_PE14MFP_Msk        (0xful << SYS_GPE_MFPH_PE14MFP_Pos)              /*!< SYS_T::GPE_MFPH: PE14_MFP Mask         */
+
+#define SYS_GPE_MFPH_PE15MFP_Pos        (28)                                              /*!< SYS_T::GPE_MFPH: PE15_MFP Position     */
+#define SYS_GPE_MFPH_PE15MFP_Msk        (0xful << SYS_GPE_MFPH_PE15MFP_Pos)              /*!< SYS_T::GPE_MFPH: PE15_MFP Mask         */
+
+#define SYS_GPF_MFPL_PF0MFP_Pos          (0)                                               /*!< SYS_T::GPF_MFPL: PF0MFP Position       */
+#define SYS_GPF_MFPL_PF0MFP_Msk          (0xful << SYS_GPF_MFPL_PF0MFP_Pos)                /*!< SYS_T::GPF_MFPL: PF0MFP Mask           */
+
+#define SYS_GPF_MFPL_PF1MFP_Pos          (4)                                               /*!< SYS_T::GPF_MFPL: PF1MFP Position       */
+#define SYS_GPF_MFPL_PF1MFP_Msk          (0xful << SYS_GPF_MFPL_PF1MFP_Pos)                /*!< SYS_T::GPF_MFPL: PF1MFP Mask           */
+
+#define SYS_GPF_MFPL_PF2MFP_Pos          (8)                                               /*!< SYS_T::GPF_MFPL: PF2MFP Position       */
+#define SYS_GPF_MFPL_PF2MFP_Msk          (0xful << SYS_GPF_MFPL_PF2MFP_Pos)                /*!< SYS_T::GPF_MFPL: PF2MFP Mask           */
+
+#define SYS_GPF_MFPL_PF3MFP_Pos          (12)                                              /*!< SYS_T::GPF_MFPL: PF3MFP Position       */
+#define SYS_GPF_MFPL_PF3MFP_Msk          (0xful << SYS_GPF_MFPL_PF3MFP_Pos)                /*!< SYS_T::GPF_MFPL: PF3MFP Mask           */
+
+#define SYS_GPF_MFPL_PF4MFP_Pos          (16)                                              /*!< SYS_T::GPF_MFPL: PF4MFP Position       */
+#define SYS_GPF_MFPL_PF4MFP_Msk          (0xful << SYS_GPF_MFPL_PF4MFP_Pos)                /*!< SYS_T::GPF_MFPL: PF4MFP Mask           */
+
+#define SYS_GPF_MFPL_PF5MFP_Pos          (20)                                              /*!< SYS_T::GPF_MFPL: PF5MFP Position       */
+#define SYS_GPF_MFPL_PF5MFP_Msk          (0xful << SYS_GPF_MFPL_PF5MFP_Pos)                /*!< SYS_T::GPF_MFPL: PF5MFP Mask           */
+
+#define SYS_GPF_MFPL_PF6MFP_Pos          (24)                                              /*!< SYS_T::GPF_MFPL: PF6MFP Position       */
+#define SYS_GPF_MFPL_PF6MFP_Msk          (0xful << SYS_GPF_MFPL_PF6MFP_Pos)                /*!< SYS_T::GPF_MFPL: PF6MFP Mask           */
+
+#define SYS_GPF_MFPL_PF7MFP_Pos          (28)                                              /*!< SYS_T::GPF_MFPL: PF7MFP Position       */
+#define SYS_GPF_MFPL_PF7MFP_Msk          (0xful << SYS_GPF_MFPL_PF7MFP_Pos)                /*!< SYS_T::GPF_MFPL: PF7MFP Mask           */
+
+#define SYS_GPF_MFPH_PF8MFP_Pos          (0)                                               /*!< SYS_T::GPF_MFPH: PF8MFP Position       */
+#define SYS_GPF_MFPH_PF8MFP_Msk          (0xful << SYS_GPF_MFPH_PF8MFP_Pos)                /*!< SYS_T::GPF_MFPH: PF8MFP Mask           */
+
+#define SYS_GPF_MFPH_PF9MFP_Pos          (4)                                               /*!< SYS_T::GPF_MFPH: PF9MFP Position       */
+#define SYS_GPF_MFPH_PF9MFP_Msk          (0xful << SYS_GPF_MFPH_PF9MFP_Pos)                /*!< SYS_T::GPF_MFPH: PF9MFP Mask           */
+
+#define SYS_GPF_MFPH_PF10MFP_Pos         (8)                                               /*!< SYS_T::GPF_MFPH: PF10MFP Position      */
+#define SYS_GPF_MFPH_PF10MFP_Msk         (0xful << SYS_GPF_MFPH_PF10MFP_Pos)               /*!< SYS_T::GPF_MFPH: PF10MFP Mask          */
+
+#define SYS_GPF_MFPH_PF11MFP_Pos         (12)                                              /*!< SYS_T::GPF_MFPH: PF11MFP Position      */
+#define SYS_GPF_MFPH_PF11MFP_Msk         (0xful << SYS_GPF_MFPH_PF11MFP_Pos)               /*!< SYS_T::GPF_MFPH: PF11MFP Mask          */
+
+#define SYS_GPF_MFPH_PF12MFP_Pos         (16)                                              /*!< SYS_T::GPF_MFPH: PF12MFP Position      */
+#define SYS_GPF_MFPH_PF12MFP_Msk         (0xful << SYS_GPF_MFPH_PF12MFP_Pos)               /*!< SYS_T::GPF_MFPH: PF12MFP Mask          */
+
+#define SYS_GPF_MFPH_PF13MFP_Pos         (20)                                              /*!< SYS_T::GPF_MFPH: PF13MFP Position      */
+#define SYS_GPF_MFPH_PF13MFP_Msk         (0xful << SYS_GPF_MFPH_PF13MFP_Pos)               /*!< SYS_T::GPF_MFPH: PF13MFP Mask          */
+
+#define SYS_GPF_MFPH_PF14MFP_Pos         (24)                                              /*!< SYS_T::GPF_MFPH: PF14MFP Position      */
+#define SYS_GPF_MFPH_PF14MFP_Msk         (0xful << SYS_GPF_MFPH_PF14MFP_Pos)               /*!< SYS_T::GPF_MFPH: PF14MFP Mask          */
+
+#define SYS_GPF_MFPH_PF15MFP_Pos         (28)                                              /*!< SYS_T::GPF_MFPH: PF15MFP Position      */
+#define SYS_GPF_MFPH_PF15MFP_Msk         (0xful << SYS_GPF_MFPH_PF15MFP_Pos)               /*!< SYS_T::GPF_MFPH: PF15MFP Mask          */
+
+#define SYS_GPA_MFOS_MFOS0_Pos           (0)                                               /*!< SYS_T::GPA_MFOS: MFOS0 Position        */
+#define SYS_GPA_MFOS_MFOS0_Msk           (0x1ul << SYS_GPA_MFOS_MFOS0_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS0 Mask            */
+
+#define SYS_GPA_MFOS_MFOS1_Pos           (1)                                               /*!< SYS_T::GPA_MFOS: MFOS1 Position        */
+#define SYS_GPA_MFOS_MFOS1_Msk           (0x1ul << SYS_GPA_MFOS_MFOS1_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS1 Mask            */
+
+#define SYS_GPA_MFOS_MFOS2_Pos           (2)                                               /*!< SYS_T::GPA_MFOS: MFOS2 Position        */
+#define SYS_GPA_MFOS_MFOS2_Msk           (0x1ul << SYS_GPA_MFOS_MFOS2_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS2 Mask            */
+
+#define SYS_GPA_MFOS_MFOS3_Pos           (3)                                               /*!< SYS_T::GPA_MFOS: MFOS3 Position        */
+#define SYS_GPA_MFOS_MFOS3_Msk           (0x1ul << SYS_GPA_MFOS_MFOS3_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS3 Mask            */
+
+#define SYS_GPA_MFOS_MFOS4_Pos           (4)                                               /*!< SYS_T::GPA_MFOS: MFOS4 Position        */
+#define SYS_GPA_MFOS_MFOS4_Msk           (0x1ul << SYS_GPA_MFOS_MFOS4_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS4 Mask            */
+
+#define SYS_GPA_MFOS_MFOS5_Pos           (5)                                               /*!< SYS_T::GPA_MFOS: MFOS5 Position        */
+#define SYS_GPA_MFOS_MFOS5_Msk           (0x1ul << SYS_GPA_MFOS_MFOS5_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS5 Mask            */
+
+#define SYS_GPA_MFOS_MFOS6_Pos           (6)                                               /*!< SYS_T::GPA_MFOS: MFOS6 Position        */
+#define SYS_GPA_MFOS_MFOS6_Msk           (0x1ul << SYS_GPA_MFOS_MFOS6_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS6 Mask            */
+
+#define SYS_GPA_MFOS_MFOS7_Pos           (7)                                               /*!< SYS_T::GPA_MFOS: MFOS7 Position        */
+#define SYS_GPA_MFOS_MFOS7_Msk           (0x1ul << SYS_GPA_MFOS_MFOS7_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS7 Mask            */
+
+#define SYS_GPA_MFOS_MFOS8_Pos           (8)                                               /*!< SYS_T::GPA_MFOS: MFOS8 Position        */
+#define SYS_GPA_MFOS_MFOS8_Msk           (0x1ul << SYS_GPA_MFOS_MFOS8_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS8 Mask            */
+
+#define SYS_GPA_MFOS_MFOS9_Pos           (9)                                               /*!< SYS_T::GPA_MFOS: MFOS9 Position        */
+#define SYS_GPA_MFOS_MFOS9_Msk           (0x1ul << SYS_GPA_MFOS_MFOS9_Pos)                 /*!< SYS_T::GPA_MFOS: MFOS9 Mask            */
+
+#define SYS_GPA_MFOS_MFOS10_Pos          (10)                                              /*!< SYS_T::GPA_MFOS: MFOS10 Position       */
+#define SYS_GPA_MFOS_MFOS10_Msk          (0x1ul << SYS_GPA_MFOS_MFOS10_Pos)                /*!< SYS_T::GPA_MFOS: MFOS10 Mask           */
+
+#define SYS_GPA_MFOS_MFOS11_Pos          (11)                                              /*!< SYS_T::GPA_MFOS: MFOS11 Position       */
+#define SYS_GPA_MFOS_MFOS11_Msk          (0x1ul << SYS_GPA_MFOS_MFOS11_Pos)                /*!< SYS_T::GPA_MFOS: MFOS11 Mask           */
+
+#define SYS_GPA_MFOS_MFOS12_Pos          (12)                                              /*!< SYS_T::GPA_MFOS: MFOS12 Position       */
+#define SYS_GPA_MFOS_MFOS12_Msk          (0x1ul << SYS_GPA_MFOS_MFOS12_Pos)                /*!< SYS_T::GPA_MFOS: MFOS12 Mask           */
+
+#define SYS_GPA_MFOS_MFOS13_Pos          (13)                                              /*!< SYS_T::GPA_MFOS: MFOS13 Position       */
+#define SYS_GPA_MFOS_MFOS13_Msk          (0x1ul << SYS_GPA_MFOS_MFOS13_Pos)                /*!< SYS_T::GPA_MFOS: MFOS13 Mask           */
+
+#define SYS_GPA_MFOS_MFOS14_Pos          (14)                                              /*!< SYS_T::GPA_MFOS: MFOS14 Position       */
+#define SYS_GPA_MFOS_MFOS14_Msk          (0x1ul << SYS_GPA_MFOS_MFOS14_Pos)                /*!< SYS_T::GPA_MFOS: MFOS14 Mask           */
+
+#define SYS_GPA_MFOS_MFOS15_Pos          (15)                                              /*!< SYS_T::GPA_MFOS: MFOS15 Position       */
+#define SYS_GPA_MFOS_MFOS15_Msk          (0x1ul << SYS_GPA_MFOS_MFOS15_Pos)                /*!< SYS_T::GPA_MFOS: MFOS15 Mask           */
+
+#define SYS_GPB_MFOS_MFOS0_Pos           (0)                                               /*!< SYS_T::GPB_MFOS: MFOS0 Position        */
+#define SYS_GPB_MFOS_MFOS0_Msk           (0x1ul << SYS_GPB_MFOS_MFOS0_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS0 Mask            */
+
+#define SYS_GPB_MFOS_MFOS1_Pos           (1)                                               /*!< SYS_T::GPB_MFOS: MFOS1 Position        */
+#define SYS_GPB_MFOS_MFOS1_Msk           (0x1ul << SYS_GPB_MFOS_MFOS1_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS1 Mask            */
+
+#define SYS_GPB_MFOS_MFOS2_Pos           (2)                                               /*!< SYS_T::GPB_MFOS: MFOS2 Position        */
+#define SYS_GPB_MFOS_MFOS2_Msk           (0x1ul << SYS_GPB_MFOS_MFOS2_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS2 Mask            */
+
+#define SYS_GPB_MFOS_MFOS3_Pos           (3)                                               /*!< SYS_T::GPB_MFOS: MFOS3 Position        */
+#define SYS_GPB_MFOS_MFOS3_Msk           (0x1ul << SYS_GPB_MFOS_MFOS3_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS3 Mask            */
+
+#define SYS_GPB_MFOS_MFOS4_Pos           (4)                                               /*!< SYS_T::GPB_MFOS: MFOS4 Position        */
+#define SYS_GPB_MFOS_MFOS4_Msk           (0x1ul << SYS_GPB_MFOS_MFOS4_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS4 Mask            */
+
+#define SYS_GPB_MFOS_MFOS5_Pos           (5)                                               /*!< SYS_T::GPB_MFOS: MFOS5 Position        */
+#define SYS_GPB_MFOS_MFOS5_Msk           (0x1ul << SYS_GPB_MFOS_MFOS5_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS5 Mask            */
+
+#define SYS_GPB_MFOS_MFOS6_Pos           (6)                                               /*!< SYS_T::GPB_MFOS: MFOS6 Position        */
+#define SYS_GPB_MFOS_MFOS6_Msk           (0x1ul << SYS_GPB_MFOS_MFOS6_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS6 Mask            */
+
+#define SYS_GPB_MFOS_MFOS7_Pos           (7)                                               /*!< SYS_T::GPB_MFOS: MFOS7 Position        */
+#define SYS_GPB_MFOS_MFOS7_Msk           (0x1ul << SYS_GPB_MFOS_MFOS7_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS7 Mask            */
+
+#define SYS_GPB_MFOS_MFOS8_Pos           (8)                                               /*!< SYS_T::GPB_MFOS: MFOS8 Position        */
+#define SYS_GPB_MFOS_MFOS8_Msk           (0x1ul << SYS_GPB_MFOS_MFOS8_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS8 Mask            */
+
+#define SYS_GPB_MFOS_MFOS9_Pos           (9)                                               /*!< SYS_T::GPB_MFOS: MFOS9 Position        */
+#define SYS_GPB_MFOS_MFOS9_Msk           (0x1ul << SYS_GPB_MFOS_MFOS9_Pos)                 /*!< SYS_T::GPB_MFOS: MFOS9 Mask            */
+
+#define SYS_GPB_MFOS_MFOS10_Pos          (10)                                              /*!< SYS_T::GPB_MFOS: MFOS10 Position       */
+#define SYS_GPB_MFOS_MFOS10_Msk          (0x1ul << SYS_GPB_MFOS_MFOS10_Pos)                /*!< SYS_T::GPB_MFOS: MFOS10 Mask           */
+
+#define SYS_GPB_MFOS_MFOS11_Pos          (11)                                              /*!< SYS_T::GPB_MFOS: MFOS11 Position       */
+#define SYS_GPB_MFOS_MFOS11_Msk          (0x1ul << SYS_GPB_MFOS_MFOS11_Pos)                /*!< SYS_T::GPB_MFOS: MFOS11 Mask           */
+
+#define SYS_GPB_MFOS_MFOS12_Pos          (12)                                              /*!< SYS_T::GPB_MFOS: MFOS12 Position       */
+#define SYS_GPB_MFOS_MFOS12_Msk          (0x1ul << SYS_GPB_MFOS_MFOS12_Pos)                /*!< SYS_T::GPB_MFOS: MFOS12 Mask           */
+
+#define SYS_GPB_MFOS_MFOS13_Pos          (13)                                              /*!< SYS_T::GPB_MFOS: MFOS13 Position       */
+#define SYS_GPB_MFOS_MFOS13_Msk          (0x1ul << SYS_GPB_MFOS_MFOS13_Pos)                /*!< SYS_T::GPB_MFOS: MFOS13 Mask           */
+
+#define SYS_GPB_MFOS_MFOS14_Pos          (14)                                              /*!< SYS_T::GPB_MFOS: MFOS14 Position       */
+#define SYS_GPB_MFOS_MFOS14_Msk          (0x1ul << SYS_GPB_MFOS_MFOS14_Pos)                /*!< SYS_T::GPB_MFOS: MFOS14 Mask           */
+
+#define SYS_GPB_MFOS_MFOS15_Pos          (15)                                              /*!< SYS_T::GPB_MFOS: MFOS15 Position       */
+#define SYS_GPB_MFOS_MFOS15_Msk          (0x1ul << SYS_GPB_MFOS_MFOS15_Pos)                /*!< SYS_T::GPB_MFOS: MFOS15 Mask           */
+
+#define SYS_GPC_MFOS_MFOS0_Pos           (0)                                               /*!< SYS_T::GPC_MFOS: MFOS0 Position        */
+#define SYS_GPC_MFOS_MFOS0_Msk           (0x1ul << SYS_GPC_MFOS_MFOS0_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS0 Mask            */
+
+#define SYS_GPC_MFOS_MFOS1_Pos           (1)                                               /*!< SYS_T::GPC_MFOS: MFOS1 Position        */
+#define SYS_GPC_MFOS_MFOS1_Msk           (0x1ul << SYS_GPC_MFOS_MFOS1_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS1 Mask            */
+
+#define SYS_GPC_MFOS_MFOS2_Pos           (2)                                               /*!< SYS_T::GPC_MFOS: MFOS2 Position        */
+#define SYS_GPC_MFOS_MFOS2_Msk           (0x1ul << SYS_GPC_MFOS_MFOS2_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS2 Mask            */
+
+#define SYS_GPC_MFOS_MFOS3_Pos           (3)                                               /*!< SYS_T::GPC_MFOS: MFOS3 Position        */
+#define SYS_GPC_MFOS_MFOS3_Msk           (0x1ul << SYS_GPC_MFOS_MFOS3_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS3 Mask            */
+
+#define SYS_GPC_MFOS_MFOS4_Pos           (4)                                               /*!< SYS_T::GPC_MFOS: MFOS4 Position        */
+#define SYS_GPC_MFOS_MFOS4_Msk           (0x1ul << SYS_GPC_MFOS_MFOS4_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS4 Mask            */
+
+#define SYS_GPC_MFOS_MFOS5_Pos           (5)                                               /*!< SYS_T::GPC_MFOS: MFOS5 Position        */
+#define SYS_GPC_MFOS_MFOS5_Msk           (0x1ul << SYS_GPC_MFOS_MFOS5_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS5 Mask            */
+
+#define SYS_GPC_MFOS_MFOS6_Pos           (6)                                               /*!< SYS_T::GPC_MFOS: MFOS6 Position        */
+#define SYS_GPC_MFOS_MFOS6_Msk           (0x1ul << SYS_GPC_MFOS_MFOS6_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS6 Mask            */
+
+#define SYS_GPC_MFOS_MFOS7_Pos           (7)                                               /*!< SYS_T::GPC_MFOS: MFOS7 Position        */
+#define SYS_GPC_MFOS_MFOS7_Msk           (0x1ul << SYS_GPC_MFOS_MFOS7_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS7 Mask            */
+
+#define SYS_GPC_MFOS_MFOS8_Pos           (8)                                               /*!< SYS_T::GPC_MFOS: MFOS8 Position        */
+#define SYS_GPC_MFOS_MFOS8_Msk           (0x1ul << SYS_GPC_MFOS_MFOS8_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS8 Mask            */
+
+#define SYS_GPC_MFOS_MFOS9_Pos           (9)                                               /*!< SYS_T::GPC_MFOS: MFOS9 Position        */
+#define SYS_GPC_MFOS_MFOS9_Msk           (0x1ul << SYS_GPC_MFOS_MFOS9_Pos)                 /*!< SYS_T::GPC_MFOS: MFOS9 Mask            */
+
+#define SYS_GPC_MFOS_MFOS10_Pos          (10)                                              /*!< SYS_T::GPC_MFOS: MFOS10 Position       */
+#define SYS_GPC_MFOS_MFOS10_Msk          (0x1ul << SYS_GPC_MFOS_MFOS10_Pos)                /*!< SYS_T::GPC_MFOS: MFOS10 Mask           */
+
+#define SYS_GPC_MFOS_MFOS11_Pos          (11)                                              /*!< SYS_T::GPC_MFOS: MFOS11 Position       */
+#define SYS_GPC_MFOS_MFOS11_Msk          (0x1ul << SYS_GPC_MFOS_MFOS11_Pos)                /*!< SYS_T::GPC_MFOS: MFOS11 Mask           */
+
+#define SYS_GPC_MFOS_MFOS12_Pos          (12)                                              /*!< SYS_T::GPC_MFOS: MFOS12 Position       */
+#define SYS_GPC_MFOS_MFOS12_Msk          (0x1ul << SYS_GPC_MFOS_MFOS12_Pos)                /*!< SYS_T::GPC_MFOS: MFOS12 Mask           */
+
+#define SYS_GPC_MFOS_MFOS13_Pos          (13)                                              /*!< SYS_T::GPC_MFOS: MFOS13 Position       */
+#define SYS_GPC_MFOS_MFOS13_Msk          (0x1ul << SYS_GPC_MFOS_MFOS13_Pos)                /*!< SYS_T::GPC_MFOS: MFOS13 Mask           */
+
+#define SYS_GPC_MFOS_MFOS14_Pos          (14)                                              /*!< SYS_T::GPC_MFOS: MFOS14 Position       */
+#define SYS_GPC_MFOS_MFOS14_Msk          (0x1ul << SYS_GPC_MFOS_MFOS14_Pos)                /*!< SYS_T::GPC_MFOS: MFOS14 Mask           */
+
+#define SYS_GPC_MFOS_MFOS15_Pos          (15)                                              /*!< SYS_T::GPC_MFOS: MFOS15 Position       */
+#define SYS_GPC_MFOS_MFOS15_Msk          (0x1ul << SYS_GPC_MFOS_MFOS15_Pos)                /*!< SYS_T::GPC_MFOS: MFOS15 Mask           */
+
+#define SYS_GPD_MFOS_MFOS0_Pos           (0)                                               /*!< SYS_T::GPD_MFOS: MFOS0 Position        */
+#define SYS_GPD_MFOS_MFOS0_Msk           (0x1ul << SYS_GPD_MFOS_MFOS0_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS0 Mask            */
+
+#define SYS_GPD_MFOS_MFOS1_Pos           (1)                                               /*!< SYS_T::GPD_MFOS: MFOS1 Position        */
+#define SYS_GPD_MFOS_MFOS1_Msk           (0x1ul << SYS_GPD_MFOS_MFOS1_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS1 Mask            */
+
+#define SYS_GPD_MFOS_MFOS2_Pos           (2)                                               /*!< SYS_T::GPD_MFOS: MFOS2 Position        */
+#define SYS_GPD_MFOS_MFOS2_Msk           (0x1ul << SYS_GPD_MFOS_MFOS2_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS2 Mask            */
+
+#define SYS_GPD_MFOS_MFOS3_Pos           (3)                                               /*!< SYS_T::GPD_MFOS: MFOS3 Position        */
+#define SYS_GPD_MFOS_MFOS3_Msk           (0x1ul << SYS_GPD_MFOS_MFOS3_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS3 Mask            */
+
+#define SYS_GPD_MFOS_MFOS4_Pos           (4)                                               /*!< SYS_T::GPD_MFOS: MFOS4 Position        */
+#define SYS_GPD_MFOS_MFOS4_Msk           (0x1ul << SYS_GPD_MFOS_MFOS4_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS4 Mask            */
+
+#define SYS_GPD_MFOS_MFOS5_Pos           (5)                                               /*!< SYS_T::GPD_MFOS: MFOS5 Position        */
+#define SYS_GPD_MFOS_MFOS5_Msk           (0x1ul << SYS_GPD_MFOS_MFOS5_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS5 Mask            */
+
+#define SYS_GPD_MFOS_MFOS6_Pos           (6)                                               /*!< SYS_T::GPD_MFOS: MFOS6 Position        */
+#define SYS_GPD_MFOS_MFOS6_Msk           (0x1ul << SYS_GPD_MFOS_MFOS6_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS6 Mask            */
+
+#define SYS_GPD_MFOS_MFOS7_Pos           (7)                                               /*!< SYS_T::GPD_MFOS: MFOS7 Position        */
+#define SYS_GPD_MFOS_MFOS7_Msk           (0x1ul << SYS_GPD_MFOS_MFOS7_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS7 Mask            */
+
+#define SYS_GPD_MFOS_MFOS8_Pos           (8)                                               /*!< SYS_T::GPD_MFOS: MFOS8 Position        */
+#define SYS_GPD_MFOS_MFOS8_Msk           (0x1ul << SYS_GPD_MFOS_MFOS8_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS8 Mask            */
+
+#define SYS_GPD_MFOS_MFOS9_Pos           (9)                                               /*!< SYS_T::GPD_MFOS: MFOS9 Position        */
+#define SYS_GPD_MFOS_MFOS9_Msk           (0x1ul << SYS_GPD_MFOS_MFOS9_Pos)                 /*!< SYS_T::GPD_MFOS: MFOS9 Mask            */
+
+#define SYS_GPD_MFOS_MFOS10_Pos          (10)                                              /*!< SYS_T::GPD_MFOS: MFOS10 Position       */
+#define SYS_GPD_MFOS_MFOS10_Msk          (0x1ul << SYS_GPD_MFOS_MFOS10_Pos)                /*!< SYS_T::GPD_MFOS: MFOS10 Mask           */
+
+#define SYS_GPD_MFOS_MFOS11_Pos          (11)                                              /*!< SYS_T::GPD_MFOS: MFOS11 Position       */
+#define SYS_GPD_MFOS_MFOS11_Msk          (0x1ul << SYS_GPD_MFOS_MFOS11_Pos)                /*!< SYS_T::GPD_MFOS: MFOS11 Mask           */
+
+#define SYS_GPD_MFOS_MFOS12_Pos          (12)                                              /*!< SYS_T::GPD_MFOS: MFOS12 Position       */
+#define SYS_GPD_MFOS_MFOS12_Msk          (0x1ul << SYS_GPD_MFOS_MFOS12_Pos)                /*!< SYS_T::GPD_MFOS: MFOS12 Mask           */
+
+#define SYS_GPD_MFOS_MFOS13_Pos          (13)                                              /*!< SYS_T::GPD_MFOS: MFOS13 Position       */
+#define SYS_GPD_MFOS_MFOS13_Msk          (0x1ul << SYS_GPD_MFOS_MFOS13_Pos)                /*!< SYS_T::GPD_MFOS: MFOS13 Mask           */
+
+#define SYS_GPD_MFOS_MFOS14_Pos          (14)                                              /*!< SYS_T::GPD_MFOS: MFOS14 Position       */
+#define SYS_GPD_MFOS_MFOS14_Msk          (0x1ul << SYS_GPD_MFOS_MFOS14_Pos)                /*!< SYS_T::GPD_MFOS: MFOS14 Mask           */
+
+#define SYS_GPD_MFOS_MFOS15_Pos          (15)                                              /*!< SYS_T::GPD_MFOS: MFOS15 Position       */
+#define SYS_GPD_MFOS_MFOS15_Msk          (0x1ul << SYS_GPD_MFOS_MFOS15_Pos)                /*!< SYS_T::GPD_MFOS: MFOS15 Mask           */
+
+#define SYS_GPE_MFOS_MFOS0_Pos           (0)                                               /*!< SYS_T::GPE_MFOS: MFOS0 Position        */
+#define SYS_GPE_MFOS_MFOS0_Msk           (0x1ul << SYS_GPE_MFOS_MFOS0_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS0 Mask            */
+
+#define SYS_GPE_MFOS_MFOS1_Pos           (1)                                               /*!< SYS_T::GPE_MFOS: MFOS1 Position        */
+#define SYS_GPE_MFOS_MFOS1_Msk           (0x1ul << SYS_GPE_MFOS_MFOS1_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS1 Mask            */
+
+#define SYS_GPE_MFOS_MFOS2_Pos           (2)                                               /*!< SYS_T::GPE_MFOS: MFOS2 Position        */
+#define SYS_GPE_MFOS_MFOS2_Msk           (0x1ul << SYS_GPE_MFOS_MFOS2_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS2 Mask            */
+
+#define SYS_GPE_MFOS_MFOS3_Pos           (3)                                               /*!< SYS_T::GPE_MFOS: MFOS3 Position        */
+#define SYS_GPE_MFOS_MFOS3_Msk           (0x1ul << SYS_GPE_MFOS_MFOS3_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS3 Mask            */
+
+#define SYS_GPE_MFOS_MFOS4_Pos           (4)                                               /*!< SYS_T::GPE_MFOS: MFOS4 Position        */
+#define SYS_GPE_MFOS_MFOS4_Msk           (0x1ul << SYS_GPE_MFOS_MFOS4_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS4 Mask            */
+
+#define SYS_GPE_MFOS_MFOS5_Pos           (5)                                               /*!< SYS_T::GPE_MFOS: MFOS5 Position        */
+#define SYS_GPE_MFOS_MFOS5_Msk           (0x1ul << SYS_GPE_MFOS_MFOS5_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS5 Mask            */
+
+#define SYS_GPE_MFOS_MFOS6_Pos           (6)                                               /*!< SYS_T::GPE_MFOS: MFOS6 Position        */
+#define SYS_GPE_MFOS_MFOS6_Msk           (0x1ul << SYS_GPE_MFOS_MFOS6_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS6 Mask            */
+
+#define SYS_GPE_MFOS_MFOS7_Pos           (7)                                               /*!< SYS_T::GPE_MFOS: MFOS7 Position        */
+#define SYS_GPE_MFOS_MFOS7_Msk           (0x1ul << SYS_GPE_MFOS_MFOS7_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS7 Mask            */
+
+#define SYS_GPE_MFOS_MFOS8_Pos           (8)                                               /*!< SYS_T::GPE_MFOS: MFOS8 Position        */
+#define SYS_GPE_MFOS_MFOS8_Msk           (0x1ul << SYS_GPE_MFOS_MFOS8_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS8 Mask            */
+
+#define SYS_GPE_MFOS_MFOS9_Pos           (9)                                               /*!< SYS_T::GPE_MFOS: MFOS9 Position        */
+#define SYS_GPE_MFOS_MFOS9_Msk           (0x1ul << SYS_GPE_MFOS_MFOS9_Pos)                 /*!< SYS_T::GPE_MFOS: MFOS9 Mask            */
+
+#define SYS_GPE_MFOS_MFOS10_Pos          (10)                                              /*!< SYS_T::GPE_MFOS: MFOS10 Position       */
+#define SYS_GPE_MFOS_MFOS10_Msk          (0x1ul << SYS_GPE_MFOS_MFOS10_Pos)                /*!< SYS_T::GPE_MFOS: MFOS10 Mask           */
+
+#define SYS_GPE_MFOS_MFOS11_Pos          (11)                                              /*!< SYS_T::GPE_MFOS: MFOS11 Position       */
+#define SYS_GPE_MFOS_MFOS11_Msk          (0x1ul << SYS_GPE_MFOS_MFOS11_Pos)                /*!< SYS_T::GPE_MFOS: MFOS11 Mask           */
+
+#define SYS_GPE_MFOS_MFOS12_Pos          (12)                                              /*!< SYS_T::GPE_MFOS: MFOS12 Position       */
+#define SYS_GPE_MFOS_MFOS12_Msk          (0x1ul << SYS_GPE_MFOS_MFOS12_Pos)                /*!< SYS_T::GPE_MFOS: MFOS12 Mask           */
+
+#define SYS_GPE_MFOS_MFOS13_Pos          (13)                                              /*!< SYS_T::GPE_MFOS: MFOS13 Position       */
+#define SYS_GPE_MFOS_MFOS13_Msk          (0x1ul << SYS_GPE_MFOS_MFOS13_Pos)                /*!< SYS_T::GPE_MFOS: MFOS13 Mask           */
+
+#define SYS_GPE_MFOS_MFOS14_Pos          (14)                                              /*!< SYS_T::GPE_MFOS: MFOS14 Position       */
+#define SYS_GPE_MFOS_MFOS14_Msk          (0x1ul << SYS_GPE_MFOS_MFOS14_Pos)                /*!< SYS_T::GPE_MFOS: MFOS14 Mask           */
+
+#define SYS_GPE_MFOS_MFOS15_Pos          (15)                                              /*!< SYS_T::GPE_MFOS: MFOS15 Position       */
+#define SYS_GPE_MFOS_MFOS15_Msk          (0x1ul << SYS_GPE_MFOS_MFOS15_Pos)                /*!< SYS_T::GPE_MFOS: MFOS15 Mask           */
+
+#define SYS_GPF_MFOS_MFOS0_Pos           (0)                                               /*!< SYS_T::GPF_MFOS: MFOS0 Position        */
+#define SYS_GPF_MFOS_MFOS0_Msk           (0x1ul << SYS_GPF_MFOS_MFOS0_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS0 Mask            */
+
+#define SYS_GPF_MFOS_MFOS1_Pos           (1)                                               /*!< SYS_T::GPF_MFOS: MFOS1 Position        */
+#define SYS_GPF_MFOS_MFOS1_Msk           (0x1ul << SYS_GPF_MFOS_MFOS1_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS1 Mask            */
+
+#define SYS_GPF_MFOS_MFOS2_Pos           (2)                                               /*!< SYS_T::GPF_MFOS: MFOS2 Position        */
+#define SYS_GPF_MFOS_MFOS2_Msk           (0x1ul << SYS_GPF_MFOS_MFOS2_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS2 Mask            */
+
+#define SYS_GPF_MFOS_MFOS3_Pos           (3)                                               /*!< SYS_T::GPF_MFOS: MFOS3 Position        */
+#define SYS_GPF_MFOS_MFOS3_Msk           (0x1ul << SYS_GPF_MFOS_MFOS3_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS3 Mask            */
+
+#define SYS_GPF_MFOS_MFOS4_Pos           (4)                                               /*!< SYS_T::GPF_MFOS: MFOS4 Position        */
+#define SYS_GPF_MFOS_MFOS4_Msk           (0x1ul << SYS_GPF_MFOS_MFOS4_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS4 Mask            */
+
+#define SYS_GPF_MFOS_MFOS5_Pos           (5)                                               /*!< SYS_T::GPF_MFOS: MFOS5 Position        */
+#define SYS_GPF_MFOS_MFOS5_Msk           (0x1ul << SYS_GPF_MFOS_MFOS5_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS5 Mask            */
+
+#define SYS_GPF_MFOS_MFOS6_Pos           (6)                                               /*!< SYS_T::GPF_MFOS: MFOS6 Position        */
+#define SYS_GPF_MFOS_MFOS6_Msk           (0x1ul << SYS_GPF_MFOS_MFOS6_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS6 Mask            */
+
+#define SYS_GPF_MFOS_MFOS7_Pos           (7)                                               /*!< SYS_T::GPF_MFOS: MFOS7 Position        */
+#define SYS_GPF_MFOS_MFOS7_Msk           (0x1ul << SYS_GPF_MFOS_MFOS7_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS7 Mask            */
+
+#define SYS_GPF_MFOS_MFOS8_Pos           (8)                                               /*!< SYS_T::GPF_MFOS: MFOS8 Position        */
+#define SYS_GPF_MFOS_MFOS8_Msk           (0x1ul << SYS_GPF_MFOS_MFOS8_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS8 Mask            */
+
+#define SYS_GPF_MFOS_MFOS9_Pos           (9)                                               /*!< SYS_T::GPF_MFOS: MFOS9 Position        */
+#define SYS_GPF_MFOS_MFOS9_Msk           (0x1ul << SYS_GPF_MFOS_MFOS9_Pos)                 /*!< SYS_T::GPF_MFOS: MFOS9 Mask            */
+
+#define SYS_GPF_MFOS_MFOS10_Pos          (10)                                              /*!< SYS_T::GPF_MFOS: MFOS10 Position       */
+#define SYS_GPF_MFOS_MFOS10_Msk          (0x1ul << SYS_GPF_MFOS_MFOS10_Pos)                /*!< SYS_T::GPF_MFOS: MFOS10 Mask           */
+
+#define SYS_GPF_MFOS_MFOS11_Pos          (11)                                              /*!< SYS_T::GPF_MFOS: MFOS11 Position       */
+#define SYS_GPF_MFOS_MFOS11_Msk          (0x1ul << SYS_GPF_MFOS_MFOS11_Pos)                /*!< SYS_T::GPF_MFOS: MFOS11 Mask           */
+
+#define SYS_GPF_MFOS_MFOS12_Pos          (12)                                              /*!< SYS_T::GPF_MFOS: MFOS12 Position       */
+#define SYS_GPF_MFOS_MFOS12_Msk          (0x1ul << SYS_GPF_MFOS_MFOS12_Pos)                /*!< SYS_T::GPF_MFOS: MFOS12 Mask           */
+
+#define SYS_GPF_MFOS_MFOS13_Pos          (13)                                              /*!< SYS_T::GPF_MFOS: MFOS13 Position       */
+#define SYS_GPF_MFOS_MFOS13_Msk          (0x1ul << SYS_GPF_MFOS_MFOS13_Pos)                /*!< SYS_T::GPF_MFOS: MFOS13 Mask           */
+
+#define SYS_GPF_MFOS_MFOS14_Pos          (14)                                              /*!< SYS_T::GPF_MFOS: MFOS14 Position       */
+#define SYS_GPF_MFOS_MFOS14_Msk          (0x1ul << SYS_GPF_MFOS_MFOS14_Pos)                /*!< SYS_T::GPF_MFOS: MFOS14 Mask           */
+
+#define SYS_GPF_MFOS_MFOS15_Pos          (15)                                              /*!< SYS_T::GPF_MFOS: MFOS15 Position       */
+#define SYS_GPF_MFOS_MFOS15_Msk          (0x1ul << SYS_GPF_MFOS_MFOS15_Pos)                /*!< SYS_T::GPF_MFOS: MFOS15 Mask           */
+
+#define SYS_MODCTL_MODEN_Pos             (0)                                               /*!< SYS_T::MODCTL: MODEN Position          */
+#define SYS_MODCTL_MODEN_Msk             (0x1ul << SYS_MODCTL_MODEN_Pos)                   /*!< SYS_T::MODCTL: MODEN Mask              */
+
+#define SYS_MODCTL_MODH_Pos              (1)                                               /*!< SYS_T::MODCTL: MODH Position           */
+#define SYS_MODCTL_MODH_Msk              (0x1ul << SYS_MODCTL_MODH_Pos)                    /*!< SYS_T::MODCTL: MODH Mask               */
+
+#define SYS_MODCTL_MODPWMSEL_Pos         (4)                                               /*!< SYS_T::MODCTL: MODPWMSEL Position      */
+#define SYS_MODCTL_MODPWMSEL_Msk         (0xful << SYS_MODCTL_MODPWMSEL_Pos)               /*!< SYS_T::MODCTL: MODPWMSEL Mask          */
+
+#define SYS_SRAM_BISTCTL_SRBIST_Pos      (0)                                               /*!< SYS_T::SRAM_BISTCTL: SRBIST Position   */
+#define SYS_SRAM_BISTCTL_SRBIST_Msk      (0x1ul << SYS_SRAM_BISTCTL_SRBIST_Pos)            /*!< SYS_T::SRAM_BISTCTL: SRBIST Mask       */
+
+#define SYS_SRAM_BISTCTL_FMCBIST_Pos     (2)                                               /*!< SYS_T::SRAM_BISTCTL: FMCBIST Position  */
+#define SYS_SRAM_BISTCTL_FMCBIST_Msk     (0x1ul << SYS_SRAM_BISTCTL_FMCBIST_Pos)           /*!< SYS_T::SRAM_BISTCTL: FMCBIST Mask      */
+
+#define SYS_SRAM_BISTCTL_USBBIST_Pos     (4)                                               /*!< SYS_T::SRAM_BISTCTL: USBBIST Position  */
+#define SYS_SRAM_BISTCTL_USBBIST_Msk     (0x1ul << SYS_SRAM_BISTCTL_USBBIST_Pos)           /*!< SYS_T::SRAM_BISTCTL: USBBIST Mask      */
+
+#define SYS_SRAM_BISTCTL_PDMABIST_Pos    (7)                                               /*!< SYS_T::SRAM_BISTCTL: PDMABIST Position */
+#define SYS_SRAM_BISTCTL_PDMABIST_Msk    (0x1ul << SYS_SRAM_BISTCTL_PDMABIST_Pos)          /*!< SYS_T::SRAM_BISTCTL: PDMABIST Mask     */
+
+#define SYS_SRAM_BISTSTS_SRBISTEF_Pos    (0)                                               /*!< SYS_T::SRAM_BISTSTS: SRBISTEF Position */
+#define SYS_SRAM_BISTSTS_SRBISTEF_Msk    (0x1ul << SYS_SRAM_BISTSTS_SRBISTEF_Pos)          /*!< SYS_T::SRAM_BISTSTS: SRBISTEF Mask     */
+
+#define SYS_SRAM_BISTSTS_CR0BISTEF_Pos   (1)                                               /*!< SYS_T::SRAM_BISTSTS: CR0BISTEF Position*/
+#define SYS_SRAM_BISTSTS_CR0BISTEF_Msk   (0x1ul << SYS_SRAM_BISTSTS_CR0BISTEF_Pos)         /*!< SYS_T::SRAM_BISTSTS: CR0BISTEF Mask    */
+
+#define SYS_SRAM_BISTSTS_CR1BISTEF_Pos   (2)                                               /*!< SYS_T::SRAM_BISTSTS: CR1BISTEF Position*/
+#define SYS_SRAM_BISTSTS_CR1BISTEF_Msk   (0x1ul << SYS_SRAM_BISTSTS_CR1BISTEF_Pos)         /*!< SYS_T::SRAM_BISTSTS: CR1BISTEF Mask    */
+
+#define SYS_SRAM_BISTSTS_USBBEF_Pos      (4)                                               /*!< SYS_T::SRAM_BISTSTS: USBBEF Position   */
+#define SYS_SRAM_BISTSTS_USBBEF_Msk      (0x1ul << SYS_SRAM_BISTSTS_USBBEF_Pos)            /*!< SYS_T::SRAM_BISTSTS: USBBEF Mask       */
+
+#define SYS_SRAM_BISTSTS_PDMABISTF_Pos   (7)                                               /*!< SYS_T::SRAM_BISTSTS: PDMABISTF Position*/
+#define SYS_SRAM_BISTSTS_PDMABISTF_Msk   (0x1ul << SYS_SRAM_BISTSTS_PDMABISTF_Pos)         /*!< SYS_T::SRAM_BISTSTS: PDMABISTF Mask    */
+
+#define SYS_SRAM_BISTSTS_SRBEND_Pos      (16)                                              /*!< SYS_T::SRAM_BISTSTS: SRBEND Position   */
+#define SYS_SRAM_BISTSTS_SRBEND_Msk      (0x1ul << SYS_SRAM_BISTSTS_SRBEND_Pos)            /*!< SYS_T::SRAM_BISTSTS: SRBEND Mask       */
+
+#define SYS_SRAM_BISTSTS_CR0BEND_Pos     (17)                                              /*!< SYS_T::SRAM_BISTSTS: CR0BEND Position  */
+#define SYS_SRAM_BISTSTS_CR0BEND_Msk     (0x1ul << SYS_SRAM_BISTSTS_CR0BEND_Pos)           /*!< SYS_T::SRAM_BISTSTS: CR0BEND Mask      */
+
+#define SYS_SRAM_BISTSTS_CR1BEND_Pos     (18)                                              /*!< SYS_T::SRAM_BISTSTS: CR1BEND Position  */
+#define SYS_SRAM_BISTSTS_CR1BEND_Msk     (0x1ul << SYS_SRAM_BISTSTS_CR1BEND_Pos)           /*!< SYS_T::SRAM_BISTSTS: CR1BEND Mask      */
+
+#define SYS_SRAM_BISTSTS_USBBEND_Pos     (20)                                              /*!< SYS_T::SRAM_BISTSTS: USBBEND Position  */
+#define SYS_SRAM_BISTSTS_USBBEND_Msk     (0x1ul << SYS_SRAM_BISTSTS_USBBEND_Pos)           /*!< SYS_T::SRAM_BISTSTS: USBBEND Mask      */
+
+#define SYS_SRAM_BISTSTS_PDMAEND_Pos     (23)                                              /*!< SYS_T::SRAM_BISTSTS: PDMAEND Position  */
+#define SYS_SRAM_BISTSTS_PDMAEND_Msk     (0x1ul << SYS_SRAM_BISTSTS_PDMAEND_Pos)           /*!< SYS_T::SRAM_BISTSTS: PDMAEND Mask      */
+
+#define SYS_HIRCTRIMCTL_FREQSEL_Pos      (0)                                               /*!< SYS_T::HIRCTRIMCTL: FREQSEL Position   */
+#define SYS_HIRCTRIMCTL_FREQSEL_Msk      (0x3ul << SYS_HIRCTRIMCTL_FREQSEL_Pos)            /*!< SYS_T::HIRCTRIMCTL: FREQSEL Mask       */
+
+#define SYS_HIRCTRIMCTL_LOOPSEL_Pos      (4)                                               /*!< SYS_T::HIRCTRIMCTL: LOOPSEL Position   */
+#define SYS_HIRCTRIMCTL_LOOPSEL_Msk      (0x3ul << SYS_HIRCTRIMCTL_LOOPSEL_Pos)            /*!< SYS_T::HIRCTRIMCTL: LOOPSEL Mask       */
+
+#define SYS_HIRCTRIMCTL_RETRYCNT_Pos     (6)                                               /*!< SYS_T::HIRCTRIMCTL: RETRYCNT Position  */
+#define SYS_HIRCTRIMCTL_RETRYCNT_Msk     (0x3ul << SYS_HIRCTRIMCTL_RETRYCNT_Pos)           /*!< SYS_T::HIRCTRIMCTL: RETRYCNT Mask      */
+
+#define SYS_HIRCTRIMCTL_CESTOPEN_Pos     (8)                                               /*!< SYS_T::HIRCTRIMCTL: CESTOPEN Position  */
+#define SYS_HIRCTRIMCTL_CESTOPEN_Msk     (0x1ul << SYS_HIRCTRIMCTL_CESTOPEN_Pos)           /*!< SYS_T::HIRCTRIMCTL: CESTOPEN Mask      */
+
+#define SYS_HIRCTRIMCTL_BOUNDEN_Pos      (9)                                               /*!< SYS_T::HIRCTRIMCTL: BOUNDEN Position   */
+#define SYS_HIRCTRIMCTL_BOUNDEN_Msk      (0x1ul << SYS_HIRCTRIMCTL_BOUNDEN_Pos)            /*!< SYS_T::HIRCTRIMCTL: BOUNDEN Mask       */
+
+#define SYS_HIRCTRIMCTL_REFCKSEL_Pos     (10)                                              /*!< SYS_T::HIRCTRIMCTL: REFCKSEL Position  */
+#define SYS_HIRCTRIMCTL_REFCKSEL_Msk     (0x1ul << SYS_HIRCTRIMCTL_REFCKSEL_Pos)           /*!< SYS_T::HIRCTRIMCTL: REFCKSEL Mask      */
+
+#define SYS_HIRCTRIMCTL_BOUNDARY_Pos     (16)                                              /*!< SYS_T::HIRCTRIMCTL: BOUNDARY Position  */
+#define SYS_HIRCTRIMCTL_BOUNDARY_Msk     (0x1ful << SYS_HIRCTRIMCTL_BOUNDARY_Pos)          /*!< SYS_T::HIRCTRIMCTL: BOUNDARY Mask      */
+
+#define SYS_HIRCTRIMIEN_TFALIEN_Pos      (1)                                               /*!< SYS_T::HIRCTRIMIEN: TFALIEN Position   */
+#define SYS_HIRCTRIMIEN_TFALIEN_Msk      (0x1ul << SYS_HIRCTRIMIEN_TFALIEN_Pos)            /*!< SYS_T::HIRCTRIMIEN: TFALIEN Mask       */
+
+#define SYS_HIRCTRIMIEN_CLKEIEN_Pos      (2)                                               /*!< SYS_T::HIRCTRIMIEN: CLKEIEN Position   */
+#define SYS_HIRCTRIMIEN_CLKEIEN_Msk      (0x1ul << SYS_HIRCTRIMIEN_CLKEIEN_Pos)            /*!< SYS_T::HIRCTRIMIEN: CLKEIEN Mask       */
+
+#define SYS_HIRCTRIMSTS_FREQLOCK_Pos     (0)                                               /*!< SYS_T::HIRCTRIMSTS: FREQLOCK Position  */
+#define SYS_HIRCTRIMSTS_FREQLOCK_Msk     (0x1ul << SYS_HIRCTRIMSTS_FREQLOCK_Pos)           /*!< SYS_T::HIRCTRIMSTS: FREQLOCK Mask      */
+
+#define SYS_HIRCTRIMSTS_TFAILIF_Pos      (1)                                               /*!< SYS_T::HIRCTRIMSTS: TFAILIF Position   */
+#define SYS_HIRCTRIMSTS_TFAILIF_Msk      (0x1ul << SYS_HIRCTRIMSTS_TFAILIF_Pos)            /*!< SYS_T::HIRCTRIMSTS: TFAILIF Mask       */
+
+#define SYS_HIRCTRIMSTS_CLKERIF_Pos      (2)                                               /*!< SYS_T::HIRCTRIMSTS: CLKERIF Position   */
+#define SYS_HIRCTRIMSTS_CLKERIF_Msk      (0x1ul << SYS_HIRCTRIMSTS_CLKERIF_Pos)            /*!< SYS_T::HIRCTRIMSTS: CLKERIF Mask       */
+
+#define SYS_HIRCTRIMSTS_OVBDIF_Pos       (3)                                               /*!< SYS_T::HIRCTRIMSTS: OVBDIF Position    */
+#define SYS_HIRCTRIMSTS_OVBDIF_Msk       (0x1ul << SYS_HIRCTRIMSTS_OVBDIF_Pos)             /*!< SYS_T::HIRCTRIMSTS: OVBDIF Mask        */
+
+#define SYS_REGLCTL_REGLCTL_Pos          (0)                                               /*!< SYS_T::REGLCTL: REGLCTL Position       */
+#define SYS_REGLCTL_REGLCTL_Msk          (0xfful << SYS_REGLCTL_REGLCTL_Pos)               /*!< SYS_T::REGLCTL: REGLCTL Mask           */
+
+#define SYS_MIRCTRIMCTL_FREQSEL_Pos      (0)                                               /*!< SYS_T::MIRCTRIMCTL: FREQSEL Position   */
+#define SYS_MIRCTRIMCTL_FREQSEL_Msk      (0x3ul << SYS_MIRCTRIMCTL_FREQSEL_Pos)            /*!< SYS_T::MIRCTRIMCTL: FREQSEL Mask       */
+
+#define SYS_MIRCTRIMCTL_LOOPSEL_Pos      (4)                                               /*!< SYS_T::MIRCTRIMCTL: LOOPSEL Position   */
+#define SYS_MIRCTRIMCTL_LOOPSEL_Msk      (0x3ul << SYS_MIRCTRIMCTL_LOOPSEL_Pos)            /*!< SYS_T::MIRCTRIMCTL: LOOPSEL Mask       */
+
+#define SYS_MIRCTRIMCTL_RETRYCNT_Pos     (6)                                               /*!< SYS_T::MIRCTRIMCTL: RETRYCNT Position  */
+#define SYS_MIRCTRIMCTL_RETRYCNT_Msk     (0x3ul << SYS_MIRCTRIMCTL_RETRYCNT_Pos)           /*!< SYS_T::MIRCTRIMCTL: RETRYCNT Mask      */
+
+#define SYS_MIRCTRIMCTL_CESTOPEN_Pos     (8)                                               /*!< SYS_T::MIRCTRIMCTL: CESTOPEN Position  */
+#define SYS_MIRCTRIMCTL_CESTOPEN_Msk     (0x1ul << SYS_MIRCTRIMCTL_CESTOPEN_Pos)           /*!< SYS_T::MIRCTRIMCTL: CESTOPEN Mask      */
+
+#define SYS_MIRCTRIMCTL_BOUNDEN_Pos      (9)                                               /*!< SYS_T::MIRCTRIMCTL: BOUNDEN Position   */
+#define SYS_MIRCTRIMCTL_BOUNDEN_Msk      (0x1ul << SYS_MIRCTRIMCTL_BOUNDEN_Pos)            /*!< SYS_T::MIRCTRIMCTL: BOUNDEN Mask       */
+
+#define SYS_MIRCTRIMCTL_REFCKSEL_Pos     (10)                                              /*!< SYS_T::MIRCTRIMCTL: REFCKSEL Position  */
+#define SYS_MIRCTRIMCTL_REFCKSEL_Msk     (0x1ul << SYS_MIRCTRIMCTL_REFCKSEL_Pos)           /*!< SYS_T::MIRCTRIMCTL: REFCKSEL Mask      */
+
+#define SYS_MIRCTRIMCTL_BOUNDARY_Pos     (16)                                              /*!< SYS_T::MIRCTRIMCTL: BOUNDARY Position  */
+#define SYS_MIRCTRIMCTL_BOUNDARY_Msk     (0x1ful << SYS_MIRCTRIMCTL_BOUNDARY_Pos)          /*!< SYS_T::MIRCTRIMCTL: BOUNDARY Mask      */
+
+#define SYS_MIRCTRIMIEN_TFALIEN_Pos      (1)                                               /*!< SYS_T::MIRCTRIMIEN: TFALIEN Position   */
+#define SYS_MIRCTRIMIEN_TFALIEN_Msk      (0x1ul << SYS_MIRCTRIMIEN_TFALIEN_Pos)            /*!< SYS_T::MIRCTRIMIEN: TFALIEN Mask       */
+
+#define SYS_MIRCTRIMIEN_CLKEIEN_Pos      (2)                                               /*!< SYS_T::MIRCTRIMIEN: CLKEIEN Position   */
+#define SYS_MIRCTRIMIEN_CLKEIEN_Msk      (0x1ul << SYS_MIRCTRIMIEN_CLKEIEN_Pos)            /*!< SYS_T::MIRCTRIMIEN: CLKEIEN Mask       */
+
+#define SYS_MIRCTRIMSTS_FREQLOCK_Pos     (0)                                               /*!< SYS_T::MIRCTRIMSTS: FREQLOCK Position  */
+#define SYS_MIRCTRIMSTS_FREQLOCK_Msk     (0x1ul << SYS_MIRCTRIMSTS_FREQLOCK_Pos)           /*!< SYS_T::MIRCTRIMSTS: FREQLOCK Mask      */
+
+#define SYS_MIRCTRIMSTS_TFAILIF_Pos      (1)                                               /*!< SYS_T::MIRCTRIMSTS: TFAILIF Position   */
+#define SYS_MIRCTRIMSTS_TFAILIF_Msk      (0x1ul << SYS_MIRCTRIMSTS_TFAILIF_Pos)            /*!< SYS_T::MIRCTRIMSTS: TFAILIF Mask       */
+
+#define SYS_MIRCTRIMSTS_CLKERIF_Pos      (2)                                               /*!< SYS_T::MIRCTRIMSTS: CLKERIF Position   */
+#define SYS_MIRCTRIMSTS_CLKERIF_Msk      (0x1ul << SYS_MIRCTRIMSTS_CLKERIF_Pos)            /*!< SYS_T::MIRCTRIMSTS: CLKERIF Mask       */
+
+#define SYS_MIRCTRIMSTS_OVBDIF_Pos       (3)                                               /*!< SYS_T::MIRCTRIMSTS: OVBDIF Position    */
+#define SYS_MIRCTRIMSTS_OVBDIF_Msk       (0x1ul << SYS_MIRCTRIMSTS_OVBDIF_Pos)             /*!< SYS_T::MIRCTRIMSTS: OVBDIF Mask        */
+
+#define SYS_RTCLVRIEN_IE_Pos             (0)                                               /*!< SYS_T::RTCLVRIEN: IE Position     */
+#define SYS_RTCLVRIEN_IE_Msk             (0x1ul << SYS_RTCLVRIEN_IE_Pos)                   /*!< SYS_T::RTCLVRIEN: IE Mask         */
+
+#define SYS_RTCLVRSTS_IF_Pos             (0)                                               /*!< SYS_T::RTCLVRSTS: IF Position     */
+#define SYS_RTCLVRSTS_IF_Msk             (0x1ul << SYS_RTCLVRSTS_IF_Pos)                   /*!< SYS_T::RTCLVRSTS: IF Mask         */
+
+#define SYS_RTCLVRSTS_RTCLVR_Pos         (8)                                               /*!< SYS_T::RTCLVRSTS: RTCLVR Position     */
+#define SYS_RTCLVRSTS_RTCLVR_Msk         (0x1ul << SYS_RTCLVRSTS_RTCLVR_Pos)               /*!< SYS_T::RTCLVRSTS: RTCLVR Mask         */
+
+#define SYS_PORCTL1_POROFF_Pos           (0)                                               /*!< SYS_T::PORCTL1: POROFF Position     */
+#define SYS_PORCTL1_POROFF_Msk           (0xfffful << SYS_PORCTL1_POROFF_Pos)              /*!< SYS_T::PORCTL1: POROFF Mask         */
+
+#define SYS_PLCTL_PLSEL_Pos              (0)                                               /*!< SYS_T::PLCTL: PLSEL Position           */
+#define SYS_PLCTL_PLSEL_Msk              (0x3ul << SYS_PLCTL_PLSEL_Pos)                    /*!< SYS_T::PLCTL: PLSEL Mask               */
+
+#define SYS_PLSTS_PLCBUSY_Pos            (0)                                               /*!< SYS_T::PLSTS: PLCBUSY Position         */
+#define SYS_PLSTS_PLCBUSY_Msk            (0x1ul << SYS_PLSTS_PLCBUSY_Pos)                  /*!< SYS_T::PLSTS: PLCBUSY Mask             */
+
+#define SYS_PLSTS_CURPL_Pos              (8)                                               /*!< SYS_T::PLSTS: CURPL Position           */
+#define SYS_PLSTS_CURPL_Msk              (0x3ul << SYS_PLSTS_CURPL_Pos)                    /*!< SYS_T::PLSTS: CURPL Mask               */
+
+/** @} SYS_CONST */
+/** @} end of SYS register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __SYS_REG_H__ */

--- a/hal/m258ke/nuvoton/system_M251.c
+++ b/hal/m258ke/nuvoton/system_M251.c
@@ -1,0 +1,133 @@
+/**************************************************************************//**
+ * @file     system_M251.c
+ * @version  V0.10
+ * @brief    System Setting Source File
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ ****************************************************************************/
+
+#include <arm_cmse.h>
+#include <stdio.h>
+#include <stdint.h>
+#include "NuMicro.h"
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+    #include "partition_M251.h"
+#endif
+
+
+extern void *__Vectors;                   /* see startup file */
+
+/*----------------------------------------------------------------------------
+  Clock Variable definitions
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock  = __HSI;              /*!< System Clock Frequency (Core Clock) */
+uint32_t CyclesPerUs      = (__HSI / 1000000);  /*!< Cycles per micro second             */
+uint32_t PllClock         = __HSI;              /*!< PLL Output Clock Frequency          */
+const uint32_t gau32ClkSrcTbl[8] = {__HXT, __LXT, 0UL, __LIRC, 0UL, __MIRC, 0UL, __HIRC};
+
+
+/**
+ * @brief    Update the Variable SystemCoreClock
+ *
+ * @details  This function is used to update the variable SystemCoreClock
+ *           and must be called whenever the core clock is changed.
+ */
+void SystemCoreClockUpdate(void)
+{
+    uint32_t u32Freq, u32ClkSrc;
+    uint32_t u32HclkDiv;
+
+    u32ClkSrc = CLK->CLKSEL0 & CLK_CLKSEL0_HCLKSEL_Msk;
+
+    /* Update PLL Clock */
+    PllClock = CLK_GetPLLClockFreq();
+
+    if (u32ClkSrc != CLK_CLKSEL0_HCLKSEL_PLL)
+    {
+        /* Use the clock sources directly */
+        u32Freq = gau32ClkSrcTbl[u32ClkSrc];
+    }
+    else
+    {
+        /* Use PLL clock */
+        u32Freq = PllClock;
+    }
+
+    u32HclkDiv = (CLK->CLKDIV0 & CLK_CLKDIV0_HCLKDIV_Msk) + 1;
+
+    /* Update System Core Clock */
+    SystemCoreClock = u32Freq / u32HclkDiv;
+
+    CyclesPerUs = (SystemCoreClock + 500000) / 1000000;
+}
+
+
+
+/**
+ * @brief    System Initialization
+ *
+ * @details  The necessary initialization of system. Global variables are forbidden here.
+ */
+void SystemInit(void)
+{
+    /* Set access cycle for CPU @ 48MHz */
+    FMC->CYCCTL = (FMC->CYCCTL & ~FMC_CYCCTL_CYCLE_Msk) | (3 << FMC_CYCCTL_CYCLE_Pos) | 0x100;
+
+#if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)
+    SCB->VTOR = (uint32_t) &__Vectors;
+#endif
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    TZ_SAU_Setup();
+    SCU_Setup();
+    FMC_NSBA_Setup();
+#endif
+
+#ifdef INIT_SYSCLK_AT_BOOTING
+
+#endif
+
+}
+
+
+#if USE_ASSERT
+
+/**
+ * @brief      Assert Error Message
+ *
+ * @param[in]  file  the source file name
+ * @param[in]  line  line number
+ *
+ * @details    The function prints the source file name and line number where
+ *             the ASSERT_PARAM() error occurs, and then stops in an infinite loop.
+ */
+void AssertError(uint8_t *file, uint32_t line)
+{
+
+    printf("[%s] line %u : wrong parameters.\r\n", file, line);
+
+    /* Infinite loop */
+    while (1) ;
+}
+#endif
+
+/**
+ * @brief    Set UART0 Default MPF
+ *
+ * @details  The initialization of uart0 default multi function pin.
+ */
+#if defined( __ICCARM__ )
+    __WEAK
+#else
+    __attribute__((weak))
+#endif
+void Uart0DefaultMPF(void)
+{
+
+    /* Set GPB multi-function pins for UART0 RXD and TXD */
+    SYS->GPB_MFPH = (SYS->GPB_MFPH & ~SYS_GPB_MFPH_PB12MFP_Msk) | SYS_GPB_MFPH_PB12MFP_UART0_RXD;
+    SYS->GPB_MFPH = (SYS->GPB_MFPH & ~SYS_GPB_MFPH_PB13MFP_Msk) | SYS_GPB_MFPH_PB13MFP_UART0_TXD;
+
+}

--- a/hal/m258ke/nuvoton/system_M251.c
+++ b/hal/m258ke/nuvoton/system_M251.c
@@ -27,44 +27,6 @@ uint32_t CyclesPerUs      = (__HSI / 1000000);  /*!< Cycles per micro second    
 uint32_t PllClock         = __HSI;              /*!< PLL Output Clock Frequency          */
 const uint32_t gau32ClkSrcTbl[8] = {__HXT, __LXT, 0UL, __LIRC, 0UL, __MIRC, 0UL, __HIRC};
 
-
-/**
- * @brief    Update the Variable SystemCoreClock
- *
- * @details  This function is used to update the variable SystemCoreClock
- *           and must be called whenever the core clock is changed.
- */
-void SystemCoreClockUpdate(void)
-{
-    uint32_t u32Freq, u32ClkSrc;
-    uint32_t u32HclkDiv;
-
-    u32ClkSrc = CLK->CLKSEL0 & CLK_CLKSEL0_HCLKSEL_Msk;
-
-    /* Update PLL Clock */
-    PllClock = CLK_GetPLLClockFreq();
-
-    if (u32ClkSrc != CLK_CLKSEL0_HCLKSEL_PLL)
-    {
-        /* Use the clock sources directly */
-        u32Freq = gau32ClkSrcTbl[u32ClkSrc];
-    }
-    else
-    {
-        /* Use PLL clock */
-        u32Freq = PllClock;
-    }
-
-    u32HclkDiv = (CLK->CLKDIV0 & CLK_CLKDIV0_HCLKDIV_Msk) + 1;
-
-    /* Update System Core Clock */
-    SystemCoreClock = u32Freq / u32HclkDiv;
-
-    CyclesPerUs = (SystemCoreClock + 500000) / 1000000;
-}
-
-
-
 /**
  * @brief    System Initialization
  *
@@ -112,22 +74,3 @@ void AssertError(uint8_t *file, uint32_t line)
     while (1) ;
 }
 #endif
-
-/**
- * @brief    Set UART0 Default MPF
- *
- * @details  The initialization of uart0 default multi function pin.
- */
-#if defined( __ICCARM__ )
-    __WEAK
-#else
-    __attribute__((weak))
-#endif
-void Uart0DefaultMPF(void)
-{
-
-    /* Set GPB multi-function pins for UART0 RXD and TXD */
-    SYS->GPB_MFPH = (SYS->GPB_MFPH & ~SYS_GPB_MFPH_PB12MFP_Msk) | SYS_GPB_MFPH_PB12MFP_UART0_RXD;
-    SYS->GPB_MFPH = (SYS->GPB_MFPH & ~SYS_GPB_MFPH_PB13MFP_Msk) | SYS_GPB_MFPH_PB13MFP_UART0_TXD;
-
-}

--- a/hal/m258ke/nuvoton/system_M251.h
+++ b/hal/m258ke/nuvoton/system_M251.h
@@ -1,0 +1,80 @@
+/**************************************************************************//**
+ * @file     system_M251.h
+ * @version  V0.10
+ * @brief    System Setting Header File
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ ****************************************************************************/
+
+#ifndef __SYSTEM_M251_H__
+#define __SYSTEM_M251_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#ifndef __HXT
+#define __HXT       (12000000UL)              /*!< External Crystal Clock Frequency           */
+#endif /* !defined(__HXT) */
+
+#ifndef __LXT
+#define __LXT       (32768UL)                 /*!< External Crystal Clock Frequency 32.768KHz */
+#endif /* !defined(__LXT) */
+
+#define __LIRC      (38400UL)                 /*!< Internal 38.4KHz RC Oscillator Frequency   */
+#define __MIRC      (4032000UL)               /*!< Internal 4.032M RC Oscillator Frequency    */
+#define __HIRC      (48000000UL)              /*!< Internal 48M RC Oscillator Frequency       */
+#define __HSI       (48000000UL)              /*!< PLL default output is 48MHz                */
+#define __SYS_OSC_CLK     (    ___HSI)        /*!< Main oscillator frequency                  */
+
+#define __SYSTEM_CLOCK    (1UL*__HXT)
+
+extern uint32_t SystemCoreClock;    /*!< System Clock Frequency (Core Clock)  */
+extern uint32_t CyclesPerUs;        /*!< Cycles per micro second              */
+extern uint32_t PllClock;           /*!< PLL Output Clock Frequency           */
+
+
+/**
+ * @brief    System Initialization
+ *
+ * @details  The necessary initialization of system. Global variables are forbidden here.
+ */
+extern void SystemInit(void);
+
+/**
+ * @brief    Update the Variable SystemCoreClock
+ *
+ * @details  This function is used to update the variable SystemCoreClock
+ *           and must be called whenever the core clock is changed.
+ */
+extern void SystemCoreClockUpdate(void);
+
+/**
+ * @brief    Set UART0 Default MPF
+ *
+ * @details  The initialization of uart0 default multi function pin.
+ */
+extern void Uart0DefaultMPF(void);
+
+/**
+ * @brief  Check if debug message finished
+ *
+ * @return   1 Message is finished.
+ *           0 Message is transmitting.
+ *
+ * @details  Check if message finished (FIFO empty of debug port)
+ */
+extern int IsDebugFifoEmpty(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_M251_H__ */

--- a/hal/m258ke/nuvoton/system_M251.h
+++ b/hal/m258ke/nuvoton/system_M251.h
@@ -48,21 +48,6 @@ extern uint32_t PllClock;           /*!< PLL Output Clock Frequency           */
 extern void SystemInit(void);
 
 /**
- * @brief    Update the Variable SystemCoreClock
- *
- * @details  This function is used to update the variable SystemCoreClock
- *           and must be called whenever the core clock is changed.
- */
-extern void SystemCoreClockUpdate(void);
-
-/**
- * @brief    Set UART0 Default MPF
- *
- * @details  The initialization of uart0 default multi function pin.
- */
-extern void Uart0DefaultMPF(void);
-
-/**
  * @brief  Check if debug message finished
  *
  * @return   1 Message is finished.

--- a/hal/m258ke/nuvoton/timer_reg.h
+++ b/hal/m258ke/nuvoton/timer_reg.h
@@ -1,0 +1,680 @@
+/**************************************************************************//**
+ * @file     timer_reg.h
+ * @version  V1.00
+ * @brief    TIMER register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __TIMER_REG_H__
+#define __TIMER_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup TIMER Timer Controller (TIMER)
+    Memory Mapped Structure for TIMER Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var TIMER_T::CTL
+     * Offset: 0x00  Timer Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |PSC       |Prescale Counter
+     * |        |          |Timer input clock or event source is divided by (PSC+1) before it is fed to the timer up counter
+     * |        |          |If this field is 0 (PSC = 0), then there is no scaling.
+     * |        |          |Note: Update prescale counter value will reset internal 8-bit prescale counter and 24-bit up counter value.
+     * |[15]    |FUNCSEL   |Function Selection
+     * |        |          |0 = Timer controller is used as timer function.
+     * |        |          |1 = Timer controller is used as PWM function.
+     * |        |          |Note: When timer is used as PWM, the clock source of time controller will be forced to PCLKx automatically.
+     * |[19]    |INTRGEN   |Inter-timer Trigger Mode Enable Bit
+     * |        |          |Setting this bit will enable the inter-timer trigger capture function.
+     * |        |          |The Timer0/2 will be in event counter mode and counting with external clock source or event
+     * |        |          |Also, Timer1/3 will be in trigger-counting mode of capture function.
+     * |        |          |0 = Inter-Timer Trigger Capture mode Disabled.
+     * |        |          |1 = Inter-Timer Trigger Capture mode Enabled.
+     * |        |          |Note: For Timer1/3, this bit is ignored and the read back value is always 0.
+     * |[20]    |PERIOSEL  |Periodic Mode Behavior Selection Enable Bit
+     * |        |          |0 = The behavior selection in periodic mode is Disabled.
+     * |        |          |When user updates CMPDAT while timer is running in periodic mode,
+     * |        |          |CNT will be reset to default value.
+     * |        |          |1 = The behavior selection in periodic mode is Enabled.
+     * |        |          |When user update CMPDAT while timer is running in periodic mode, the limitations as bellows list,
+     * |        |          |If updated CMPDAT value > CNT, CMPDAT will be updated and CNT keep running continually.
+     * |        |          |If updated CMPDAT value = CNT, timer time-out interrupt will be asserted.
+     * |        |          |If updated CMPDAT value < CNT, CNT will be reset to default value.
+     * |[21]    |TGLPINSEL |Toggle-output Pin Select
+     * |        |          |0 = Toggle mode output to TMx (Timer Event Counter Pin).
+     * |        |          |1 = Toggle mode output to TMx_EXT (Timer External Capture Pin).
+     * |[22]    |CAPSRC    |Capture Pin Source Selection
+     * |        |          |0 = Capture Function source is from TMx_EXT (x= 0~3) pin.
+     * |        |          |1 = Capture Function source is from internal ACMP output signal, internal clock (MIRC, LIRC, HIRC), or external clock (HXT, LXT).
+     * |        |          |Note: When CAPSRC = 1, User can set INTERCAPSEL (TIMERx_EXTCTL[10:8]) to decide which internal ACMP output signal or which clock is as timer capture source.
+     * |[23]    |WKEN      |Wake-up Function Enable Bit
+     * |        |          |If this bit is set to 1, while timer interrupt flag TIF (TIMERx_INTSTS[0]) is 1 and INTEN (TIMERx_CTL[29]) is enabled, the timer interrupt signal will generate a wake-up trigger event to CPU.
+     * |        |          |0 = Wake-up function Disabled if timer interrupt signal generated.
+     * |        |          |1 = Wake-up function Enabled if timer interrupt signal generated.
+     * |[24]    |EXTCNTEN  |Event Counter Mode Enable Bit
+     * |        |          |This bit is for external counting pin function enabled.
+     * |        |          |0 = Event counter mode Disabled.
+     * |        |          |1 = Event counter mode Enabled.
+     * |        |          |Note: When timer is used as an event counter, this bit should be set to 1 and select PCLK as timer clock source.
+     * |[25]    |ACTSTS    |Timer Active Status Bit (Read Only)
+     * |        |          |This bit indicates the 24-bit up counter status.
+     * |        |          |0 = 24-bit up counter is not active.
+     * |        |          |1 = 24-bit up counter is active.
+     * |        |          |Note: This bit may active when CNT 0 transition to CNT 1.
+     * |[28:27] |OPMODE    |Timer Counting Mode Select
+     * |        |          |00 = The timer controller is operated in One-shot mode.
+     * |        |          |01 = The timer controller is operated in Periodic mode.
+     * |        |          |10 = The timer controller is operated in Toggle-output mode.
+     * |        |          |11 = The timer controller is operated in Continuous Counting mode.
+     * |[29]    |INTEN     |Timer Interrupt Enable Bit
+     * |        |          |0 = Timer time-out interrupt Disabled.
+     * |        |          |1 = Timer time-out interrupt Enabled.
+     * |        |          |Note: If this bit is enabled, when the timer time-out interrupt flag TIF is set to 1, the timer interrupt signal is generated and inform to CPU.
+     * |[30]    |CNTEN     |Timer Counting Enable Bit
+     * |        |          |0 = Stops/Suspends counting.
+     * |        |          |1 = Starts counting.
+     * |        |          |Note1: In stop status, and then set CNTEN to 1 will enable the 24-bit up counter to keep counting from the last stop counting value.
+     * |        |          |Note2: This bit is auto-cleared by hardware in one-shot mode (TIMER_CTL[28:27] = 00) when the timer time-out interrupt flag TIF (TIMERx_INTSTS[0]) is generated.
+     * |        |          |Note3: Set enable/disable this bit needs 2 * TMR_CLK period to become active, user can read ACTSTS (TIMERx_CTL[25]) to check enable/disable command is completed or not.
+     * |[31]    |ICEDEBUG  |ICE Debug Mode Acknowledge Disable Bit (Write Protect)
+     * |        |          |0 = ICE debug mode acknowledgement effects TIMER counting.
+     * |        |          |TIMER counter will be held while CPU is held by ICE.
+     * |        |          |1 = ICE debug mode acknowledgement Disabled.
+     * |        |          |TIMER counter will keep going no matter CPU is held by ICE or not.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var TIMER_T::CMP
+     * Offset: 0x04  Timer Comparator Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[23:0]  |CMPDAT    |Timer Comparator Value
+     * |        |          |CMPDAT is a 24-bit compared value register
+     * |        |          |When the internal 24-bit up counter value is equal to CMPDAT value, the TIF (TIMERx_INTSTS[0] Timer Interrupt Flag) will set to 1.
+     * |        |          |Time-out period = (Period of timer clock input) * (8-bit PSC + 1) * (24-bit CMPDAT).
+     * |        |          |Note1: Never write 0x0 or 0x1 in CMPDAT field, or the core will run into unknown state.
+     * |        |          |Note2: When timer is operating at continuous counting mode, the 24-bit up counter will keep counting continuously even if user writes a new value into CMPDAT field
+     * |        |          |But if timer is operating at other modes, the 24-bit up counter will restart counting from 0 and using newest CMPDAT value to be the timer compared value while user writes a new value into CMPDAT field.
+     * @var TIMER_T::INTSTS
+     * Offset: 0x08  Timer Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TIF       |Timer Interrupt Flag
+     * |        |          |This bit indicates the interrupt flag status of Timer while 24-bit timer up counter CNT (TIMERx_CNT[23:0]) value reaches to CMPDAT (TIMERx_CMP[23:0]) value.
+     * |        |          |0 = No effect.
+     * |        |          |1 = CNT value matches the CMPDAT value.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[1]     |TWKF      |Timer Wake-up Flag
+     * |        |          |This bit indicates the interrupt wake-up flag status of timer.
+     * |        |          |0 = Timer does not cause CPU wake-up.
+     * |        |          |1 = CPU wake-up from Idle or Power-down mode if timer time-out interrupt signal generated.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * @var TIMER_T::CNT
+     * Offset: 0x0C  Timer Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[23:0]  |CNT       |Timer Data Register
+     * |        |          |Read operation.
+     * |        |          |Read this register to get CNT value. For example:
+     * |        |          |If EXTCNTEN (TIMERx_CTL[24]) is 0, user can read CNT value for getting current 24-bit counter value.
+     * |        |          |If EXTCNTEN (TIMERx_CTL[24]) is 1, user can read CNT value for getting current 24-bit event input counter value.
+     * |        |          |Write operation.
+     * |        |          |Writing any value to this register will reset current CNT value to 0 and reload internal 8-bit prescale counter.
+     * |[31]    |RSTACT    |Timer Data Register Reset Active (Read Only)
+     * |        |          |This bit indicates if the counter reset operation active.
+     * |        |          |When user writes this CNT register, timer starts to reset its internal 24-bit timer up-counter to 0 and reload 8-bit pre-scale counter
+     * |        |          |At the same time, timer set this flag to 1 to indicate the counter reset operation is in progress
+     * |        |          |Once the counter reset operation done, timer clear this bit to 0 automatically.
+     * |        |          |0 = Reset operation is done.
+     * |        |          |1 = Reset operation triggered by writing TIMERx_CNT is in progress.
+     * @var TIMER_T::CAP
+     * Offset: 0x10  Timer Capture Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[23:0]  |CAPDAT    |Timer Capture Data Register
+     * |        |          |When CAPEN (TIMERx_EXTCTL[3]) bit is set, CAPFUNCS (TIMERx_EXTCTL[4]) bit is 0, and a transition on TMx_EXT pin matched the CAPEDGE (TIMERx_EXTCTL[14:12]) setting, CAPIF (TIMERx_EINTSTS[0]) will set to 1 and the current timer counter value CNT (TIMERx_CNT[23:0]) will be auto-loaded into this CAPDAT field.
+     * @var TIMER_T::EXTCTL
+     * Offset: 0x14  Timer External Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTPHASE  |Timer External Count Phase
+     * |        |          |This bit indicates the detection phase of external counting pin TMx (x= 0~3).
+     * |        |          |0 = A falling edge of external counting pin will be counted.
+     * |        |          |1 = A rising edge of external counting pin will be counted.
+     * |[3]     |CAPEN     |Timer Capture Enable Bit
+     * |        |          |This bit enables the capture input function.
+     * |        |          |0 =Capture source Disabled.
+     * |        |          |1 =Capture source Enabled.
+     * |        |          |Note: When CAPEN is 1, user can set INTERCAPSEL (TIMERx_EXTCTL [10:8]) to select capture source.
+     * |[4]     |CAPFUNCS  |Capture Function Selection
+     * |        |          |0 = External Capture Mode Enabled.
+     * |        |          |1 = External Reset Mode Enabled.
+     * |        |          |Note1: When CAPFUNCS is 0, transition on TMx_EXT (x= 0~3) pin is using to save current 24-bit timer counter value (CNT value) to CAPDAT field.
+     * |        |          |Note2: When CAPFUNCS is 1, transition on TMx_EXT (x= 0~3) pin is using to save current 24-bit timer counter value (CNT value) to CAPDAT field then CNT value will be reset immediately.
+     * |[5]     |CAPIEN    |Timer External Capture Interrupt Enable Bit
+     * |        |          |0 = TMx_EXT (x= 0~3) pin, ACMP, internal clock, or external clock detection Interrupt Disabled.
+     * |        |          |1 = TMx_EXT (x= 0~3) pin, ACMP, internal clock, or external clock detection Interrupt Enabled.
+     * |        |          |Note: CAPIEN is used to enable timer external interrupt
+     * |        |          |If CAPIEN enabled, timer will rise an interrupt when CAPIF (TIMERx_EINTSTS[0]) is 1.
+     * |        |          |For example, while CAPIEN = 1, CAPEN = 1, and CAPEDGE = 00, a 1 to 0 transition on the Tx_EXT (x= 0~3) pin, ACMP, internal clock, or external clock will cause the CAPIF to be set then the interrupt signal is generated and sent to NVIC to inform CPU.
+     * |[6]     |CAPDBEN   |Timer External Capture Pin De-bounce Enable Bit
+     * |        |          |0 = TMx_EXT (x= 0~3) pin de-bounce or ACMP output de-bounce Disabled.
+     * |        |          |1 = TMx_EXT (x= 0~3) pin de-bounce or ACMP output de-bounce Enabled.
+     * |        |          |Note: If this bit is enabled, the edge detection of TMx_EXT pin or ACMP output is detected with de-bounce circuit.
+     * |[7]     |CNTDBEN   |Timer Counter Pin De-bounce Enable Bit
+     * |        |          |0 = TMx (x= 0~3) pin de-bounce Disabled.
+     * |        |          |1 = TMx (x= 0~3) pin de-bounce Enabled.
+     * |        |          |Note: If this bit is enabled, the edge detection of TMx pin is detected with de-bounce circuit.
+     * |[10:8]  |INTERCAPSEL|Internal Capture Source Select
+     * |        |          |000 = Capture Function source is from internal ACMP0 output signal.
+     * |        |          |001 = Capture Function source is from internal ACMP1 output signal.
+     * |        |          |010 = Capture Function source is from HXT.
+     * |        |          |011 = Capture Function source is from LXT.
+     * |        |          |100 = Capture Function source is from HIRC.
+     * |        |          |101 = Capture Function source is from LIRC.
+     * |        |          |110 = Capture Function source is from MIRC.
+     * |        |          |111 = Reserved.
+     * |        |          |Note: these bits only available when CAPSRC (TIMERx_CTL[22]) is 1.
+     * |[14:12] |CAPEDGE   |Timer External Capture Pin Edge Detect
+     * |        |          |When first capture event is generated, the CNT (TIMERx_CNT[23:0]) will be reset to 0 and first CAPDAT (TIMERx_CAP[23:0]) should be to 0.
+     * |        |          |000 = Capture event occurred when detect falling edge transfer on TMx_EXT (x= 0~3) pin.
+     * |        |          |001 = Capture event occurred when detect rising edge transfer on TMx_EXT (x= 0~3) pin.
+     * |        |          |010 = Capture event occurred when detect both falling and rising edge transfer on TMx_EXT (x= 0~3) pin, and first capture event occurred at falling edge transfer.
+     * |        |          |011 = Capture event occurred when detect both rising and falling edge transfer on TMx_EXT (x= 0~3) pin, and first capture event occurred at rising edge transfer.
+     * |        |          |110 = First capture event occurred at falling edge, follows capture events are at rising edge transfer on TMx_EXT (x= 0~3) pin.
+     * |        |          |111 = First capture event occurred at rising edge, follows capture events are at falling edge transfer on TMx_EXT (x= 0~3) pin.
+     * |        |          |100, 101 = Reserved.
+     * |        |          |Note: Set CAPSRC (TIMERx_CTL[22]) and INTERCAPSEL (TIMERx_EXTCTL[10:8]) to select capture source.
+     * |[16]    |ECNTSSEL  |Event Counter Source Selection to Trigger Event Counter Function
+     * |        |          |0 = Event Counter input source is from TMx (x= 0~3) pin.
+     * |        |          |1 = Event Counter input source is from USB internal SOF output signal.
+     * |[31:28] |CAPDIVSCL |Timer Capture Source Divider Scale
+     * |        |          |This bits indicate the divide scale for capture source divider
+     * |        |          |0000 = Capture source/1.
+     * |        |          |0001 = Capture source/2.
+     * |        |          |0010 = Capture source/4.
+     * |        |          |0011 = Capture source/8.
+     * |        |          |0100 = Capture source/16.
+     * |        |          |0101 = Capture source/32.
+     * |        |          |0110 = Capture source/64.
+     * |        |          |0111 = Capture source/128.
+     * |        |          |1000 = Capture source/256.
+     * |        |          |1001~1111 = Reserved.
+     * |        |          |Note: Sets INTERCAPSEL (TIMERx_EXTCTL[10:8]) and CAPSRC (TIMERx_CTL[22]) to select capture source.
+     * @var TIMER_T::EINTSTS
+     * Offset: 0x18  Timer External Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CAPIF     |Timer External Capture Interrupt Flag
+     * |        |          |This bit indicates the timer external capture interrupt flag status.
+     * |        |          |0 = TMx_EXT (x= 0~3) pin, ACMP, internal clock, or external clock interrupt did not occur.
+     * |        |          |1 = TMx_EXT (x= 0~3) pin, ACMP, internal clock, or external clock interrupt occurred.
+     * |        |          |Note1: This bit is cleared by writing 1 to it.
+     * |        |          |Note2: When CAPEN (TIMERx_EXTCTL[3]) bit is set, CAPFUNCS (TIMERx_EXTCTL[4]) bit is 0, and a transition on Tx_EXT (x= 0~3) pin, ACMP, internal clock, or external clock matched the CAPEDGE (TIMERx_EXTCTL[2:1]) setting, this bit will set to 1 by hardware.
+     * |        |          |Note3: There is a new incoming capture event detected before CPU clearing the CAPIF status
+     * |        |          |If the above condition occurred, the Timer will keep register TIMERx_CAP unchanged and drop the new capture value.
+     * @var TIMER_T::TRGCTL
+     * Offset: 0x1C  Timer Trigger Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TRGSSEL   |Trigger Source Select Bit
+     * |        |          |This bit is used to select internal trigger source is form timer time-out interrupt signal or capture interrupt signal.
+     * |        |          |0 = Time-out interrupt signal is used to internal trigger PWM, PDMA, DAC, and EADC.
+     * |        |          |1 = Capture interrupt signal is used to internal trigger PWM, PDMA, DAC, and EADC.
+     * |[1]     |TRGPWM    |Trigger PWM/BPWM Enable Bit
+     * |        |          |If this bit is set to 1, each timer time-out event or capture event can be as PWM/BPWM counter clock source.
+     * |        |          |0 = Timer interrupt trigger PWM/BPWM Disabled.
+     * |        |          |1 = Timer interrupt trigger PWM/BPWM Enabled.
+     * |        |          |Note: If TRGSSEL (TIMERx_TRGCTL[0]) = 0, time-out interrupt signal as PWM/BPWM counter clock source.
+     * |        |          |If TRGSSEL (TIMERx_TRGCTL[0]) = 1, capture interrupt signal as PWM/BPWM counter clock source.
+     * |[2]     |TRGEADC   |Trigger EADC Enable Bit
+     * |        |          |If this bit is set to 1, each timer time-out event or capture event can be triggered EADC conversion.
+     * |        |          |0 = Timer interrupt trigger EADC Disabled.
+     * |        |          |1 = Timer interrupt trigger EADC Enabled.
+     * |        |          |Note: If TRGSSEL (TIMERx_TRGCTL[0]) = 0, time-out interrupt signal will trigger EADC conversion.
+     * |        |          |If TRGSSEL (TIMERx_TRGCTL[0]) = 1, capture interrupt signal will trigger ADC conversion.
+     * |[3]     |TRGDAC    |Trigger DAC Enable Bit
+     * |        |          |If this bit is set to 1, timer time-out interrupt or capture interrupt can be triggered DAC.
+     * |        |          |0 = Timer interrupt trigger DAC Disabled.
+     * |        |          |1 = Timer interrupt trigger DAC Enabled.
+     * |        |          |Note: If TRGSSEL (TIMERx_TRGCTL[0]) = 0, time-out interrupt signal will trigger DAC.
+     * |        |          |If TRGSSEL (TIMERx_TRGCTL[0]) = 1, capture interrupt signal will trigger DAC.
+     * |[4]     |TRGPDMA   |Trigger PDMA Enable Bit
+     * |        |          |If this bit is set to 1, each timer time-out event or capture event can be triggered PDMA transfer.
+     * |        |          |0 = Timer interrupt trigger PDMA Disabled.
+     * |        |          |1 = Timer interrupt trigger PDMA Enabled.
+     * |        |          |Note: If TRGSSEL (TIMERx_TRGCTL[0]) = 0, time-out interrupt signal will trigger PDMA transfer.
+     * |        |          |If TRGSSEL (TIMERx_TRGCTL[0]) = 1, capture interrupt signal will trigger PDMA transfer.
+     * @var TIMER_T::PWMCTL
+     * Offset: 0x40  Timer PWM Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTEN     |PWM Counter Enable Bit
+     * |        |          |0 = PWM counter and clock prescale Stop Running.
+     * |        |          |1 = PWM counter and clock prescale Start Running.
+     * |[3]     |CNTMODE   |PWM Counter Mode
+     * |        |          |0 = Auto-reload mode.
+     * |        |          |1 = One-shot mode.
+     * |[12]    |PWMINTWKEN|PWM Interrupt Wake-up Enable
+     * |        |          |If PWM interrupt occurs when chip is at power down mode, PWMINTWKEN can determine whether chip wake-up occurs or not.
+     * |        |          |0 = PWM interrupt wake-up disable.
+     * |        |          |1 = PWM interrupt wake-up enable.
+     * |[30]    |DBGHALT   |ICE Debug Mode Counter Halt (Write Protect)
+     * |        |          |If debug mode counter halt is enabled, PWM counter will keep current value until exit ICE debug mode.
+     * |        |          |0 = ICE debug mode counter halt disable.
+     * |        |          |1 = ICE debug mode counter halt enable.
+     * |        |          |Note: This bit is write protected. Refer toSYS_REGLCTL register.
+     * |[31]    |DBGTRIOFF |ICE Debug Mode Acknowledge Disable Bit (Write Protect)
+     * |        |          |0 = ICE debug mode acknowledgement effects PWM output.
+     * |        |          |PWM output pin will be forced as tri-state while ICE debug mode acknowledged.
+     * |        |          |1 = ICE debug mode acknowledgement disabled.
+     * |        |          |PWM output pin will keep output no matter ICE debug mode acknowledged or not.
+     * |        |          |Note: This bit is write protected. Refer toSYS_REGLCTL register.
+     * @var TIMER_T::PWMCLKPSC
+     * Offset: 0x44  Timer PWM Counter Clock Pre-scale Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CLKPSC    |PWM Counter Clock Pre-scale
+     * |        |          |The active clock of PWM counter is decided by counter clock prescale and divided by (CLKPSC + 1)
+     * |        |          |If CLKPSC is 0, then there is no scaling in PWM counter clock source.
+     * @var TIMER_T::PWMCNTCLR
+     * Offset: 0x48  Timer PWM Clear Counter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTCLR    |Clear PWM Counter Control Bit
+     * |        |          |It is automatically cleared by hardware.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Clear 16-bit PWM counter to 0x00000 in up count type.
+     * |        |          |Note: Timer peripheral clock source should be set as PCLK to ensure that this bit can automatically cleared by hardware.
+     * @var TIMER_T::PWMPERIOD
+     * Offset: 0x4C  Timer PWM Period Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |PERIOD    |PWM Period Register
+     * |        |          |In up count type: PWM counter counts from 0 to PERIOD, and restarts from 0.
+     * |        |          |In up count type:
+     * |        |          |PWM period time = (PERIOD + 1) * (CLKPSC + 1) * TMRx_PWMCLK.
+     * @var TIMER_T::PWMCMPDAT
+     * Offset: 0x50  Timer PWM Comparator Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CMP       |PWM Comparator Register
+     * |        |          |PWM CMP is used to compare with PWM CNT to generate PWM output waveform, interrupt events and trigger EADC, PDMA, and DAC starting converting.
+     * @var TIMER_T::PWMCNT
+     * Offset: 0x54  Timer PWM Counter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CNT       |PWM Counter Value Register (Read Only)
+     * |        |          |User can monitor CNT to know the current counter value in 16-bit period counter.
+     * @var TIMER_T::PWMPOLCTL
+     * Offset: 0x58  Timer PWM Pin Output Polar Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PINV      |PWMx Output Pin Polar Control Bit
+     * |        |          |The bit is used to control polarity state of PWMx_OUT pin.
+     * |        |          |0 = PWMx_OUT pin polar inverse Disabled.
+     * |        |          |1 = PWMx_OUT polar inverse Enabled.
+     * |        |          |Note: Sets POSEL (TIMERx_PWMPOCTL[8]) to select Tx or Tx_EXT as PWMx output pin.
+     * @var TIMER_T::PWMPOCTL
+     * Offset: 0x5C  Timer PWM Pin Output Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |POEN      |PWMx Output Pin Enable Bit
+     * |        |          |0 = PWMx_OUT pin at tri-state mode.
+     * |        |          |1 = PWMx_OUT pin in output mode.
+     * |        |          |Note: Sets POSEL (TIMERx_PWMPOCTL[8]) to select Tx or Tx_EXT as PWMx output pin.
+     * |[8]     |POSEL     |PWM Output Pin Select
+     * |        |          |0 = PWMx_OUT pin is Tx.
+     * |        |          |1 = PWMx_OUT pin is Tx_EXT.
+     * @var TIMER_T::PWMINTEN0
+     * Offset: 0x60  Timer PWM Interrupt Enable Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |PIEN      |PWM Period Point Interrupt Enable Bit
+     * |        |          |0 = Period point interrupt Disabled.
+     * |        |          |1 = Period point interrupt Enabled.
+     * |[2]     |CMPUIEN   |PWM Compare Up Count Interrupt Enable Bit
+     * |        |          |0 = Compare up count interrupt Disabled.
+     * |        |          |1 = Compare up count interrupt Enabled.
+     * @var TIMER_T::PWMINTSTS0
+     * Offset: 0x64  Timer PWM Interrupt Status Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |PIF       |PWM Period Point Interrupt Flag
+     * |        |          |This bit is set by hardware when TIMERx_PWM counter reaches PERIOD.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[2]     |CMPUIF    |PWM Compare Up Count Interrupt Flag
+     * |        |          |This bit is set by hardware when TIMERx_PWM counter in up count direction and reaches CMP.
+     * |        |          |Note1: If CMP equal to PERIOD, there is no CMPUIF flag in up count type.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * @var TIMER_T::PWMTRGCTL
+     * Offset: 0x68  Timer PWM Trigger Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |TRGSEL    |PWM Counter Event Source Select to Trigger Conversion
+     * |        |          |00 = Trigger conversion at period point (PIF).
+     * |        |          |01 = Trigger conversion at compare up count point (CMPUIF).
+     * |        |          |10 = Trigger conversion at period or compare up count point (PIF or CMPUIF).
+     * |        |          |11 = Reserved.
+     * |[7]     |PWMTRGEADC|PWM Counter Event Trigger EADC Conversion Enable Bit
+     * |        |          |0 = PWM counter event trigger EADC conversion Disabled.
+     * |        |          |1 = PWM counter event trigger EADC conversion Enabled.
+     * |        |          |Note: Set TRGSEL (TIMERx_PWMTRGCTL[1:0]) to select PWM trigger conversion source.
+     * |[8]     |PWMTRGDAC |PWM Counter Event Trigger DAC Conversion Enable Bit
+     * |        |          |If this bit is set to 1, PWM can trigger DAC conversion.
+     * |        |          |0 = PWM trigger DAC Disabled.
+     * |        |          |1 = PWM trigger DAC Enabled.
+     * |        |          |Note: Set TRGSEL (TIMERx_PWMTRGCTL[1:0]) to select PWM trigger conversion source.
+     * |[9]     |PWMTRGPDMA|PWM Counter Event Trigger PDMA Conversion Enable Bit
+     * |        |          |If this bit is set to 1, PWM can trigger PDMA conversion.
+     * |        |          |0 = PWM trigger PDMA Disabled.
+     * |        |          |1 = PWM trigger PDMA Enabled.
+     * |        |          |Note: Set TRGSEL (TIMERx_PWMTRGCTL[1:0]) to select PWM trigger conversion source.
+     * @var TIMER_T::PWMSTATUS
+     * Offset: 0x6C  Timer PWM Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CNTMAXF   |PWM Counter Equal to 0xFFFF Flag
+     * |        |          |0 = The PWM counter value never reached its maximum value 0xFFFF.
+     * |        |          |1 = The PWM counter value has reached its maximum value.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[8]     |PWMINTWKF |PWM Interrupt Wake-up Flag
+     * |        |          |0 = PWM interrupt wake-up is not occurred.
+     * |        |          |1 = PWM interrupt wake-up has occurred.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[16]    |EADCTRGF  |Trigger EADC Start Conversion Flag
+     * |        |          |0 = PWM counter event trigger EADC start conversion is not occurred.
+     * |        |          |1 = PWM counter event trigger EADC start conversion has occurred.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[17]    |DACTRGF   |Trigger DAC Start Conversion Flag
+     * |        |          |0 = PWM counter event trigger DAC start conversion is not occurred.
+     * |        |          |1 = PWM counter event trigger DAC start conversion has occurred.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[18]    |PDMATRGF  |Trigger PDMA Start Conversion Flag
+     * |        |          |0 = PWM counter event trigger PDMA start conversion is not occurred.
+     * |        |          |1 = PWM counter event trigger PDMA start conversion has occurred.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * @var TIMER_T::PWMPBUF
+     * Offset: 0x70  Timer PWM Period Buffer Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |PBUF      |PWM Period Buffer Register (Read Only)
+     * |        |          |Used as PERIOD active register.
+     * @var TIMER_T::PWMCMPBUF
+     * Offset: 0x74  Timer PWM Comparator Buffer Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |CMPBUF    |PWM Comparator Buffer Register (Read Only)
+     * |        |          |Used as CMP active register.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] Timer Control Register                                          */
+    __IO uint32_t CMP;                   /*!< [0x0004] Timer Comparator Register                                       */
+    __IO uint32_t INTSTS;                /*!< [0x0008] Timer Interrupt Status Register                                 */
+    __IO uint32_t CNT;                   /*!< [0x000c] Timer Data Register                                             */
+    __I  uint32_t CAP;                   /*!< [0x0010] Timer Capture Data Register                                     */
+    __IO uint32_t EXTCTL;                /*!< [0x0014] Timer External Control Register                                 */
+    __IO uint32_t EINTSTS;               /*!< [0x0018] Timer External Interrupt Status Register                        */
+    __IO uint32_t TRGCTL;                /*!< [0x001c] Timer Trigger Control Register                                  */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[8];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t PWMCTL;                /*!< [0x0040] Timer PWM Control Register                                      */
+    __IO uint32_t PWMCLKPSC;             /*!< [0x0044] Timer PWM Counter Clock Pre-scale Register                      */
+    __IO uint32_t PWMCNTCLR;             /*!< [0x0048] Timer PWM Clear Counter Register                                */
+    __IO uint32_t PWMPERIOD;             /*!< [0x004c] Timer PWM Period Register                                       */
+    __IO uint32_t PWMCMPDAT;             /*!< [0x0050] Timer PWM Comparator Register                                   */
+    __I  uint32_t PWMCNT;                /*!< [0x0054] Timer PWM Counter Register                                      */
+    __IO uint32_t PWMPOLCTL;             /*!< [0x0058] Timer PWM Pin Output Polar Control Register                     */
+    __IO uint32_t PWMPOCTL;              /*!< [0x005c] Timer PWM Pin Output Control Register                           */
+    __IO uint32_t PWMINTEN0;             /*!< [0x0060] Timer PWM Interrupt Enable Register 0                           */
+    __IO uint32_t PWMINTSTS0;            /*!< [0x0064] Timer PWM Interrupt Status Register 0                           */
+    __IO uint32_t PWMTRGCTL;             /*!< [0x0068] Timer PWM Trigger Control Register                              */
+    __IO uint32_t PWMSTATUS;             /*!< [0x006c] Timer PWM Status Register                                       */
+    __I  uint32_t PWMPBUF;               /*!< [0x0070] Timer PWM Period Buffer Register                                */
+    __I  uint32_t PWMCMPBUF;             /*!< [0x0074] Timer PWM Comparator Buffer Register                            */
+} TIMER_T;
+
+/**
+    @addtogroup TIMER_CONST TIMER Bit Field Definition
+    Constant Definitions for TIMER Controller
+@{ */
+
+#define TIMER_CTL_PSC_Pos                (0)                                               /*!< TIMER_T::CTL: PSC Position             */
+#define TIMER_CTL_PSC_Msk                (0xfful << TIMER_CTL_PSC_Pos)                     /*!< TIMER_T::CTL: PSC Mask                 */
+
+#define TIMER_CTL_FUNCSEL_Pos            (15)                                              /*!< TIMER_T::CTL: FUNCSEL Position         */
+#define TIMER_CTL_FUNCSEL_Msk            (0x1ul << TIMER_CTL_FUNCSEL_Pos)                  /*!< TIMER_T::CTL: FUNCSEL Mask             */
+
+#define TIMER_CTL_INTRGEN_Pos            (19)                                              /*!< TIMER_T::CTL: INTRGEN Position         */
+#define TIMER_CTL_INTRGEN_Msk            (0x1ul << TIMER_CTL_INTRGEN_Pos)                  /*!< TIMER_T::CTL: INTRGEN Mask             */
+
+#define TIMER_CTL_PERIOSEL_Pos           (20)                                              /*!< TIMER_T::CTL: PERIOSEL Position        */
+#define TIMER_CTL_PERIOSEL_Msk           (0x1ul << TIMER_CTL_PERIOSEL_Pos)                 /*!< TIMER_T::CTL: PERIOSEL Mask            */
+
+#define TIMER_CTL_TGLPINSEL_Pos          (21)                                              /*!< TIMER_T::CTL: TGLPINSEL Position       */
+#define TIMER_CTL_TGLPINSEL_Msk          (0x1ul << TIMER_CTL_TGLPINSEL_Pos)                /*!< TIMER_T::CTL: TGLPINSEL Mask           */
+
+#define TIMER_CTL_CAPSRC_Pos             (22)                                              /*!< TIMER_T::CTL: CAPSRC Position          */
+#define TIMER_CTL_CAPSRC_Msk             (0x1ul << TIMER_CTL_CAPSRC_Pos)                   /*!< TIMER_T::CTL: CAPSRC Mask              */
+
+#define TIMER_CTL_WKEN_Pos               (23)                                              /*!< TIMER_T::CTL: WKEN Position            */
+#define TIMER_CTL_WKEN_Msk               (0x1ul << TIMER_CTL_WKEN_Pos)                     /*!< TIMER_T::CTL: WKEN Mask                */
+
+#define TIMER_CTL_EXTCNTEN_Pos           (24)                                              /*!< TIMER_T::CTL: EXTCNTEN Position        */
+#define TIMER_CTL_EXTCNTEN_Msk           (0x1ul << TIMER_CTL_EXTCNTEN_Pos)                 /*!< TIMER_T::CTL: EXTCNTEN Mask            */
+
+#define TIMER_CTL_ACTSTS_Pos             (25)                                              /*!< TIMER_T::CTL: ACTSTS Position          */
+#define TIMER_CTL_ACTSTS_Msk             (0x1ul << TIMER_CTL_ACTSTS_Pos)                   /*!< TIMER_T::CTL: ACTSTS Mask              */
+
+#define TIMER_CTL_OPMODE_Pos             (27)                                              /*!< TIMER_T::CTL: OPMODE Position          */
+#define TIMER_CTL_OPMODE_Msk             (0x3ul << TIMER_CTL_OPMODE_Pos)                   /*!< TIMER_T::CTL: OPMODE Mask              */
+
+#define TIMER_CTL_INTEN_Pos              (29)                                              /*!< TIMER_T::CTL: INTEN Position           */
+#define TIMER_CTL_INTEN_Msk              (0x1ul << TIMER_CTL_INTEN_Pos)                    /*!< TIMER_T::CTL: INTEN Mask               */
+
+#define TIMER_CTL_CNTEN_Pos              (30)                                              /*!< TIMER_T::CTL: CNTEN Position           */
+#define TIMER_CTL_CNTEN_Msk              (0x1ul << TIMER_CTL_CNTEN_Pos)                    /*!< TIMER_T::CTL: CNTEN Mask               */
+
+#define TIMER_CTL_ICEDEBUG_Pos           (31)                                              /*!< TIMER_T::CTL: ICEDEBUG Position        */
+#define TIMER_CTL_ICEDEBUG_Msk           (0x1ul << TIMER_CTL_ICEDEBUG_Pos)                 /*!< TIMER_T::CTL: ICEDEBUG Mask            */
+
+#define TIMER_CMP_CMPDAT_Pos             (0)                                               /*!< TIMER_T::CMP: CMPDAT Position          */
+#define TIMER_CMP_CMPDAT_Msk             (0xfffffful << TIMER_CMP_CMPDAT_Pos)              /*!< TIMER_T::CMP: CMPDAT Mask              */
+
+#define TIMER_INTSTS_TIF_Pos             (0)                                               /*!< TIMER_T::INTSTS: TIF Position          */
+#define TIMER_INTSTS_TIF_Msk             (0x1ul << TIMER_INTSTS_TIF_Pos)                   /*!< TIMER_T::INTSTS: TIF Mask              */
+
+#define TIMER_INTSTS_TWKF_Pos            (1)                                               /*!< TIMER_T::INTSTS: TWKF Position         */
+#define TIMER_INTSTS_TWKF_Msk            (0x1ul << TIMER_INTSTS_TWKF_Pos)                  /*!< TIMER_T::INTSTS: TWKF Mask             */
+
+#define TIMER_CNT_CNT_Pos                (0)                                               /*!< TIMER_T::CNT: CNT Position             */
+#define TIMER_CNT_CNT_Msk                (0xfffffful << TIMER_CNT_CNT_Pos)                 /*!< TIMER_T::CNT: CNT Mask                 */
+
+#define TIMER_CNT_RSTACT_Pos             (31)                                              /*!< TIMER_T::CNT: RSTACT Position          */
+#define TIMER_CNT_RSTACT_Msk             (0x1ul << TIMER_CNT_RSTACT_Pos)                   /*!< TIMER_T::CNT: RSTACT Mask              */
+
+#define TIMER_CAP_CAPDAT_Pos             (0)                                               /*!< TIMER_T::CAP: CAPDAT Position          */
+#define TIMER_CAP_CAPDAT_Msk             (0xfffffful << TIMER_CAP_CAPDAT_Pos)              /*!< TIMER_T::CAP: CAPDAT Mask              */
+
+#define TIMER_EXTCTL_CNTPHASE_Pos        (0)                                               /*!< TIMER_T::EXTCTL: CNTPHASE Position     */
+#define TIMER_EXTCTL_CNTPHASE_Msk        (0x1ul << TIMER_EXTCTL_CNTPHASE_Pos)              /*!< TIMER_T::EXTCTL: CNTPHASE Mask         */
+
+#define TIMER_EXTCTL_CAPEN_Pos           (3)                                               /*!< TIMER_T::EXTCTL: CAPEN Position        */
+#define TIMER_EXTCTL_CAPEN_Msk           (0x1ul << TIMER_EXTCTL_CAPEN_Pos)                 /*!< TIMER_T::EXTCTL: CAPEN Mask            */
+
+#define TIMER_EXTCTL_CAPFUNCS_Pos        (4)                                               /*!< TIMER_T::EXTCTL: CAPFUNCS Position     */
+#define TIMER_EXTCTL_CAPFUNCS_Msk        (0x1ul << TIMER_EXTCTL_CAPFUNCS_Pos)              /*!< TIMER_T::EXTCTL: CAPFUNCS Mask         */
+
+#define TIMER_EXTCTL_CAPIEN_Pos          (5)                                               /*!< TIMER_T::EXTCTL: CAPIEN Position       */
+#define TIMER_EXTCTL_CAPIEN_Msk          (0x1ul << TIMER_EXTCTL_CAPIEN_Pos)                /*!< TIMER_T::EXTCTL: CAPIEN Mask           */
+
+#define TIMER_EXTCTL_CAPDBEN_Pos         (6)                                               /*!< TIMER_T::EXTCTL: CAPDBEN Position      */
+#define TIMER_EXTCTL_CAPDBEN_Msk         (0x1ul << TIMER_EXTCTL_CAPDBEN_Pos)               /*!< TIMER_T::EXTCTL: CAPDBEN Mask          */
+
+#define TIMER_EXTCTL_CNTDBEN_Pos         (7)                                               /*!< TIMER_T::EXTCTL: CNTDBEN Position      */
+#define TIMER_EXTCTL_CNTDBEN_Msk         (0x1ul << TIMER_EXTCTL_CNTDBEN_Pos)               /*!< TIMER_T::EXTCTL: CNTDBEN Mask          */
+
+#define TIMER_EXTCTL_INTERCAPSEL_Pos     (8)                                               /*!< TIMER_T::EXTCTL: INTERCAPSEL Position  */
+#define TIMER_EXTCTL_INTERCAPSEL_Msk     (0x7ul << TIMER_EXTCTL_INTERCAPSEL_Pos)           /*!< TIMER_T::EXTCTL: INTERCAPSEL Mask      */
+
+#define TIMER_EXTCTL_CAPEDGE_Pos         (12)                                              /*!< TIMER_T::EXTCTL: CAPEDGE Position      */
+#define TIMER_EXTCTL_CAPEDGE_Msk         (0x7ul << TIMER_EXTCTL_CAPEDGE_Pos)               /*!< TIMER_T::EXTCTL: CAPEDGE Mask          */
+
+#define TIMER_EXTCTL_ECNTSSEL_Pos        (16)                                              /*!< TIMER_T::EXTCTL: ECNTSSEL Position     */
+#define TIMER_EXTCTL_ECNTSSEL_Msk        (0x1ul << TIMER_EXTCTL_ECNTSSEL_Pos)              /*!< TIMER_T::EXTCTL: ECNTSSEL Mask         */
+
+#define TIMER_EXTCTL_CAPDIVSCL_Pos       (28)                                              /*!< TIMER_T::EXTCTL: CAPDIVSCL Position    */
+#define TIMER_EXTCTL_CAPDIVSCL_Msk       (0xful << TIMER_EXTCTL_CAPDIVSCL_Pos)             /*!< TIMER_T::EXTCTL: CAPDIVSCL Mask        */
+
+#define TIMER_EINTSTS_CAPIF_Pos          (0)                                               /*!< TIMER_T::EINTSTS: CAPIF Position       */
+#define TIMER_EINTSTS_CAPIF_Msk          (0x1ul << TIMER_EINTSTS_CAPIF_Pos)                /*!< TIMER_T::EINTSTS: CAPIF Mask           */
+
+#define TIMER_TRGCTL_TRGSSEL_Pos         (0)                                               /*!< TIMER_T::TRGCTL: TRGSSEL Position      */
+#define TIMER_TRGCTL_TRGSSEL_Msk         (0x1ul << TIMER_TRGCTL_TRGSSEL_Pos)               /*!< TIMER_T::TRGCTL: TRGSSEL Mask          */
+
+#define TIMER_TRGCTL_TRGPWM_Pos          (1)                                               /*!< TIMER_T::TRGCTL: TRGPWM Position       */
+#define TIMER_TRGCTL_TRGPWM_Msk          (0x1ul << TIMER_TRGCTL_TRGPWM_Pos)                /*!< TIMER_T::TRGCTL: TRGPWM Mask           */
+
+#define TIMER_TRGCTL_TRGEADC_Pos         (2)                                               /*!< TIMER_T::TRGCTL: TRGEADC Position      */
+#define TIMER_TRGCTL_TRGEADC_Msk         (0x1ul << TIMER_TRGCTL_TRGEADC_Pos)               /*!< TIMER_T::TRGCTL: TRGEADC Mask          */
+
+#define TIMER_TRGCTL_TRGDAC_Pos          (3)                                               /*!< TIMER_T::TRGCTL: TRGDAC Position       */
+#define TIMER_TRGCTL_TRGDAC_Msk          (0x1ul << TIMER_TRGCTL_TRGDAC_Pos)                /*!< TIMER_T::TRGCTL: TRGDAC Mask           */
+
+#define TIMER_TRGCTL_TRGPDMA_Pos         (4)                                               /*!< TIMER_T::TRGCTL: TRGPDMA Position      */
+#define TIMER_TRGCTL_TRGPDMA_Msk         (0x1ul << TIMER_TRGCTL_TRGPDMA_Pos)               /*!< TIMER_T::TRGCTL: TRGPDMA Mask          */
+
+#define TIMER_TRGCTL_TRGTK_Pos           (8)                                               /*!< TIMER_T::TRGCTL: TRGTK Position      */
+#define TIMER_TRGCTL_TRGTK_Msk           (0x1ul << TIMER_TRGCTL_TRGTK_Pos)                 /*!< TIMER_T::TRGCTL: TRGTK Mask          */
+
+#define TIMER_PWMCTL_CNTEN_Pos           (0)                                               /*!< TIMER_T::PWMCTL: CNTEN Position        */
+#define TIMER_PWMCTL_CNTEN_Msk           (0x1ul << TIMER_PWMCTL_CNTEN_Pos)                 /*!< TIMER_T::PWMCTL: CNTEN Mask            */
+
+#define TIMER_PWMCTL_CNTMODE_Pos         (3)                                               /*!< TIMER_T::PWMCTL: CNTMODE Position      */
+#define TIMER_PWMCTL_CNTMODE_Msk         (0x1ul << TIMER_PWMCTL_CNTMODE_Pos)               /*!< TIMER_T::PWMCTL: CNTMODE Mask          */
+
+#define TIMER_PWMCTL_PWMINTWKEN_Pos      (12)                                              /*!< TIMER_T::PWMCTL: PWMINTWKEN Position   */
+#define TIMER_PWMCTL_PWMINTWKEN_Msk      (0x1ul << TIMER_PWMCTL_PWMINTWKEN_Pos)            /*!< TIMER_T::PWMCTL: PWMINTWKEN Mask       */
+
+#define TIMER_PWMCTL_DBGHALT_Pos         (30)                                              /*!< TIMER_T::PWMCTL: DBGHALT Position      */
+#define TIMER_PWMCTL_DBGHALT_Msk         (0x1ul << TIMER_PWMCTL_DBGHALT_Pos)               /*!< TIMER_T::PWMCTL: DBGHALT Mask          */
+
+#define TIMER_PWMCTL_DBGTRIOFF_Pos       (31)                                              /*!< TIMER_T::PWMCTL: DBGTRIOFF Position    */
+#define TIMER_PWMCTL_DBGTRIOFF_Msk       (0x1ul << TIMER_PWMCTL_DBGTRIOFF_Pos)             /*!< TIMER_T::PWMCTL: DBGTRIOFF Mask        */
+
+#define TIMER_PWMCLKPSC_CLKPSC_Pos       (0)                                               /*!< TIMER_T::PWMCLKPSC: CLKPSC Position    */
+#define TIMER_PWMCLKPSC_CLKPSC_Msk       (0xfful << TIMER_PWMCLKPSC_CLKPSC_Pos)            /*!< TIMER_T::PWMCLKPSC: CLKPSC Mask        */
+
+#define TIMER_PWMCNTCLR_CNTCLR_Pos       (0)                                               /*!< TIMER_T::PWMCNTCLR: CNTCLR Position    */
+#define TIMER_PWMCNTCLR_CNTCLR_Msk       (0x1ul << TIMER_PWMCNTCLR_CNTCLR_Pos)             /*!< TIMER_T::PWMCNTCLR: CNTCLR Mask        */
+
+#define TIMER_PWMPERIOD_PERIOD_Pos       (0)                                               /*!< TIMER_T::PWMPERIOD: PERIOD Position    */
+#define TIMER_PWMPERIOD_PERIOD_Msk       (0xfffful << TIMER_PWMPERIOD_PERIOD_Pos)          /*!< TIMER_T::PWMPERIOD: PERIOD Mask        */
+
+#define TIMER_PWMCMPDAT_CMP_Pos          (0)                                               /*!< TIMER_T::PWMCMPDAT: CMP Position       */
+#define TIMER_PWMCMPDAT_CMP_Msk          (0xfffful << TIMER_PWMCMPDAT_CMP_Pos)             /*!< TIMER_T::PWMCMPDAT: CMP Mask           */
+
+#define TIMER_PWMCNT_CNT_Pos             (0)                                               /*!< TIMER_T::PWMCNT: CNT Position          */
+#define TIMER_PWMCNT_CNT_Msk             (0xfffful << TIMER_PWMCNT_CNT_Pos)                /*!< TIMER_T::PWMCNT: CNT Mask              */
+
+#define TIMER_PWMPOLCTL_PINV_Pos         (0)                                               /*!< TIMER_T::PWMPOLCTL: PINV Position      */
+#define TIMER_PWMPOLCTL_PINV_Msk         (0x1ul << TIMER_PWMPOLCTL_PINV_Pos)               /*!< TIMER_T::PWMPOLCTL: PINV Mask          */
+
+#define TIMER_PWMPOCTL_POEN_Pos          (0)                                               /*!< TIMER_T::PWMPOCTL: POEN Position       */
+#define TIMER_PWMPOCTL_POEN_Msk          (0x1ul << TIMER_PWMPOCTL_POEN_Pos)                /*!< TIMER_T::PWMPOCTL: POEN Mask           */
+
+#define TIMER_PWMPOCTL_POSEL_Pos         (8)                                               /*!< TIMER_T::PWMPOCTL: POSEL Position      */
+#define TIMER_PWMPOCTL_POSEL_Msk         (0x1ul << TIMER_PWMPOCTL_POSEL_Pos)               /*!< TIMER_T::PWMPOCTL: POSEL Mask          */
+
+#define TIMER_PWMINTEN0_PIEN_Pos         (1)                                               /*!< TIMER_T::PWMINTEN0: PIEN Position      */
+#define TIMER_PWMINTEN0_PIEN_Msk         (0x1ul << TIMER_PWMINTEN0_PIEN_Pos)               /*!< TIMER_T::PWMINTEN0: PIEN Mask          */
+
+#define TIMER_PWMINTEN0_CMPUIEN_Pos      (2)                                               /*!< TIMER_T::PWMINTEN0: CMPUIEN Position   */
+#define TIMER_PWMINTEN0_CMPUIEN_Msk      (0x1ul << TIMER_PWMINTEN0_CMPUIEN_Pos)            /*!< TIMER_T::PWMINTEN0: CMPUIEN Mask       */
+
+#define TIMER_PWMINTSTS0_PIF_Pos         (1)                                               /*!< TIMER_T::PWMINTSTS0: PIF Position      */
+#define TIMER_PWMINTSTS0_PIF_Msk         (0x1ul << TIMER_PWMINTSTS0_PIF_Pos)               /*!< TIMER_T::PWMINTSTS0: PIF Mask          */
+
+#define TIMER_PWMINTSTS0_CMPUIF_Pos      (2)                                               /*!< TIMER_T::PWMINTSTS0: CMPUIF Position   */
+#define TIMER_PWMINTSTS0_CMPUIF_Msk      (0x1ul << TIMER_PWMINTSTS0_CMPUIF_Pos)            /*!< TIMER_T::PWMINTSTS0: CMPUIF Mask       */
+
+#define TIMER_PWMTRGCTL_TRGSEL_Pos       (0)                                               /*!< TIMER_T::PWMTRGCTL: TRGSEL Position    */
+#define TIMER_PWMTRGCTL_TRGSEL_Msk       (0x3ul << TIMER_PWMTRGCTL_TRGSEL_Pos)             /*!< TIMER_T::PWMTRGCTL: TRGSEL Mask        */
+
+#define TIMER_PWMTRGCTL_PWMTRGEADC_Pos   (7)                                               /*!< TIMER_T::PWMTRGCTL: PWMTRGEADC Position*/
+#define TIMER_PWMTRGCTL_PWMTRGEADC_Msk   (0x1ul << TIMER_PWMTRGCTL_PWMTRGEADC_Pos)         /*!< TIMER_T::PWMTRGCTL: PWMTRGEADC Mask    */
+
+#define TIMER_PWMTRGCTL_PWMTRGDAC_Pos    (8)                                               /*!< TIMER_T::PWMTRGCTL: PWMTRGDAC Position */
+#define TIMER_PWMTRGCTL_PWMTRGDAC_Msk    (0x1ul << TIMER_PWMTRGCTL_PWMTRGDAC_Pos)          /*!< TIMER_T::PWMTRGCTL: PWMTRGDAC Mask     */
+
+#define TIMER_PWMTRGCTL_PWMTRGPDMA_Pos   (9)                                               /*!< TIMER_T::PWMTRGCTL: PWMTRGPDMA Position*/
+#define TIMER_PWMTRGCTL_PWMTRGPDMA_Msk   (0x1ul << TIMER_PWMTRGCTL_PWMTRGPDMA_Pos)         /*!< TIMER_T::PWMTRGCTL: PWMTRGPDMA Mask    */
+
+#define TIMER_PWMSTATUS_CNTMAXF_Pos      (0)                                               /*!< TIMER_T::PWMSTATUS: CNTMAXF Position   */
+#define TIMER_PWMSTATUS_CNTMAXF_Msk      (0x1ul << TIMER_PWMSTATUS_CNTMAXF_Pos)            /*!< TIMER_T::PWMSTATUS: CNTMAXF Mask       */
+
+#define TIMER_PWMSTATUS_PWMINTWKF_Pos    (8)                                               /*!< TIMER_T::PWMSTATUS: PWMINTWKF Position */
+#define TIMER_PWMSTATUS_PWMINTWKF_Msk    (0x1ul << TIMER_PWMSTATUS_PWMINTWKF_Pos)          /*!< TIMER_T::PWMSTATUS: PWMINTWKF Mask     */
+
+#define TIMER_PWMSTATUS_EADCTRGF_Pos     (16)                                              /*!< TIMER_T::PWMSTATUS: EADCTRGF Position  */
+#define TIMER_PWMSTATUS_EADCTRGF_Msk     (0x1ul << TIMER_PWMSTATUS_EADCTRGF_Pos)           /*!< TIMER_T::PWMSTATUS: EADCTRGF Mask      */
+
+#define TIMER_PWMSTATUS_DACTRGF_Pos      (17)                                              /*!< TIMER_T::PWMSTATUS: DACTRGF Position   */
+#define TIMER_PWMSTATUS_DACTRGF_Msk      (0x1ul << TIMER_PWMSTATUS_DACTRGF_Pos)            /*!< TIMER_T::PWMSTATUS: DACTRGF Mask       */
+
+#define TIMER_PWMSTATUS_PDMATRGF_Pos     (18)                                              /*!< TIMER_T::PWMSTATUS: PDMATRGF Position  */
+#define TIMER_PWMSTATUS_PDMATRGF_Msk     (0x1ul << TIMER_PWMSTATUS_PDMATRGF_Pos)           /*!< TIMER_T::PWMSTATUS: PDMATRGF Mask      */
+
+#define TIMER_PWMPBUF_PBUF_Pos           (0)                                               /*!< TIMER_T::PWMPBUF: PBUF Position        */
+#define TIMER_PWMPBUF_PBUF_Msk           (0xfffful << TIMER_PWMPBUF_PBUF_Pos)              /*!< TIMER_T::PWMPBUF: PBUF Mask            */
+
+#define TIMER_PWMCMPBUF_CMPBUF_Pos       (0)                                               /*!< TIMER_T::PWMCMPBUF: CMPBUF Position    */
+#define TIMER_PWMCMPBUF_CMPBUF_Msk       (0xfffful << TIMER_PWMCMPBUF_CMPBUF_Pos)          /*!< TIMER_T::PWMCMPBUF: CMPBUF Mask        */
+
+/** @} TIMER_CONST */
+/** @} end of TIMER register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __TIMER_REG_H__ */

--- a/hal/m258ke/nuvoton/tk_reg.h
+++ b/hal/m258ke/nuvoton/tk_reg.h
@@ -1,0 +1,1771 @@
+/**************************************************************************//**
+ * @file     tk_reg.h
+ * @version  V1.00
+ * @brief    Touch key register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __TK_REG_H__
+#define __TK_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup TK Touch Key (TK)
+    Memory Mapped Structure for TK Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var TK_T::SCANC
+     * Offset: 0x00  Touch Key Scan Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TK0SEN    |TK0 Scan Enable
+     * |        |          |This bit is ignored if TK0REN (TK_REFC[0]) is “1” except SCAN_ALL (TK_REFC[23]) is “1”.
+     * |        |          |0 = TKDAT0 (TK_DAT0[7:0])TK0_DATA is invalid.
+     * |        |          |1 = TK0 is always enable for Touch Key scan. TKDAT0 (TK_DAT0[7:0])TK0_DATA is valid.
+     * |[1]     |TK1SEN    |TK1 Scan Enable
+     * |        |          |This bit is ignored if TK1REN (TK_REFC[1]) is “1”.
+     * |        |          |0 = TKDAT1 (TK_DAT0[15:8])TK1_DATA is invalid.
+     * |        |          |1 = TK1 is always enable for Touch Key scan. TKDAT1 (TK_DAT0[15:8])TK1_DATA is valid.
+     * |[2]     |TK2SEN    |TK2 Scan Enable
+     * |        |          |This bit is ignored if TK2REN (TK_REFC[2]) is “1”.
+     * |        |          |0 = TKDAT2 (TK_DAT0[23:16])TK2_DATA is invalid.
+     * |        |          |1 = TK2 is always enable for Touch Key scan. TKDAT2 (TK_DAT0[23:16])TK2_DATA is valid.
+     * |[3]     |TK3SEN    |TK3 Scan Enable
+     * |        |          |0 = TKDAT3 (TK_DAT0[31:24])TK3_DATA is invalid.
+     * |        |          |1 = TK3 is always enable for Touch Key scan. TKDAT3 (TK_DAT0[31:24])TK3_DATA is valid.
+     * |        |          |This bit is ignored if TK3REN (TK_REFC[3]) is “1”.
+     * |[4]     |TK4SEN    |TK4 Scan Enable
+     * |        |          |This bit is ignored if TK4REN (TK_REFC[4]) is “1”.
+     * |        |          |0 = TKDAT4 (TK_DAT1[7:0])TK4_DATA is invalid.
+     * |        |          |1 = TK4 is always enable for Touch Key scan. TKDAT4 (TK_DAT1[7:0])TK4_DATA is valid.
+     * |[5]     |TK5SEN    |TK5 Scan Enable
+     * |        |          |This bit is ignored if TK5REN (TK_REFC[5]) is “1”.
+     * |        |          |0 = TKDAT5 (TK_DAT1[15:8])TK5_DATA is invalid.
+     * |        |          |1 = TK5 is always enable for Touch Key scan. TKDAT5 (TK_DAT1[15:8])TK5_DATA is valid.
+     * |[6]     |TK6SEN    |TK6 Scan Enable
+     * |        |          |This bit is ignored if TK6REN (TK_REFC[6]) is “1”.
+     * |        |          |0 = TKDAT6 (TK_DAT1[23:16])TK6_DATA is invalid.
+     * |        |          |1 = TK6 is always enable for Touch Key scan. TKDAT6 (TK_DAT1[23:16])TK6_DATA is valid.
+     * |[7]     |TK7SEN    |TK7 Scan Enable
+     * |        |          |This bit is ignored if TK7REN (TK_REFC[7]) is “1”.
+     * |        |          |0 = TKDAT7 (TK_DAT1[31:24])TK7_DATA is invalid.
+     * |        |          |1 = TK7 is always enable for Touch Key scan. TKDAT7 (TK_DAT1[31:24])TK7_DATA is valid.
+     * |[8]     |TK8SEN    |TK8 Scan Enable
+     * |        |          |This bit is ignored if TK8REN (TK_REFC[8]) is “1”.
+     * |        |          |0 = TKDAT8 (TK_DAT2[7:0])TK8_DATA is invalid.
+     * |        |          |1 = TK8 is always enable for Touch Key scan. TKDAT8 (TK_DAT2[7:0])TK8_DATA is valid.
+     * |[9]     |TK9SEN    |TK9 Scan Enable
+     * |        |          |This bit is ignored if TK9REN (TK_REFC[9]) is “1”.
+     * |        |          |0 = TKDAT9 (TK_DAT2[15:8])TK9_DATA is invalid.
+     * |        |          |1 = TK9 is always enable for Touch Key scan. TKDAT9 (TK_DAT2[15:8])TK9_DATA is valid.
+     * |[10]    |TK10SEN   |TK10 Scan Enable
+     * |        |          |This bit is ignored if TK10REN (TK_REFC[10]) is “1”.
+     * |        |          |0 = TKDAT10 (TK_DAT2[23:16])TK10_DATA is invalid.
+     * |        |          |1 = TK10 is always enable for Touch Key scan. TKDAT10 (TK_DAT2[23:16])TK10_DATA is valid.
+     * |[11]    |TK11SEN   |TK11 Scan Enable
+     * |        |          |This bit is ignored if TK11REN (TK_REFC[11]) is “1”.
+     * |        |          |0 = TKDAT11 (TK_DAT2[31:24])TK11_DATA is invalid.
+     * |        |          |1 = TK11 is always enable for Touch Key scan. TKDAT11 (TK_DAT2[31:24])TK11_DATA is valid.
+     * |[12]    |TK12SEN   |TK12 Scan Enable
+     * |        |          |This bit is ignored if TK12REN (TK_REFC[12]) is “1”.
+     * |        |          |0 = TKDAT12 (TK_DAT3[7:0])TK12_DATA is invalid.
+     * |        |          |1 = TK12 is always enable for Touch Key scan. TKDAT12 (TK_DAT3[7:0])TK12_DATA is valid.
+     * |[13]    |TK13SEN   |TK13 Scan Enable
+     * |        |          |This bit is ignored if TK13REN (TK_REFC[13]) is “1”.
+     * |        |          |0 = TKDAT13 (TK_DAT3[15:8])TK13_DATA is invalid.
+     * |        |          |1 = TK13 is always enable for Touch key scan. TKDAT13 (TK_DAT3[15:8])TK13_DATA is valid.
+     * |[14]    |TK14SEN   |TK14 Scan Enable
+     * |        |          |This bit is ignored if TK14REN (TK_REFC[14]) is “1”.
+     * |        |          |0 = TKDAT14 (TK_DAT3[23:16])TK14_DATA is invalid.
+     * |        |          |1 = TK14 is always enabled for Touch key scan. TKDAT14 (TK_DAT3[23:16])TK14_DATA is valid.
+     * |[15]    |TK15SEN   |TK15 Scan Enable
+     * |        |          |This bit is ignored if TK15REN (TK_REFC[15]) is “1”.
+     * |        |          |0 = TKDAT15 (TK_DAT3[31:24])TK15_DATA is invalid.
+     * |        |          |1 = TK15 is always enabled for kTouch Key scan. TTKDAT15 (TK_DAT3[31:24])K15_DATA is valid.
+     * |[16]    |TK16SEN   |TK16 Scan Enable
+     * |        |          |This bit is ignored if TK16REN (TK_REFC[16]) is “1”.
+     * |        |          |0 = TKDAT16 (TK_DAT4[7:0])16_DATA is invalid.
+     * |        |          |1 = TK16 is always enabled for kTouch Key scan. TKDAT16 (TK_DAT4[7:0])TK16_DATA is valid.
+     * |[23:20] |AVDDH_S   |AVCCHAVDDH Voltage Select
+     * |        |          |0000 = 1/16 VDD.
+     * |        |          |0001 = 1/8 VDD.
+     * |        |          |0010 = 3/16 VDD.
+     * |        |          |0011 = 1/4 VDD.
+     * |        |          |0100 = 5/16 VDD.
+     * |        |          |0101 = 3/8 VDD.
+     * |        |          |0110 = 7/16 VDD.
+     * |        |          |0111 = 1/2 VDD.
+     * |        |          |1000 = 1/32 VDD.
+     * |        |          |1001 = 1/16 VDD.
+     * |        |          |1010 = 3/32 VDD.
+     * |        |          |1011 = 1/8 VDD.
+     * |        |          |1100 = 5/32 VDD.
+     * |        |          |1101 = 3/16 VDD.
+     * |        |          |1110 = 7/32 VDD.
+     * |        |          |1111 = 1/4 VDD.
+     * |[24]    |SCAN      |Scan
+     * |        |          |Write an “1’ to this bit will immediately initiate key scan on all channels which are enabled.
+     * |        |          |This bit will be self-cleared after key scan started.
+     * |[25]    |TMRTRG_EN |Timer Trigger Enable
+     * |        |          |0 = Disable timer to trigger key scan.
+     * |        |          |1 = Enable timer triggers key scan periodically
+     * |        |          |Touch KKey scan will be initiated by timer periodically.
+     * |[31]    |TK_EN     |Touch Key Scan Enable Bit
+     * |        |          |0 = Disable Touch Key Function.
+     * |        |          |1 = Enable Touch Key Function.
+     * @var TK_T::REFC
+     * Offset: 0x04  Touch Key Reference Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TK0REN    |TK0 Reference Enable
+     * |        |          |0 = TK0 is not reference.
+     * |        |          |1 = TK0 is set as reference, and TKDAT0 (TK_DAT0[7:0])TK0_DATA is invalid
+     * |[1]     |TK1REN    |TK1 Reference Enable
+     * |        |          |0 = TK1 is not reference.
+     * |        |          |1 = TK1 is set as reference, and TKDAT1 (TK_DAT0[15:8])TK1_DATA is invalid.
+     * |[2]     |TK2REN    |TK2 Reference Enable
+     * |        |          |0 = TK2 is not reference.
+     * |        |          |1 = TK2 is set as reference, and TKDAT2 (TK_DAT0[23:16])TK2_DATA is invalid.
+     * |[3]     |TK3REN    |TK3 Reference Enable
+     * |        |          |0 = TK3 is not reference.
+     * |        |          |1 = TK3 is set as reference, and TKDAT3 (TK_DAT0[31:24])TK3_DATA is invalid.
+     * |[4]     |TK4REN    |TK4 Reference Enable
+     * |        |          |0 = TK4 is not reference.
+     * |        |          |1 = TK4 is set as reference, and TKDAT4 (TK_DAT1[7:0])TK4_DATA is invalid.
+     * |[5]     |TK5REN    |TK5 Reference Enable
+     * |        |          |0 = TK5 is not reference.
+     * |        |          |1 = TK5 is set as reference, and TKDAT5 (TK_DAT1[15:8])TK5_DATA is invalid.
+     * |[6]     |TK6REN    |TK6 Reference Enable
+     * |        |          |0 = TK6 is not reference.
+     * |        |          |1 = TK6 is set as reference, and TKDAT6 (TK_DAT1[23:16])TK6_DATA is invalid.
+     * |[7]     |TK7REN    |TK7 Reference Enable
+     * |        |          |0 = TK7 is not reference.
+     * |        |          |1 = TK7 is set as reference, and TKDAT7 (TK_DAT1[31:24])TK7_DATA is invalid.
+     * |[8]     |TK8REN    |TK8 Reference Enable
+     * |        |          |0 = TK8 is not reference.
+     * |        |          |1 = TK8 is set as reference, and TKDAT8 (TK_DAT2[7:0])TK8_DATA is invalid.
+     * |[9]     |TK9REN    |TK9 Reference Enable
+     * |        |          |0 = TK9 is not reference.
+     * |        |          |1 = TK9 is set as reference, and TKDAT9 (TK_DAT2[15:8])TK9_DATA is invalid.
+     * |[10]    |TK10REN   |TK10 Reference Enable
+     * |        |          |0 = TK10 is not reference.
+     * |        |          |1 = TK10 is set as reference, and TKDAT10 (TK_DAT2[23:16])TK10_DATA is invalid.
+     * |[11]    |TK11REN   |TK11 Reference Enable
+     * |        |          |0 = TK11 is not reference.
+     * |        |          |1 = TK11 is set as reference, and TKDAT11 (TK_DAT2[31:24])TK11_DATA is invalid.
+     * |[12]    |TK12REN   |TK12 Reference Enable
+     * |        |          |0 = TK12 is not reference.
+     * |        |          |1 = TK12 is set as reference, and TKDAT12 (TK_DAT3[7:0])TK12_DATA is invalid.
+     * |[13]    |TK13REN   |TK13 Reference Enable
+     * |        |          |0 = TK13 is not reference.
+     * |        |          |1 = TK13 is set as reference, and TKDAT13 (TK_DAT3[15:8])TK13_DATA is invalid.
+     * |[14]    |TK14REN   |TK14 Reference Enable
+     * |        |          |0 = TK14 is not reference.
+     * |        |          |1 = TK14 is set as reference, and TKDAT14 (TK_DAT3[23:16])TK14_DATA is invalid.
+     * |[15]    |TK15REN   |TK15 Reference Enable
+     * |        |          |0 = TK15 is not reference.
+     * |        |          |1 = TK15 is set as reference, and TKDAT15 (TK_DAT3[31:24])TK15_DATA is invalid.
+     * |[16]    |TK16REN   |TK16 Reference Enable
+     * |        |          |0 = TK16 is not reference.
+     * |        |          |1 = TK16 is set as reference, and TKDAT16 (TK_DAT4[7:0])TK16_DATA is invalid.
+     * |        |          |Note: This bit is forced to “1” automatically if none is set as reference.
+     * |[23]    |SCAN_ALL  |All Keys Scan Enable
+     * |        |          |This function is used for low power key scanning operation
+     * |        |          |TKDAT_ALL0 (TK_DAT40[157:80]) is the only one valid data when key scan is complete.
+     * |        |          |0 = Disable All Keys Scan function.
+     * |        |          |1 = Enable All Keys Scan function
+     * |        |          |This function is used for low power key scanning operation
+     * |        |          |TK0_DATA is the only one valid data when key scan is complete.
+     * |[26:24] |SENSET    |Touch Key Sensing Time Control
+     * |        |          |000 = 128 x PULSET.
+     * |        |          |001 = 255 x PULSET.
+     * |        |          |010 = 5111023 x PULSET.
+     * |        |          |011 = 10232047 x PULSET.
+     * |        |          |100 = 8 x PULSET.
+     * |        |          |101 = 16 x PULSET.
+     * |        |          |110 = 32 x PULSET.
+     * |        |          |111 = 64 x PULSET.
+     * |[30:28] |PULSET    |Touch Key Sensing Pulse Width Time Control
+     * |        |          |000 = 1us.
+     * |        |          |001 = 2us.
+     * |        |          |010 = 4us.
+     * |        |          |011 = 8us.
+     * |        |          |100 = Reserved.
+     * |        |          |101 = Reserved.
+     * |        |          |110 = 250ns.
+     * |        |          |111 = 500ns.
+     * @var TK_T::CCBD0
+     * Offset: 0x08  Touch Key Complement Capacitor Bank Data Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CCBD0     |TK0 Complement CB Data
+     * |        |          |This is register is used for TK0 sensitivity adjustment.
+     * |[15:8]  |CCBD1     |TK1 Complement CB Data
+     * |        |          |This is register is used for TK1 sensitivity adjustment.
+     * |[23:16] |CCBD2     |TK2 Complement CB Data
+     * |        |          |This is register is used for TK2 sensitivity adjustment.
+     * |[31:24] |CCBD3     |TK3 Complement CB Data
+     * |        |          |This is register is used for TK3 sensitivity adjustment.
+     * @var TK_T::CCBD1
+     * Offset: 0x0C  Touch Key Complement Capacitor Bank Data Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CCBD4     |TK4 Complement CB Data
+     * |        |          |This is register is used for TK4 sensitivity adjustment.
+     * |[15:8]  |CCBD5     |TK5 Complement CB Data
+     * |        |          |This is register is used for TK5 sensitivity adjustment.
+     * |[23:16] |CCBD6     |TK6 Complement CB Data
+     * |        |          |This is register is used for TK6 sensitivity adjustment.
+     * |[31:24] |CCBD7     |TK7 Complement CB Data
+     * |        |          |This is register is used for TK7 sensitivity adjustment.
+     * @var TK_T::CCBD2
+     * Offset: 0x10  Touch Key Complement Capacitor Bank Data Register 2
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CCBD8     |TK8 Complement CB Data
+     * |        |          |This is register is used for TK8 sensitivity adjustment.
+     * |[15:8]  |CCBD9     |TK9 Complement CB Data
+     * |        |          |This is register is used for TK9 sensitivity adjustment.
+     * |[23:16] |CCBD10    |TK10 Complement CB Data
+     * |        |          |This is register is used for TK10 sensitivity adjustment.
+     * |[31:24] |CCBD11    |TK11 Complement CB Data
+     * |        |          |This is register is used for TK11 sensitivity adjustment.
+     * @var TK_T::CCBD3
+     * Offset: 0x14  Touch Key Complement Capacitor Bank Data Register 3
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CCBD12    |TK12 Complement CB Data
+     * |        |          |This is register is used for TK12 sensitivity adjustment.
+     * |[15:8]  |CCBD13    |TK13 Complement CB Data
+     * |        |          |This is register is used for TK13 sensitivity adjustment.
+     * |[23:16] |CCBD14    |TK14 Complement CB Data
+     * |        |          |This is register is used for TK14 sensitivity adjustment.
+     * |[31:24] |CCBD15    |TK15 Complement CB Data
+     * |        |          |This is register is used for TK15 sensitivity adjustment.
+     * @var TK_T::CCBD4
+     * Offset: 0x18  Touch Key Complement Capacitor Bank Data Register 4
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CCBD16    |TK16 Complement CB Data
+     * |        |          |This is register is used for TK16 sensitivity adjustment.
+     * |[15:8]  |CCBD_ALL  |All Keys Scan Complement CB Data
+     * |        |          |This is register is used for All Key Scan sensitivity adjustment.
+     * @var TK_T::IDLSC
+     * Offset: 0x1C  Touch Key Idle State Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |IDLS0     |TK0 Idle State Control
+     * |        |          |This register is ignored if both TK0SEN (TK_SCANC[0]) and POLEN0 (TK_POLC[8]) are “0” or TK0REN (TK_REFC[0]) is “1”.
+     * |        |          |00 = TK0 connected to Gnd.
+     * |        |          |01 = TK0 connected to AVCCHAVDDH.
+     * |        |          |10 = TK0 connected to VDD.
+     * |        |          |11 = TK0 connected to VDD.
+     * |[3:2]   |IDLS1     |TK1 Idle State Control
+     * |        |          |This register is ignored if both TK1SEN (TK_SCANC[1]) and POLEN1 (TK_POLC[9]) are “0” or TK1REN (TK_REFC[1]) is “1”.
+     * |        |          |00 = TK1 connected to Gnd.
+     * |        |          |01 = TK1 connected to AVCCHAVDDH.
+     * |        |          |10 = TK1 connected to VDD.
+     * |        |          |11 = TK1 connected to VDD.
+     * |[5:4]   |IDLS2     |TK2 Idle State Control
+     * |        |          |This register is ignored if both TK2SEN (TK_SCANC[2]) and POLEN2 (TK_POLC[10]) are “0” or TK2REN (TK_REFC[2]) is “1”.
+     * |        |          |00 = TK2 connected to Gnd.
+     * |        |          |01 = TK2 connected to AVCCHAVDDH.
+     * |        |          |10 = TK2 connected to VDD.
+     * |        |          |11 = TK2 connected to VDD.
+     * |[7:6]   |IDLS3     |TK3 Idle State Control
+     * |        |          |This register is ignored if both TK3SEN (TK_SCANC[3]) and POLEN3 (TK_POLC[11]) are “0” or TK3REN (TK_REFC[3]) is “1”.
+     * |        |          |00 = TK3 connected to Gnd.
+     * |        |          |01 = TK3 connected to AVCCHAVDDH.
+     * |        |          |10 = TK3 connected to VDD.
+     * |        |          |11 = TK3 connected to VDD.
+     * |[9:8]   |IDLS4     |TK4 Idle State Control
+     * |        |          |This register is ignored if both TK4SEN (TK_SCANC[4]) and POLEN4 (TK_POLC[12]) are “0” or TK4REN (TK_REFC[4]) is “1”.
+     * |        |          |00 = TK4 connected to Gnd.
+     * |        |          |01 = TK4 connected to AVCCHAVDDH.
+     * |        |          |10 = TK4 connected to VDD.
+     * |        |          |11 = TK4 connected to VDD.
+     * |[11:10] |IDLS5     |TK5 Idle State Control
+     * |        |          |This register is ignored if both TK5SEN (TK_SCANC[5]) and POLEN5 (TK_POLC[13]) are “0” or TK5REN (TK_REFC[5]) is “1”.
+     * |        |          |00 = TK5 connected to Gnd.
+     * |        |          |01 = TK5 connected to AVCCHAVDDH.
+     * |        |          |10 = TK5 connected to VDD.
+     * |        |          |11 = TK5 connected to VDD.
+     * |[13:12] |IDLS6     |TK6 Idle State Control
+     * |        |          |This register is ignored if both TK6SEN (TK_SCANC[6]) and POLEN6 (TK_POLC[14]) are “0” or TK6REN (TK_REFC[6]) is “1”.
+     * |        |          |00 = TK6 connected to Gnd.
+     * |        |          |01 = TK6 connected to AVCCHAVDDH.
+     * |        |          |10 = TK6 connected to VDD.
+     * |        |          |11 = TK6 connected to VDD.
+     * |[15:14] |IDLS7     |TK7 Idle State Control
+     * |        |          |This register is ignored if both TK7SEN (TK_SCANC[7]) and POLEN7 (TK_POLC[15]) are “0” or TK7REN (TK_REFC[7]) is “1”.
+     * |        |          |00 = TK7 connected to Gnd.
+     * |        |          |01 = TK7 connected to AVCCHAVDDH.
+     * |        |          |10 = TK7 connected to VDD.
+     * |        |          |11 = TK7 connected to VDD.
+     * |[17:16] |IDLS8     |TK8 Idle State Control
+     * |        |          |This register is ignored if both TK8SEN (TK_SCANC[8]) and POLEN8 (TK_POLC[16]) are “0” or TK8REN (TK_REFC[8]) is “1”.
+     * |        |          |00 = TK8 connected to Gnd.
+     * |        |          |01 = TK8 connected to AVCCHAVDDH.
+     * |        |          |10 = TK8 connected to VDD.
+     * |        |          |11 = TK8 connected to VDD.
+     * |[19:18] |IDLS9     |TK9 Idle State Control
+     * |        |          |This register is ignored if both TK9SEN (TK_SCANC[9]) and POLEN9 (TK_POLC[17]) are “0” or TK9REN (TK_REFC[9]) is “1”.
+     * |        |          |00 = TK9 connected to Gnd.
+     * |        |          |01 = TK9 connected to AVCCHAVDDH.
+     * |        |          |10 = TK9 connected to VDD.
+     * |        |          |11 = TK9 connected to VDD.
+     * |[21:20] |IDLS10    |TK10 Idle State Control
+     * |        |          |This register is ignored if both TK10SEN (TK_SCANC[10]) and POLEN10 (TK_POLC[18]) are “0” or TK10REN (TK_REFC[10]) is “1”.
+     * |        |          |00 = TK10 connected to Gnd.
+     * |        |          |01 = TK10 connected to AVCCHAVDDH.
+     * |        |          |10 = TK10 connected to VDD.
+     * |        |          |11 = TK10 connected to VDD.
+     * |[23:22] |IDLS11    |TK11 Idle State Control
+     * |        |          |This register is ignored if both TK11SEN (TK_SCANC[11]) and POLEN11 (TK_POLC[19]) are “0” or TK11REN (TK_REFC[11]) is “1”.
+     * |        |          |00 = TK11 connected to Gnd.
+     * |        |          |01 = TK11 connected to AVCCHAVDDH.
+     * |        |          |10 = TK11 connected to VDD.
+     * |        |          |11 = TK11 connected to VDD.
+     * |[25:24] |IDLS12    |TK12 Idle State Control
+     * |        |          |This register is ignored if both TK12SEN (TK_SCANC[12]) and POLEN12 (TK_POLC[20]) are “0” or TK12REN (TK_REFC[12]) is “1”.
+     * |        |          |00 = TK12 connected to Gnd.
+     * |        |          |01 = TK12 connected to AVCCHAVDDH.
+     * |        |          |10 = TK12 connected to VDD.
+     * |        |          |11 = TK12 connected to VDD.
+     * |[27:26] |IDLS13    |TK13 Idle State Control
+     * |        |          |This register is ignored if both TK13SEN (TK_SCANC[13]) and POLEN13 (TK_POLC[21]) are “0” or TK13REN (TK_REFC[13]) is “1”.
+     * |        |          |00 = TK13 connected to Gnd.
+     * |        |          |01 = TK13 connected to AVCCHAVDDH.
+     * |        |          |10 = TK13 connected to VDD.
+     * |        |          |11 = TK13 connected to VDD.
+     * |[29:28] |IDLS14    |TK14 Idle State Control
+     * |        |          |This register is ignored if both TK14SEN (TK_SCANC[14]) and POLEN14 (TK_POLC[22]) are “0” or TK14REN (TK_REFC[14]) is “1”.
+     * |        |          |00 = TK14 connected to Gnd.
+     * |        |          |01 = TK14 connected to AVCCHAVDDH.
+     * |        |          |10 = TK14 connected to VDD.
+     * |        |          |11 = TK14 connected to VDD.
+     * |[31:30] |IDLS15    |TK15 Idle State Control
+     * |        |          |This register is ignored if both TK15SEN (TK_SCANC[15]) and POLEN15 (TK_POLC[23]) are “0” or TK15REN (TK_REFC[15]) is “1”.
+     * |        |          |00 = TK15 connected to Gnd.
+     * |        |          |01 = TK15 connected to AVCCHAVDDH.
+     * |        |          |10 = TK15 connected to VDD.
+     * |        |          |11 = TK15 connected to VDD.
+     * @var TK_T::POLSEL
+     * Offset: 0x20  Touch Key Polarity Select Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |POL0      |TK0 Polarity Select
+     * |        |          |This register is ignored if POLEN0 (TK_POLC[8]) is “0” or TK0REN (TK_REFC[0]) is “1”.
+     * |        |          |00 = TK0 connected to Gnd.
+     * |        |          |01 = TK0 connected to AVCCHAVDDH.
+     * |        |          |10 = TK0 connected to VDD.
+     * |        |          |11 = TK0 connected to VDD.
+     * |[3:2]   |POL1      |TK1 Polarity Select
+     * |        |          |This register is ignored if POLEN1 (TK_POLC[9]) is “0” or TK1REN (TK_REFC[1]) is “1”.
+     * |        |          |00 = TK1 connected to Gnd.
+     * |        |          |01 = TK1 connected to AVCCHAVDDH.
+     * |        |          |10 = TK1 connected to VDD.
+     * |        |          |11 = TK1 connected to VDD.
+     * |[5:4]   |POL2      |TK2 Polarity Select
+     * |        |          |This register is ignored if POLEN2 (TK_POLC[10]) is “0” or TK2REN (TK_REFC[2]) is “1”.
+     * |        |          |00 = TK2 connected to Gnd.
+     * |        |          |01 = TK2 connected to AVCCHAVDDH.
+     * |        |          |10 = TK2 connected to VDD.
+     * |        |          |11 = TK2 connected to VDD.
+     * |[7:6]   |POL3      |TK3 Polarity Select
+     * |        |          |This register is ignored if POLEN3 (TK_POLC[11]) is “0” or TK3REN (TK_REFC[3]) is “1”.
+     * |        |          |00 = TK3 connected to Gnd.
+     * |        |          |01 = TK3 connected to AVCCHAVDDH.
+     * |        |          |10 = TK3 connected to VDD.
+     * |        |          |11 = TK3 connected to VDD.
+     * |[9:8]   |POL4      |TK4 Polarity Select
+     * |        |          |This register is ignored if POLEN4 (TK_POLC[12]) is “0” or TK4REN (TK_REFC[4]) is “1”.
+     * |        |          |00 = TK4 connected to Gnd.
+     * |        |          |01 = TK4 connected to AVCCHAVDDH.
+     * |        |          |10 = TK4 connected to VDD.
+     * |        |          |11 = TK4 connected to VDD.
+     * |[11:10] |POL5      |TK5 Polarity Select
+     * |        |          |This register is ignored if POLEN5 (TK_POLC[13]) is “0” or TK5REN (TK_REFC[5]) is “1”.
+     * |        |          |00 = TK5 connected to Gnd.
+     * |        |          |01 = TK5 connected to AVCCHAVDDH.
+     * |        |          |10 = TK5 connected to VDD.
+     * |        |          |11 = TK5 connected to VDD.
+     * |[13:12] |POL6      |TK6 Polarity Select
+     * |        |          |This register is ignored if POLEN6 (TK_POLC[14]) is “0” or TK6REN (TK_REFC[6]) is “1”.
+     * |        |          |00 = TK6 connected to Gnd.
+     * |        |          |01 = TK6 connected to AVCCHAVDDH.
+     * |        |          |10 = TK6 connected to VDD.
+     * |        |          |11 = TK6 connected to VDD.
+     * |[15:14] |POL7      |TK7 Polarity Select
+     * |        |          |This register is ignored if POLEN7 (TK_POLC[15]) is “0” or TK7REN (TK_REFC[7]) is “1”.
+     * |        |          |00 = TK7 connected to Gnd.
+     * |        |          |01 = TK7 connected to AVCCHAVDDH.
+     * |        |          |10 = TK7 connected to VDD.
+     * |        |          |11 = TK7 connected to VDD.
+     * |[17:16] |POL8      |TK8 Polarity Select
+     * |        |          |This register is ignored if POLEN8 (TK_POLC[16]) is “0” or TK8REN (TK_REFC[8]) is “1”.
+     * |        |          |00 = TK8 connected to Gnd.
+     * |        |          |01 = TK8 connected to AVCCHAVDDH.
+     * |        |          |10 = TK8 connected to VDD.
+     * |        |          |11 = TK8 connected to VDD.
+     * |[19:18] |POL9      |TK9 Polarity Select
+     * |        |          |This register is ignored if POLEN9 (TK_POLC[17]) is “0” or TK9REN (TK_REFC[9]) is “1”.
+     * |        |          |00 = TK9 connected to Gnd.
+     * |        |          |01 = TK9 connected to AVCCHAVDDH.
+     * |        |          |10 = TK9 connected to VDD.
+     * |        |          |11 = TK9 connected to VDD.
+     * |[21:20] |POL10     |TK10 Polarity Select
+     * |        |          |This register is ignored if POLEN10 (TK_POLC[18]) is “0” or TK10REN (TK_REFC[10]) is “1”.
+     * |        |          |00 = TK10 connected to Gnd.
+     * |        |          |01 = TK10 connected to AVCCHAVDDH.
+     * |        |          |10 = TK10 connected to VDD.
+     * |        |          |11 = TK10 connected to VDD.
+     * |[23:22] |POL11     |TK11 Polarity Select
+     * |        |          |This register is ignored if POLEN11 (TK_POLC[19]) is “0” or TK11REN (TK_REFC[11]) is “1”.
+     * |        |          |00 = TK11 connected to Gnd.
+     * |        |          |01 = TK11 connected to AVCCHAVDDH.
+     * |        |          |10 = TK11 connected to VDD.
+     * |        |          |11 = TK11 connected to VDD.
+     * |[25:24] |POL12     |TK12 Polarity Select
+     * |        |          |This register is ignored if POLEN12 (TK_POLC[20]) is “0” or TK12REN (TK_REFC[12]) is “1”.
+     * |        |          |00 = TK12 connected to Gnd.
+     * |        |          |01 = TK12 connected to AVCCHAVDDH.
+     * |        |          |10 = TK12 connected to VDD.
+     * |        |          |11 = TK12 connected to VDD.
+     * |[27:26] |POL13     |TK13 Polarity Select
+     * |        |          |This register is ignored if POLEN13 (TK_POLC[21]) is “0” or TK13REN (TK_REFC[13]) is “1”.
+     * |        |          |00 = TK13 connected to Gnd.
+     * |        |          |01 = TK13 connected to AVCCHAVDDH.
+     * |        |          |10 = TK13 connected to VDD.
+     * |        |          |11 = TK13 connected to VDD.
+     * |[29:28] |POL14     |TK14 Polarity Select
+     * |        |          |This register is ignored if POLEN14 (TK_POLC[22]) is “0” or TK14REN (TK_REFC[14]) is “1”.
+     * |        |          |00 = TK14 connected to Gnd.
+     * |        |          |01 = TK14 connected to AVCCHAVDDH.
+     * |        |          |10 = TK14 connected to VDD.
+     * |        |          |11 = TK14 connected to VDD.
+     * |[31:30] |POL15     |TK15 Polarity Select
+     * |        |          |This register is ignored if POLEN15 (TK_POLC[23]) is “0” or TK15REN (TK_REFC[15]) is “1”.
+     * |        |          |00 = TK15 connected to Gnd.
+     * |        |          |01 = TK15 connected to AVCCHAVDDH.
+     * |        |          |10 = TK15 connected to VDD.
+     * |        |          |11 = TK15 connected to VDD.
+     * @var TK_T::POLC
+     * Offset: 0x24  Touch Key Polarity Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |IDLS16    |TK16 Idle State Control
+     * |        |          |This register is ignored if both TK16SEN (TK_SCANC[16]) and POLEN16 (TK_POLC[24]) are “0” or TK16REN (TK_REFC[16]) is “1”.
+     * |        |          |00 = TK16 connected to Gnd.
+     * |        |          |01 = TK16 connected to AVCCHAVDDH.
+     * |        |          |10 = TK16 connected to VDD.
+     * |        |          |11 = TK16 connected to VDD.
+     * |[3:2]   |POL16     |TK16 Polarity Control
+     * |        |          |This register is ignored if POLEN16 (TK_POLC[24]) is “0” or TK16REN (TK_REFC[16]) is “1”.
+     * |        |          |00 = TK16 connected to Gnd.
+     * |        |          |01 = TK16 connected to AVCCHAVDDH.
+     * |        |          |10 = TK16 connected to VDD.
+     * |        |          |11 = TK16 connected to VDD.
+     * |[5:4]   |POL_CAP   |Capacitor Bank Polarity Select
+     * |        |          |00 = Gnd.
+     * |        |          |01 = AVCCHAVDDH.
+     * |        |          |10 = VDD.
+     * |        |          |11 = VDD.
+     * |[8]     |POLEN0    |TK0 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[9]     |POLEN1    |TK1 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[10]    |POLEN2    |TK2 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[11]    |POLEN3    |TK3 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[12]    |POLEN4    |TK4 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[13]    |POLEN5    |TK5 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[14]    |POLEN6    |TK6 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[15]    |POLEN7    |TK7 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[16]    |POLEN8    |TK8 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[17]    |POLEN9    |TK9 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[18]    |POLEN10   |TK10 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[19]    |POLEN11   |TK11 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[20]    |POLEN12   |TK12 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[21]    |POLEN13   |TK13 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[22]    |POLEN14   |TK14 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[23]    |POLEN15   |TK15 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[24]    |POLEN16   |TK16 Polarity Function Enable
+     * |        |          |0 = Disable.
+     * |        |          |1 = Enable.
+     * |[31]    |POL_INIT  |Touch Key Sensing Initial Potential Control
+     * |        |          |0 = Key pad is connected to Gnd before sensing.
+     * |        |          |1 = Key pad is connected to AVCCHAVDDH before sensing.
+     * @var TK_T::STA
+     * Offset: 0x28  Touch Key Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BUSY      |Touch Key Busy (Read Only)
+     * |        |          |0 = KTouch key sensing scan is complete or stopped.
+     * |        |          |1 = KTouch key sensing scan is proceeding.
+     * |[1]     |SCIF      |Touch Key Scan Complete Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = Touch Keys are being scan is proceeding and data is not ready for read.
+     * |        |          |1 = Touch Keys scan is complete and data is ready for read in TKDATx registers.
+     * |        |          |Note1: The Touch Key interrupt asserts if SCIE bit of TK_INTEN register is set.
+     * |        |          |Note2: The Touch Key interrupt also asserts if STHIE bit of TK_INTEN register is set and any channel data value is greater/less than its threshold setting.
+     * |[6]     |TKIF      |Key Scan Interrupt Flag (Read Only)
+     * |        |          |0 = No threshold control event with each Keys Scan.
+     * |        |          |1 = Threshold control event occurs with each Keys Scan.
+     * |        |          |This bit is 1 while any one of TKIF0~TKIF16 is 1.
+     * |[7]     |TKIF_ALL  |All Keys Scan Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with All Keys Scan.
+     * |        |          |1 = Threshold control event occurs with All Keys Scan.
+     * |[8]     |TKIF0     |TK0 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK0.
+     * |        |          |1 = Threshold control event occurs with TK0.
+     * |[9]     |TKIF1     |TK1 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK1.
+     * |        |          |1 = Threshold control event occurs with TK1.
+     * |[10]    |TKIF2     |TK2 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK2.
+     * |        |          |1 = Threshold control event occurs with TK2.
+     * |[11]    |TKIF3     |TK3 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK3.
+     * |        |          |1 = Threshold control event occurs with TK3.
+     * |[12]    |TKIF4     |TK4 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK4.
+     * |        |          |1 = Threshold control event occurs with TK4.
+     * |[13]    |TKIF5     |TK5 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK5.
+     * |        |          |1 = Threshold control event occurs with TK5.
+     * |[14]    |TKIF6     |TK6 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK6.
+     * |        |          |1 = Threshold control event occurs with TK6.
+     * |[15]    |TKIF7     |TK7 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK7.
+     * |        |          |1 = Threshold control event occurs with TK7.
+     * |[16]    |TKIF8     |TK8 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK8.
+     * |        |          |1 = Threshold control event occurs with TK8.
+     * |[17]    |TKIF9     |TK9 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK9.
+     * |        |          |1 = Threshold control event occurs with TK9.
+     * |[18]    |TKIF10    |TK10 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK10.
+     * |        |          |1 = Threshold control event occurs with TK10.
+     * |[19]    |TKIF11    |TK11 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK11.
+     * |        |          |1 = Threshold control event occurs with TK11.
+     * |[20]    |TKIF12    |TK12 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK12.
+     * |        |          |1 = Threshold control event occurs with TK12.
+     * |[21]    |TKIF13    |TK13 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK13.
+     * |        |          |1 = Threshold control event occurs with TK13.
+     * |[22]    |TKIF14    |TK14 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK14.
+     * |        |          |1 = Threshold control event occurs with TK14.
+     * |[23]    |TKIF15    |TK15 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK15.
+     * |        |          |1 = Threshold control event occurs with TK15.
+     * |[24]    |TKIF16    |TK16 Interrupt Flag (Read Only)
+     * |        |          |This bit will be cleared by writing a “1” to this bit.
+     * |        |          |0 = No threshold control event with TK16.
+     * |        |          |1 = Threshold control event occurs with TK16.
+     * @var TK_T::DAT0
+     * Offset: 0x2C  Touch Key Data Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |TKDAT0    |TK0 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK0SEN (TK_SCANC[0]) is “0” or TK0REN (TK_REFC[0]) is “1” except SCAN_ALL (TK_REFC[23]) is “1”.
+     * |[15:8]  |TKDAT1    |TK1 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK1SEN (TK_SCANC[1]) is “0” or TK1REN (TK_REFC[1]) is “1”.
+     * |[23:16] |TKDAT2    |TK2 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK2SEN (TK_SCANC[2]) is “0” or TK2REN (TK_REFC[2]) is “1”.
+     * |[31:24] |TKDAT3    |TK3 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK3SEN (TK_SCANC[3]) is “0” or TK3REN (TK_REFC[3]) is “1”.
+     * @var TK_T::DAT1
+     * Offset: 0x30  Touch Key Data Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |TKDAT4    |TK0 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK4SEN (TK_SCANC[4]) is “0” or TK4REN (TK_REFC[4]) is “1”.
+     * |[15:8]  |TKDAT5    |TK5 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK5SEN (TK_SCANC[5]) is “0” or TK5REN (TK_REFC[5]) is “1”.
+     * |[23:16] |TKDAT6    |TK6 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK6SEN (TK_SCANC[6]) is “0” or TK6REN (TK_REFC[6]) is “1”.
+     * |[31:24] |TKDAT7    |TK7 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK7SEN (TK_SCANC[7]) is “0” or TK7REN (TK_REFC[7]) is “1”.
+     * @var TK_T::DAT2
+     * Offset: 0x34  Touch Key Data Register 2
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |TKDAT8    |TK8 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK8SEN (TK_SCANC[8]) is “0” or TK8REN (TK_REFC[8]) is “1”.
+     * |[15:8]  |TKDAT9    |TK9 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK9SEN (TK_SCANC[9]) is “0” or TK9REN (TK_REFC[9]) is “1”.
+     * |[23:16] |TKDAT10   |TK10 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK10SEN (TK_SCANC[10]) is “0” or TK10REN (TK_REFC[10]) is “1”.
+     * |[31:24] |TKDAT11   |TK11 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK11SEN (TK_SCANC[11]) is “0” or TK11REN (TK_REFC[11]) is “1”.
+     * @var TK_T::DAT3
+     * Offset: 0x38  Touch Key Data Register 3
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |TKDAT12   |TK12 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK12SEN (TK_SCANC[12]) is “0” or TK12REN (TK_REFC[12]) is “1”.
+     * |[15:8]  |TKDAT13   |TK13 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK13SEN (TK_SCANC[13]) is “0” or TK13REN (TK_REFC[13]) is “1”.
+     * |[23:16] |TKDAT14   |TK14 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK14SEN (TK_SCANC[14]) is “0” or TK14REN (TK_REFC[14]) is “1”.
+     * |[31:24] |TKDAT15   |TK15 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK15SEN (TK_SCANC[15]) is “0” or TK15REN (TK_REFC[15]) is “1”.
+     * @var TK_T::DAT4
+     * Offset: 0x3C  Touch Key Data Register 4
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |TKDAT16   |TK16 Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if TK16SEN (TK_SCANC[16]) is “0” or TK16REN (TK_REFC[16]) is “1”.
+     * |[15:8]  |TKDAT_ALL |All Keys Scan Sensing Result Data (Read Only)
+     * |        |          |This data is invalid if SCAN_ALL (TK_REFC[23]) is “0”.
+     * @var TK_T::INTEN
+     * Offset: 0x40  Touch Key Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SCTHIE    |Touch Key Scan Complete with High/Low Threshold Control Interrupt Enable
+     * |        |          |0 = KTouch key Scan scan Complete complete with threshold control interrupt is disable.
+     * |        |          |1 = KTouch key Scan scan Complete complete with threshold control interrupt is enable.
+     * |[1]     |SCIE      |Touch Key Scan Complete Interrupt Enable
+     * |        |          |0 = KTouch key sScan cComplete without threshold control interrupt is disable.
+     * |        |          |1 = KTouch key sScan cComplete without threshold control interrupt is enable.
+     * @var TK_T::THC01
+     * Offset: 0x44  Touch Key TK0/TK1 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH0      |High Threshold of TK0
+     * |        |          |High level for TK0 threshold control.
+     * |[31:24] |HTH1      |High Threshold of TK1
+     * |        |          |High level for TK1 threshold control.
+     * @var TK_T::THC23
+     * Offset: 0x48  Touch Key TK2/TK3 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH2      |High Threshold of TK2
+     * |        |          |High level for TK2 threshold control.
+     * |[31:24] |HTH3      |High Threshold of TK3
+     * |        |          |High level for TK3 threshold control.
+     * @var TK_T::THC45
+     * Offset: 0x4C  Touch Key TK4/TK5 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH4      |High Threshold of TK4
+     * |        |          |High level for TK4 threshold control.
+     * |[31:24] |HTH5      |High Threshold of TK5
+     * |        |          |High level for TK5 threshold control.
+     * @var TK_T::THC67
+     * Offset: 0x50  Touch Key TK6/TK7 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH6      |High Threshold of TK6
+     * |        |          |High level for TK6 threshold control.
+     * |[31:24] |HTH7      |High Threshold of TK7
+     * |        |          |High level for TK7 threshold control.
+     * @var TK_T::THC89
+     * Offset: 0x54  Touch Key TK8/TK9 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH8      |High Threshold of TK8
+     * |        |          |High level for TK8 threshold control.
+     * |[31:24] |HTH9      |High Threshold of TK9
+     * |        |          |High level for TK9 threshold control.
+     * @var TK_T::THC1011
+     * Offset: 0x58  Touch Key TK10/TK11 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH10     |High Threshold of TK10
+     * |        |          |High level for TK10 threshold control.
+     * |[31:24] |HTH11     |High Threshold of TK11
+     * |        |          |High level for TK11 threshold control.
+     * @var TK_T::THC1213
+     * Offset: 0x5C  Touch Key TK12/TK13 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH12     |High Threshold of TK12
+     * |        |          |High level for TK12 threshold control.
+     * |[31:24] |HTH13     |High Threshold of TK13
+     * |        |          |High level for TK13 threshold control.
+     * @var TK_T::THC1415
+     * Offset: 0x60  Touch Key TK14/TK15 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH14     |High Threshold of TK14
+     * |        |          |High level for TK14 threshold control.
+     * |[31:24] |HTH15     |High Threshold of TK15
+     * |        |          |High level for TK15 threshold control.
+     * @var TK_T::THC16
+     * Offset: 0x64  Touch Key TK16 Threshold Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:8]  |HTH16     |High Threshold of TK16
+     * |        |          |High level for TK16 threshold control.
+     * |[31:24] |HTH_ALL   |High Threshold of All Keys Scan
+     * |        |          |High level for All Keys Scan threshold control.
+     * @var TK_T::TK_REFCBD0
+     * Offset: 0x68  Touch Key Reference Capacitor Bank Data Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CBD0      |TK0 Capacitor Bank Data
+     * |        |          |This is register is used for TK0 sensitivity adjustment.
+     * |[15:8]  |CBD1      |TK1 Capacitor Bank Data
+     * |        |          |This is register is used for TK1 sensitivity adjustment.
+     * |[23:16] |CBD2      |TK2 Capacitor Bank Data
+     * |        |          |This is register is used for TK2 sensitivity adjustment.
+     * |[31:24] |CBD3      |TK3 Capacitor Bank Data
+     * |        |          |This is register is used for TK3 sensitivity adjustment.
+     * @var TK_T::TK_REFCBD1
+     * Offset: 0x6C  Touch Key Reference Capacitor Bank Data Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CBD4      |TK4 Capacitor Bank Data
+     * |        |          |This is register is used for TK4 sensitivity adjustment.
+     * |[15:8]  |CBD5      |TK5 Capacitor Bank Data
+     * |        |          |This is register is used for TK5 sensitivity adjustment.
+     * |[23:16] |CBD6      |TK6 Capacitor Bank Data
+     * |        |          |This is register is used for TK6 sensitivity adjustment.
+     * |[31:24] |CBD7      |TK7 Capacitor Bank Data
+     * |        |          |This is register is used for TK7 sensitivity adjustment.
+     * @var TK_T::TK_REFCBD2
+     * Offset: 0x70  Touch Key Reference Capacitor Bank Data Register 2
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CBD8      |TK8 Capacitor Bank Data
+     * |        |          |This is register is used for TK8 sensitivity adjustment.
+     * |[15:8]  |CBD9      |TK9 Capacitor Bank Data
+     * |        |          |This is register is used for TK9 sensitivity adjustment.
+     * |[23:16] |CBD10     |TK10 Capacitor Bank Data
+     * |        |          |This is register is used for TK10 sensitivity adjustment.
+     * |[31:24] |CBD11     |TK11 Capacitor Bank Data
+     * |        |          |This is register is used for TK11 sensitivity adjustment.
+     * @var TK_T::TK_REFCBD3
+     * Offset: 0x74  Touch Key Reference Capacitor Bank Data Register 3
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CBD12     |TK12 Capacitor Bank Data
+     * |        |          |This is register is used for TK12 sensitivity adjustment.
+     * |[15:8]  |CBD13     |TK13 Capacitor Bank Data
+     * |        |          |This is register is used for TK13 sensitivity adjustment.
+     * |[23:16] |CBD14     |TK14 Capacitor Bank Data
+     * |        |          |This is register is used for TK14 sensitivity adjustment.
+     * |[31:24] |CBD15     |TK15 Capacitor Bank Data
+     * |        |          |This is register is used for TK15 sensitivity adjustment.
+     * @var TK_T::TK_REFCBD4
+     * Offset: 0x78  Touch Key Reference Capacitor Bank Data Register 4
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |CBD16     |TK16 Capacitor Bank Data
+     * |        |          |This is register is used for TK16 sensitivity adjustment.
+     * |[15:8]  |CBD_ALL   |All Keys Scan Capacitor Bank Data
+     * |        |          |This is register is used for All Keys Scan sensitivity adjustment.
+
+     */
+    __IO uint32_t SCANC;                 /*!< [0x0000] Touch Key Scan Control Register                                  */
+    __IO uint32_t REFC;                  /*!< [0x0004] Touch Key Reference Control Register                             */
+    __IO uint32_t CCBD0;                 /*!< [0x0008] Touch Key Complement Capacitor Bank Data Register 0              */
+    __IO uint32_t CCBD1;                 /*!< [0x000c] Touch Key Complement Capacitor Bank Data Register 1              */
+    __IO uint32_t CCBD2;                 /*!< [0x0010] Touch Key Complement Capacitor Bank Data Register 2              */
+    __IO uint32_t CCBD3;                 /*!< [0x0014] Touch Key Complement Capacitor Bank Data Register 3              */
+    __IO uint32_t CCBD4;                 /*!< [0x0018] Touch Key Complement Capacitor Bank Data Register 4              */
+    __IO uint32_t IDLSC;                 /*!< [0x001c] Touch Key Idle State Control Register                            */
+    __IO uint32_t POLSEL;                /*!< [0x0020] Touch Key Polarity Select Register                               */
+    __IO uint32_t POLC;                  /*!< [0x0024] Touch Key Polarity Control Register                              */
+    __IO uint32_t STA;                   /*!< [0x0028] Touch Key Status Register                                        */
+    __I  uint32_t DAT0;                  /*!< [0x002c] Touch Key Data Register 0                                        */
+    __I  uint32_t DAT1;                  /*!< [0x0030] Touch Key Data Register 1                                        */
+    __I  uint32_t DAT2;                  /*!< [0x0034] Touch Key Data Register 2                                        */
+    __I  uint32_t DAT3;                  /*!< [0x0038] Touch Key Data Register 3                                        */
+    __I  uint32_t DAT4;                  /*!< [0x003c] Touch Key Data Register 4                                        */
+    __IO uint32_t INTEN;                 /*!< [0x0040] Touch Key Interrupt Enable Register                              */
+    __IO uint32_t THC01;                 /*!< [0x0044] Touch Key TK0/TK1 Threshold Control Register                     */
+    __IO uint32_t THC23;                 /*!< [0x0048] Touch Key TK2/TK3 Threshold Control Register                     */
+    __IO uint32_t THC45;                 /*!< [0x004c] Touch Key TK4/TK5 Threshold Control Register                     */
+    __IO uint32_t THC67;                 /*!< [0x0050] Touch Key TK6/TK7 Threshold Control Register                     */
+    __IO uint32_t THC89;                 /*!< [0x0054] Touch Key TK8/TK9 Threshold Control Register                     */
+    __IO uint32_t THC1011;               /*!< [0x0058] Touch Key TK10/TK11 Threshold Control Register                   */
+    __IO uint32_t THC1213;               /*!< [0x005c] Touch Key TK12/TK13 Threshold Control Register                   */
+    __IO uint32_t THC1415;               /*!< [0x0060] Touch Key TK14/TK15 Threshold Control Register                   */
+    __IO uint32_t THC16;                 /*!< [0x0064] Touch Key TK16 Threshold Control Register                        */
+    __IO uint32_t TK_REFCBD0;            /*!< [0x0068] Touch Key Reference Capacitor Bank Data Register 0               */
+    __IO uint32_t TK_REFCBD1;            /*!< [0x006C] Touch Key Reference Capacitor Bank Data Register 1               */
+    __IO uint32_t TK_REFCBD2;            /*!< [0x0070] Touch Key Reference Capacitor Bank Data Register 2               */
+    __IO uint32_t TK_REFCBD3;            /*!< [0x0074] Touch Key Reference Capacitor Bank Data Register 3               */
+    __IO uint32_t TK_REFCBD4;            /*!< [0x0078] Touch Key Reference Capacitor Bank Data Register 4               */
+    __I  uint32_t RESERVED;              /*!< [0x007c] Reserved                                                         */
+    __IO uint32_t SCANC1;                /*!< [0x0080] Touch Key Scan Control Register 1                                */
+    __IO uint32_t REFC1;                 /*!< [0x0084] Touch Key Reference Control Register 1                           */
+    __IO uint32_t CCBD5;                 /*!< [0x0088] Touch Key Complement Capacitor Bank Data Register 5              */
+    __IO uint32_t CCBD6;                 /*!< [0x008c] Touch Key Complement Capacitor Bank Data Register 6              */
+    __IO uint32_t CCBD7;                 /*!< [0x0090] Touch Key Complement Capacitor Bank Data Register 7              */
+    __I  uint32_t RESERVED1[2];          /*!< [0x0094]~[0x0098] Reserved                                                */
+    __IO uint32_t IDLSC1;                /*!< [0x009c] Touch Key Idle State Control Register 1                          */
+    __IO uint32_t POLSEL1;               /*!< [0x00A0] Touch Key Polarity Select Register 1                             */
+    __IO uint32_t POLC1;                 /*!< [0x00A4] Touch Key Polarity Control Register 1                            */
+    __IO  uint32_t STA1;                 /*!< [0x00A8] Touch Key Status Register 1                                      */
+    __I  uint32_t DAT5;                  /*!< [0x00Ac] Touch Key Data Register 5                                        */
+    __I  uint32_t DAT6;                  /*!< [0x00B0] Touch Key Data Register 6                                        */
+    __I  uint32_t DAT7;                  /*!< [0x00B4] Touch Key Data Register 7                                        */
+    __I  uint32_t RESERVE2[3];           /*!< [0x00B8]~[0x00C0] Reserved                                                */
+    __IO uint32_t THC1718;               /*!< [0x00C4] Touch Key TK17/TK18 Threshold Control Register                   */
+    __IO uint32_t THC1920;               /*!< [0x00C8] Touch Key TK19/TK20 Threshold Control Register                   */
+    __IO uint32_t THC2122;               /*!< [0x00Cc] Touch Key TK21/TK22 Threshold Control Register                   */
+    __IO uint32_t THC2324;               /*!< [0x00D0] Touch Key TK23/TK24 Threshold Control Register                   */
+    __IO uint32_t THC25;                 /*!< [0x00D4] Touch Key TK25 Threshold Control Register                        */
+    __I  uint32_t RESERVE3[4];           /*!< [0x00D8]~[0x00E4] Reserved                                                */
+    __IO uint32_t TK_REFCBD5;            /*!< [0x00E8] Touch Key Reference Capacitor Bank Data Register 5               */
+    __IO uint32_t TK_REFCBD6;            /*!< [0x00EC] Touch Key Reference Capacitor Bank Data Register 6               */
+    __IO uint32_t TK_REFCBD7;            /*!< [0x00F0] Touch Key Reference Capacitor Bank Data Register 7               */
+
+} TK_T;
+
+/**
+    @addtogroup TK_CONST TK Bit Field Definition
+    Constant Definitions for TK Controller
+@{ */
+
+#define TK_SCANC_TK0SEN_Pos              (0)                                               /*!< TK_T::SCANC: TK0SEN Position           */
+#define TK_SCANC_TK0SEN_Msk              (0x1ul << TK_SCANC_TK0SEN_Pos)                    /*!< TK_T::SCANC: TK0SEN Mask               */
+
+#define TK_SCANC_TK1SEN_Pos              (1)                                               /*!< TK_T::SCANC: TK1SEN Position           */
+#define TK_SCANC_TK1SEN_Msk              (0x1ul << TK_SCANC_TK1SEN_Pos)                    /*!< TK_T::SCANC: TK1SEN Mask               */
+
+#define TK_SCANC_TK2SEN_Pos              (2)                                               /*!< TK_T::SCANC: TK2SEN Position           */
+#define TK_SCANC_TK2SEN_Msk              (0x1ul << TK_SCANC_TK2SEN_Pos)                    /*!< TK_T::SCANC: TK2SEN Mask               */
+
+#define TK_SCANC_TK3SEN_Pos              (3)                                               /*!< TK_T::SCANC: TK3SEN Position           */
+#define TK_SCANC_TK3SEN_Msk              (0x1ul << TK_SCANC_TK3SEN_Pos)                    /*!< TK_T::SCANC: TK3SEN Mask               */
+
+#define TK_SCANC_TK4SEN_Pos              (4)                                               /*!< TK_T::SCANC: TK4SEN Position           */
+#define TK_SCANC_TK4SEN_Msk              (0x1ul << TK_SCANC_TK4SEN_Pos)                    /*!< TK_T::SCANC: TK4SEN Mask               */
+
+#define TK_SCANC_TK5SEN_Pos              (5)                                               /*!< TK_T::SCANC: TK5SEN Position           */
+#define TK_SCANC_TK5SEN_Msk              (0x1ul << TK_SCANC_TK5SEN_Pos)                    /*!< TK_T::SCANC: TK5SEN Mask               */
+
+#define TK_SCANC_TK6SEN_Pos              (6)                                               /*!< TK_T::SCANC: TK6SEN Position           */
+#define TK_SCANC_TK6SEN_Msk              (0x1ul << TK_SCANC_TK6SEN_Pos)                    /*!< TK_T::SCANC: TK6SEN Mask               */
+
+#define TK_SCANC_TK7SEN_Pos              (7)                                               /*!< TK_T::SCANC: TK7SEN Position           */
+#define TK_SCANC_TK7SEN_Msk              (0x1ul << TK_SCANC_TK7SEN_Pos)                    /*!< TK_T::SCANC: TK7SEN Mask               */
+
+#define TK_SCANC_TK8SEN_Pos              (8)                                               /*!< TK_T::SCANC: TK8SEN Position           */
+#define TK_SCANC_TK8SEN_Msk              (0x1ul << TK_SCANC_TK8SEN_Pos)                    /*!< TK_T::SCANC: TK8SEN Mask               */
+
+#define TK_SCANC_TK9SEN_Pos              (9)                                               /*!< TK_T::SCANC: TK9SEN Position           */
+#define TK_SCANC_TK9SEN_Msk              (0x1ul << TK_SCANC_TK9SEN_Pos)                    /*!< TK_T::SCANC: TK9SEN Mask               */
+
+#define TK_SCANC_TK10SEN_Pos             (10)                                              /*!< TK_T::SCANC: TK10SEN Position          */
+#define TK_SCANC_TK10SEN_Msk             (0x1ul << TK_SCANC_TK10SEN_Pos)                   /*!< TK_T::SCANC: TK10SEN Mask              */
+
+#define TK_SCANC_TK11SEN_Pos             (11)                                              /*!< TK_T::SCANC: TK11SEN Position          */
+#define TK_SCANC_TK11SEN_Msk             (0x1ul << TK_SCANC_TK11SEN_Pos)                   /*!< TK_T::SCANC: TK11SEN Mask              */
+
+#define TK_SCANC_TK12SEN_Pos             (12)                                              /*!< TK_T::SCANC: TK12SEN Position          */
+#define TK_SCANC_TK12SEN_Msk             (0x1ul << TK_SCANC_TK12SEN_Pos)                   /*!< TK_T::SCANC: TK12SEN Mask              */
+
+#define TK_SCANC_TK13SEN_Pos             (13)                                              /*!< TK_T::SCANC: TK13SEN Position          */
+#define TK_SCANC_TK13SEN_Msk             (0x1ul << TK_SCANC_TK13SEN_Pos)                   /*!< TK_T::SCANC: TK13SEN Mask              */
+
+#define TK_SCANC_TK14SEN_Pos             (14)                                              /*!< TK_T::SCANC: TK14SEN Position          */
+#define TK_SCANC_TK14SEN_Msk             (0x1ul << TK_SCANC_TK14SEN_Pos)                   /*!< TK_T::SCANC: TK14SEN Mask              */
+
+#define TK_SCANC_TK15SEN_Pos             (15)                                              /*!< TK_T::SCANC: TK15SEN Position          */
+#define TK_SCANC_TK15SEN_Msk             (0x1ul << TK_SCANC_TK15SEN_Pos)                   /*!< TK_T::SCANC: TK15SEN Mask              */
+
+#define TK_SCANC_TK16SEN_Pos             (16)                                              /*!< TK_T::SCANC: TK16SEN Position          */
+#define TK_SCANC_TK16SEN_Msk             (0x1ul << TK_SCANC_TK16SEN_Pos)                   /*!< TK_T::SCANC: TK16SEN Mask              */
+
+#define TK_SCANC_AVDDH_S_Pos             (20)                                              /*!< TK_T::SCANC: AVDDH_S Position          */
+#define TK_SCANC_AVDDH_S_Msk             (0xful << TK_SCANC_AVDDH_S_Pos)                   /*!< TK_T::SCANC: AVDDH_S Mask              */
+
+#define TK_SCANC_SCAN_Pos                (24)                                              /*!< TK_T::SCANC: SCAN Position             */
+#define TK_SCANC_SCAN_Msk                (0x1ul << TK_SCANC_SCAN_Pos)                      /*!< TK_T::SCANC: SCAN Mask                 */
+
+#define TK_SCANC_TMRTRG_EN_Pos           (25)                                              /*!< TK_T::SCANC: TMRTRG_EN Position        */
+#define TK_SCANC_TMRTRG_EN_Msk           (0x1ul << TK_SCANC_TMRTRG_EN_Pos)                 /*!< TK_T::SCANC: TMRTRG_EN Mask            */
+
+#define TK_SCANC_TK_EN_Pos               (31)                                              /*!< TK_T::SCANC: TK_EN Position            */
+#define TK_SCANC_TK_EN_Msk               (0x1ul << TK_SCANC_TK_EN_Pos)                     /*!< TK_T::SCANC: TK_EN Mask                */
+
+#define TK_SCANC1_TK17SEN_Pos            (0)                                               /*!< TK_T::SCANC1: TK17SEN Position         */
+#define TK_SCANC1_TK17SEN_Msk            (0x1ul << TK_SCANC1_TK17SEN_Pos)                  /*!< TK_T::SCANC1: TK17SEN Mask             */
+
+#define TK_SCANC1_TK18SEN_Pos            (1)                                               /*!< TK_T::SCANC1: TK18SEN Position         */
+#define TK_SCANC1_TK18SEN_Msk            (0x1ul << TK_SCANC1_TK18SEN_Pos)                  /*!< TK_T::SCANC1: TK18SEN Mask             */
+
+#define TK_SCANC1_TK19SEN_Pos            (2)                                               /*!< TK_T::SCANC: TK19SEN Position          */
+#define TK_SCANC1_TK19SEN_Msk            (0x1ul << TK_SCANC1_TK19SEN_Pos)                  /*!< TK_T::SCANC: TK19SEN Mask              */
+
+#define TK_SCANC1_TK20SEN_Pos            (3)                                               /*!< TK_T::SCANC: TK20SEN Position          */
+#define TK_SCANC1_TK20SEN_Msk            (0x1ul << TK_SCANC1_TK20SEN_Pos)                  /*!< TK_T::SCANC: TK20SEN Mask              */
+
+#define TK_SCANC1_TK21SEN_Pos            (4)                                               /*!< TK_T::SCANC: TK21SEN Position          */
+#define TK_SCANC1_TK21SEN_Msk            (0x1ul << TK_SCANC1_TK21SEN_Pos)                  /*!< TK_T::SCANC: TK21SEN Mask              */
+
+#define TK_SCANC1_TK22SEN_Pos            (5)                                               /*!< TK_T::SCANC: TK22SEN Position          */
+#define TK_SCANC1_TK22SEN_Msk            (0x1ul << TK_SCANC1_TK22SEN_Pos)                  /*!< TK_T::SCANC: TK22SEN Mask              */
+
+#define TK_SCANC1_TK23SEN_Pos            (6)                                               /*!< TK_T::SCANC: TK23SEN Position          */
+#define TK_SCANC1_TK23SEN_Msk            (0x1ul << TK_SCANC1_TK23SEN_Pos)                  /*!< TK_T::SCANC: TK23SEN Mask              */
+
+#define TK_SCANC1_TK24SEN_Pos            (7)                                               /*!< TK_T::SCANC: TK24SEN Position          */
+#define TK_SCANC1_TK24SEN_Msk            (0x1ul << TK_SCANC1_TK24SEN_Pos)                  /*!< TK_T::SCANC: TK24SEN Mask              */
+
+#define TK_SCANC1_TK25SEN_Pos            (8)                                               /*!< TK_T::SCANC: TK25SEN Position          */
+#define TK_SCANC1_TK25SEN_Msk            (0x1ul << TK_SCANC1_TK25SEN_Pos)                  /*!< TK_T::SCANC: TK25SEN Mask              */
+
+#define TK_REFC_TK0REN_Pos               (0)                                               /*!< TK_T::REFC: TK0REN Position            */
+#define TK_REFC_TK0REN_Msk               (0x1ul << TK_REFC_TK0REN_Pos)                     /*!< TK_T::REFC: TK0REN Mask                */
+
+#define TK_REFC_TK1REN_Pos               (1)                                               /*!< TK_T::REFC: TK1REN Position            */
+#define TK_REFC_TK1REN_Msk               (0x1ul << TK_REFC_TK1REN_Pos)                     /*!< TK_T::REFC: TK1REN Mask                */
+
+#define TK_REFC_TK2REN_Pos               (2)                                               /*!< TK_T::REFC: TK2REN Position            */
+#define TK_REFC_TK2REN_Msk               (0x1ul << TK_REFC_TK2REN_Pos)                     /*!< TK_T::REFC: TK2REN Mask                */
+
+#define TK_REFC_TK3REN_Pos               (3)                                               /*!< TK_T::REFC: TK3REN Position            */
+#define TK_REFC_TK3REN_Msk               (0x1ul << TK_REFC_TK3REN_Pos)                     /*!< TK_T::REFC: TK3REN Mask                */
+
+#define TK_REFC_TK4REN_Pos               (4)                                               /*!< TK_T::REFC: TK4REN Position            */
+#define TK_REFC_TK4REN_Msk               (0x1ul << TK_REFC_TK4REN_Pos)                     /*!< TK_T::REFC: TK4REN Mask                */
+
+#define TK_REFC_TK5REN_Pos               (5)                                               /*!< TK_T::REFC: TK5REN Position            */
+#define TK_REFC_TK5REN_Msk               (0x1ul << TK_REFC_TK5REN_Pos)                     /*!< TK_T::REFC: TK5REN Mask                */
+
+#define TK_REFC_TK6REN_Pos               (6)                                               /*!< TK_T::REFC: TK6REN Position            */
+#define TK_REFC_TK6REN_Msk               (0x1ul << TK_REFC_TK6REN_Pos)                     /*!< TK_T::REFC: TK6REN Mask                */
+
+#define TK_REFC_TK7REN_Pos               (7)                                               /*!< TK_T::REFC: TK7REN Position            */
+#define TK_REFC_TK7REN_Msk               (0x1ul << TK_REFC_TK7REN_Pos)                     /*!< TK_T::REFC: TK7REN Mask                */
+
+#define TK_REFC_TK8REN_Pos               (8)                                               /*!< TK_T::REFC: TK8REN Position            */
+#define TK_REFC_TK8REN_Msk               (0x1ul << TK_REFC_TK8REN_Pos)                     /*!< TK_T::REFC: TK8REN Mask                */
+
+#define TK_REFC_TK9REN_Pos               (9)                                               /*!< TK_T::REFC: TK9REN Position            */
+#define TK_REFC_TK9REN_Msk               (0x1ul << TK_REFC_TK9REN_Pos)                     /*!< TK_T::REFC: TK9REN Mask                */
+
+#define TK_REFC_TK10REN_Pos              (10)                                              /*!< TK_T::REFC: TK10REN Position           */
+#define TK_REFC_TK10REN_Msk              (0x1ul << TK_REFC_TK10REN_Pos)                    /*!< TK_T::REFC: TK10REN Mask               */
+
+#define TK_REFC_TK11REN_Pos              (11)                                              /*!< TK_T::REFC: TK11REN Position           */
+#define TK_REFC_TK11REN_Msk              (0x1ul << TK_REFC_TK11REN_Pos)                    /*!< TK_T::REFC: TK11REN Mask               */
+
+#define TK_REFC_TK12REN_Pos              (12)                                              /*!< TK_T::REFC: TK12REN Position           */
+#define TK_REFC_TK12REN_Msk              (0x1ul << TK_REFC_TK12REN_Pos)                    /*!< TK_T::REFC: TK12REN Mask               */
+
+#define TK_REFC_TK13REN_Pos              (13)                                              /*!< TK_T::REFC: TK13REN Position           */
+#define TK_REFC_TK13REN_Msk              (0x1ul << TK_REFC_TK13REN_Pos)                    /*!< TK_T::REFC: TK13REN Mask               */
+
+#define TK_REFC_TK14REN_Pos              (14)                                              /*!< TK_T::REFC: TK14REN Position           */
+#define TK_REFC_TK14REN_Msk              (0x1ul << TK_REFC_TK14REN_Pos)                    /*!< TK_T::REFC: TK14REN Mask               */
+
+#define TK_REFC_TK15REN_Pos              (15)                                              /*!< TK_T::REFC: TK15REN Position           */
+#define TK_REFC_TK15REN_Msk              (0x1ul << TK_REFC_TK15REN_Pos)                    /*!< TK_T::REFC: TK15REN Mask               */
+
+#define TK_REFC_TK16REN_Pos              (16)                                              /*!< TK_T::REFC: TK16REN Position           */
+#define TK_REFC_TK16REN_Msk              (0x1ul << TK_REFC_TK16REN_Pos)                    /*!< TK_T::REFC: TK16REN Mask               */
+
+#define TK_REFC_SCAN_ALL_Pos             (23)                                              /*!< TK_T::REFC: SCAN_ALL Position          */
+#define TK_REFC_SCAN_ALL_Msk             (0x1ul << TK_REFC_SCAN_ALL_Pos)                   /*!< TK_T::REFC: SCAN_ALL Mask              */
+
+#define TK_REFC_SENSET_Pos               (24)                                              /*!< TK_T::REFC: SENSET Position            */
+#define TK_REFC_SENSET_Msk               (0x7ul << TK_REFC_SENSET_Pos)                     /*!< TK_T::REFC: SENSET Mask                */
+
+#define TK_REFC_PULSET_Pos               (28)                                              /*!< TK_T::REFC: PULSET Position            */
+#define TK_REFC_PULSET_Msk               (0x7ul << TK_REFC_PULSET_Pos)                     /*!< TK_T::REFC: PULSET Mask                */
+
+#define TK_REFC1_TK17REN_Pos             (0)                                               /*!< TK_T::REFC1: TK17REN Position          */
+#define TK_REFC1_TK17REN_Msk             (0x1ul << TK_REFC1_TK17REN_Pos)                   /*!< TK_T::REFC1: TK17REN Mask              */
+
+#define TK_REFC1_TK18REN_Pos             (1)                                               /*!< TK_T::REFC1: TK18REN Position          */
+#define TK_REFC1_TK18REN_Msk             (0x1ul << TK_REFC1_TK18REN_Pos)                   /*!< TK_T::REFC1: TK18REN Mask              */
+
+#define TK_REFC1_TK19REN_Pos             (2)                                               /*!< TK_T::REFC1: TK19REN Position          */
+#define TK_REFC1_TK19REN_Msk             (0x1ul << TK_REFC1_TK19REN_Pos)                   /*!< TK_T::REFC1: TK19REN Mask              */
+
+#define TK_REFC1_TK20REN_Pos             (3)                                               /*!< TK_T::REFC1: TK20REN Position          */
+#define TK_REFC1_TK20REN_Msk             (0x1ul << TK_REFC1_TK20REN_Pos)                   /*!< TK_T::REFC1: TK20REN Mask              */
+
+#define TK_REFC1_TK21REN_Pos             (4)                                               /*!< TK_T::REFC1: TK21REN Position          */
+#define TK_REFC1_TK21REN_Msk             (0x1ul << TK_REFC1_TK21REN_Pos)                   /*!< TK_T::REFC1: TK21REN Mask              */
+
+#define TK_REFC1_TK22REN_Pos             (5)                                               /*!< TK_T::REFC1: TK22REN Position          */
+#define TK_REFC1_TK22REN_Msk             (0x1ul << TK_REFC1_TK22REN_Pos)                   /*!< TK_T::REFC1: TK22REN Mask              */
+
+#define TK_REFC1_TK23REN_Pos             (6)                                               /*!< TK_T::REFC1: TK23REN Position          */
+#define TK_REFC1_TK23REN_Msk             (0x1ul << TK_REFC1_TK23REN_Pos)                   /*!< TK_T::REFC1: TK23REN Mask              */
+
+#define TK_REFC1_TK24REN_Pos             (7)                                               /*!< TK_T::REFC1: TK24REN Position          */
+#define TK_REFC1_TK24REN_Msk             (0x1ul << TK_REFC1_TK24REN_Pos)                   /*!< TK_T::REFC1: TK24REN Mask              */
+
+#define TK_REFC1_TK25REN_Pos             (8)                                               /*!< TK_T::REFC1: TK25REN Position          */
+#define TK_REFC1_TK25REN_Msk             (0x1ul << TK_REFC1_TK25REN_Pos)                   /*!< TK_T::REFC1: TK25REN Mask              */
+
+#define TK_CCBD0_CCBD0_Pos               (0)                                               /*!< TK_T::CCBD0: CCBD0 Position            */
+#define TK_CCBD0_CCBD0_Msk               (0xfful << TK_CCBD0_CCBD0_Pos)                    /*!< TK_T::CCBD0: CCBD0 Mask                */
+
+#define TK_CCBD0_CCBD1_Pos               (8)                                               /*!< TK_T::CCBD0: CCBD1 Position            */
+#define TK_CCBD0_CCBD1_Msk               (0xfful << TK_CCBD0_CCBD1_Pos)                    /*!< TK_T::CCBD0: CCBD1 Mask                */
+
+#define TK_CCBD0_CCBD2_Pos               (16)                                              /*!< TK_T::CCBD0: CCBD2 Position            */
+#define TK_CCBD0_CCBD2_Msk               (0xfful << TK_CCBD0_CCBD2_Pos)                    /*!< TK_T::CCBD0: CCBD2 Mask                */
+
+#define TK_CCBD0_CCBD3_Pos               (24)                                              /*!< TK_T::CCBD0: CCBD3 Position            */
+#define TK_CCBD0_CCBD3_Msk               (0xfful << TK_CCBD0_CCBD3_Pos)                    /*!< TK_T::CCBD0: CCBD3 Mask                */
+
+#define TK_CCBD1_CCBD4_Pos               (0)                                               /*!< TK_T::CCBD1: CCBD4 Position            */
+#define TK_CCBD1_CCBD4_Msk               (0xfful << TK_CCBD1_CCBD4_Pos)                    /*!< TK_T::CCBD1: CCBD4 Mask                */
+
+#define TK_CCBD1_CCBD5_Pos               (8)                                               /*!< TK_T::CCBD1: CCBD5 Position            */
+#define TK_CCBD1_CCBD5_Msk               (0xfful << TK_CCBD1_CCBD5_Pos)                    /*!< TK_T::CCBD1: CCBD5 Mask                */
+
+#define TK_CCBD1_CCBD6_Pos               (16)                                              /*!< TK_T::CCBD1: CCBD6 Position            */
+#define TK_CCBD1_CCBD6_Msk               (0xfful << TK_CCBD1_CCBD6_Pos)                    /*!< TK_T::CCBD1: CCBD6 Mask                */
+
+#define TK_CCBD1_CCBD7_Pos               (24)                                              /*!< TK_T::CCBD1: CCBD7 Position            */
+#define TK_CCBD1_CCBD7_Msk               (0xfful << TK_CCBD1_CCBD7_Pos)                    /*!< TK_T::CCBD1: CCBD7 Mask                */
+
+#define TK_CCBD2_CCBD8_Pos               (0)                                               /*!< TK_T::CCBD2: CCBD8 Position            */
+#define TK_CCBD2_CCBD8_Msk               (0xfful << TK_CCBD2_CCBD8_Pos)                    /*!< TK_T::CCBD2: CCBD8 Mask                */
+
+#define TK_CCBD2_CCBD9_Pos               (8)                                               /*!< TK_T::CCBD2: CCBD9 Position            */
+#define TK_CCBD2_CCBD9_Msk               (0xfful << TK_CCBD2_CCBD9_Pos)                    /*!< TK_T::CCBD2: CCBD9 Mask                */
+
+#define TK_CCBD2_CCBD10_Pos              (16)                                              /*!< TK_T::CCBD2: CCBD10 Position           */
+#define TK_CCBD2_CCBD10_Msk              (0xfful << TK_CCBD2_CCBD10_Pos)                   /*!< TK_T::CCBD2: CCBD10 Mask               */
+
+#define TK_CCBD2_CCBD11_Pos              (24)                                              /*!< TK_T::CCBD2: CCBD11 Position           */
+#define TK_CCBD2_CCBD11_Msk              (0xfful << TK_CCBD2_CCBD11_Pos)                   /*!< TK_T::CCBD2: CCBD11 Mask               */
+
+#define TK_CCBD3_CCBD12_Pos              (0)                                               /*!< TK_T::CCBD3: CCBD12 Position           */
+#define TK_CCBD3_CCBD12_Msk              (0xfful << TK_CCBD3_CCBD12_Pos)                   /*!< TK_T::CCBD3: CCBD12 Mask               */
+
+#define TK_CCBD3_CCBD13_Pos              (8)                                               /*!< TK_T::CCBD3: CCBD13 Position           */
+#define TK_CCBD3_CCBD13_Msk              (0xfful << TK_CCBD3_CCBD13_Pos)                   /*!< TK_T::CCBD3: CCBD13 Mask               */
+
+#define TK_CCBD3_CCBD14_Pos              (16)                                              /*!< TK_T::CCBD3: CCBD14 Position           */
+#define TK_CCBD3_CCBD14_Msk              (0xfful << TK_CCBD3_CCBD14_Pos)                   /*!< TK_T::CCBD3: CCBD14 Mask               */
+
+#define TK_CCBD3_CCBD15_Pos              (24)                                              /*!< TK_T::CCBD3: CCBD15 Position           */
+#define TK_CCBD3_CCBD15_Msk              (0xfful << TK_CCBD3_CCBD15_Pos)                   /*!< TK_T::CCBD3: CCBD15 Mask               */
+
+#define TK_CCBD4_CCBD16_Pos              (0)                                               /*!< TK_T::CCBD4: CCBD16 Position           */
+#define TK_CCBD4_CCBD16_Msk              (0xfful << TK_CCBD4_CCBD16_Pos)                   /*!< TK_T::CCBD4: CCBD16 Mask               */
+
+#define TK_CCBD4_CCBD_ALL_Pos            (8)                                               /*!< TK_T::CCBD4: CCBD_ALL Position         */
+#define TK_CCBD4_CCBD_ALL_Msk            (0xfful << TK_CCBD4_CCBD_ALL_Pos)                 /*!< TK_T::CCBD4: CCBD_ALL Mask             */
+
+#define TK_CCBD5_CCBD17_Pos              (0)                                               /*!< TK_T::CCBD5: CCBD17 Position           */
+#define TK_CCBD5_CCBD17_Msk              (0xfful << TK_CCBD5_CCBD17_Pos)                   /*!< TK_T::CCBD5: CCBD17 Mask               */
+
+#define TK_CCBD5_CCBD18_Pos              (8)                                               /*!< TK_T::CCBD5: CCBD18 Position           */
+#define TK_CCBD5_CCBD18_Msk              (0xfful << TK_CCBD5_CCBD18_Pos)                   /*!< TK_T::CCBD5: CCBD18 Mask               */
+
+#define TK_CCBD5_CCBD19_Pos              (16)                                              /*!< TK_T::CCBD5: CCBD19 Position           */
+#define TK_CCBD5_CCBD19_Msk              (0xfful << TK_CCBD5_CCBD19_Pos)                   /*!< TK_T::CCBD5: CCBD19 Mask               */
+
+#define TK_CCBD5_CCBD20_Pos              (24)                                              /*!< TK_T::CCBD5: CCBD20 Position           */
+#define TK_CCBD5_CCBD20_Msk              (0xfful << TK_CCBD5_CCBD20_Pos)                   /*!< TK_T::CCBD5: CCBD20 Mask               */
+
+#define TK_CCBD6_CCBD21_Pos              (0)                                               /*!< TK_T::CCBD6: CCBD21 Position           */
+#define TK_CCBD6_CCBD21_Msk              (0xfful << TK_CCBD6_CCBD21_Pos)                   /*!< TK_T::CCBD6: CCBD21 Mask               */
+
+#define TK_CCBD6_CCBD22_Pos              (8)                                               /*!< TK_T::CCBD6: CCBD22 Position           */
+#define TK_CCBD6_CCBD22_Msk              (0xfful << TK_CCBD6_CCBD22_Pos)                   /*!< TK_T::CCBD6: CCBD22 Mask               */
+
+#define TK_CCBD6_CCBD23_Pos              (16)                                              /*!< TK_T::CCBD6: CCBD23 Position           */
+#define TK_CCBD6_CCBD23_Msk              (0xfful << TK_CCBD6_CCBD23_Pos)                   /*!< TK_T::CCBD6: CCBD23 Mask               */
+
+#define TK_CCBD6_CCBD24_Pos              (24)                                              /*!< TK_T::CCBD6: CCBD24 Position           */
+#define TK_CCBD6_CCBD24_Msk              (0xfful << TK_CCBD6_CCBD24_Pos)                   /*!< TK_T::CCBD6: CCBD24 Mask               */
+
+#define TK_CCBD7_CCBD25_Pos              (0)                                               /*!< TK_T::CCBD7: CCBD25 Position           */
+#define TK_CCBD7_CCBD25_Msk              (0xfful << TK_CCBD7_CCBD25_Pos)                   /*!< TK_T::CCBD7: CCBD25 Mask               */
+
+#define TK_IDLSC_IDLS0_Pos               (0)                                               /*!< TK_T::IDLSC: IDLS0 Position            */
+#define TK_IDLSC_IDLS0_Msk               (0x3ul << TK_IDLSC_IDLS0_Pos)                     /*!< TK_T::IDLSC: IDLS0 Mask                */
+
+#define TK_IDLSC_IDLS1_Pos               (2)                                               /*!< TK_T::IDLSC: IDLS1 Position            */
+#define TK_IDLSC_IDLS1_Msk               (0x3ul << TK_IDLSC_IDLS1_Pos)                     /*!< TK_T::IDLSC: IDLS1 Mask                */
+
+#define TK_IDLSC_IDLS2_Pos               (4)                                               /*!< TK_T::IDLSC: IDLS2 Position            */
+#define TK_IDLSC_IDLS2_Msk               (0x3ul << TK_IDLSC_IDLS2_Pos)                     /*!< TK_T::IDLSC: IDLS2 Mask                */
+
+#define TK_IDLSC_IDLS3_Pos               (6)                                               /*!< TK_T::IDLSC: IDLS3 Position            */
+#define TK_IDLSC_IDLS3_Msk               (0x3ul << TK_IDLSC_IDLS3_Pos)                     /*!< TK_T::IDLSC: IDLS3 Mask                */
+
+#define TK_IDLSC_IDLS4_Pos               (8)                                               /*!< TK_T::IDLSC: IDLS4 Position            */
+#define TK_IDLSC_IDLS4_Msk               (0x3ul << TK_IDLSC_IDLS4_Pos)                     /*!< TK_T::IDLSC: IDLS4 Mask                */
+
+#define TK_IDLSC_IDLS5_Pos               (10)                                              /*!< TK_T::IDLSC: IDLS5 Position            */
+#define TK_IDLSC_IDLS5_Msk               (0x3ul << TK_IDLSC_IDLS5_Pos)                     /*!< TK_T::IDLSC: IDLS5 Mask                */
+
+#define TK_IDLSC_IDLS6_Pos               (12)                                              /*!< TK_T::IDLSC: IDLS6 Position            */
+#define TK_IDLSC_IDLS6_Msk               (0x3ul << TK_IDLSC_IDLS6_Pos)                     /*!< TK_T::IDLSC: IDLS6 Mask                */
+
+#define TK_IDLSC_IDLS7_Pos               (14)                                              /*!< TK_T::IDLSC: IDLS7 Position            */
+#define TK_IDLSC_IDLS7_Msk               (0x3ul << TK_IDLSC_IDLS7_Pos)                     /*!< TK_T::IDLSC: IDLS7 Mask                */
+
+#define TK_IDLSC_IDLS8_Pos               (16)                                              /*!< TK_T::IDLSC: IDLS8 Position            */
+#define TK_IDLSC_IDLS8_Msk               (0x3ul << TK_IDLSC_IDLS8_Pos)                     /*!< TK_T::IDLSC: IDLS8 Mask                */
+
+#define TK_IDLSC_IDLS9_Pos               (18)                                              /*!< TK_T::IDLSC: IDLS9 Position            */
+#define TK_IDLSC_IDLS9_Msk               (0x3ul << TK_IDLSC_IDLS9_Pos)                     /*!< TK_T::IDLSC: IDLS9 Mask                */
+
+#define TK_IDLSC_IDLS10_Pos              (20)                                              /*!< TK_T::IDLSC: IDLS10 Position           */
+#define TK_IDLSC_IDLS10_Msk              (0x3ul << TK_IDLSC_IDLS10_Pos)                    /*!< TK_T::IDLSC: IDLS10 Mask               */
+
+#define TK_IDLSC_IDLS11_Pos              (22)                                              /*!< TK_T::IDLSC: IDLS11 Position           */
+#define TK_IDLSC_IDLS11_Msk              (0x3ul << TK_IDLSC_IDLS11_Pos)                    /*!< TK_T::IDLSC: IDLS11 Mask               */
+
+#define TK_IDLSC_IDLS12_Pos              (24)                                              /*!< TK_T::IDLSC: IDLS12 Position           */
+#define TK_IDLSC_IDLS12_Msk              (0x3ul << TK_IDLSC_IDLS12_Pos)                    /*!< TK_T::IDLSC: IDLS12 Mask               */
+
+#define TK_IDLSC_IDLS13_Pos              (26)                                              /*!< TK_T::IDLSC: IDLS13 Position           */
+#define TK_IDLSC_IDLS13_Msk              (0x3ul << TK_IDLSC_IDLS13_Pos)                    /*!< TK_T::IDLSC: IDLS13 Mask               */
+
+#define TK_IDLSC_IDLS14_Pos              (28)                                              /*!< TK_T::IDLSC: IDLS14 Position           */
+#define TK_IDLSC_IDLS14_Msk              (0x3ul << TK_IDLSC_IDLS14_Pos)                    /*!< TK_T::IDLSC: IDLS14 Mask               */
+
+#define TK_IDLSC_IDLS15_Pos              (30)                                              /*!< TK_T::IDLSC: IDLS15 Position           */
+#define TK_IDLSC_IDLS15_Msk              (0x3ul << TK_IDLSC_IDLS15_Pos)                    /*!< TK_T::IDLSC: IDLS15 Mask               */
+
+#define TK_POLC_IDLS16_Pos               (0)                                               /*!< TK_T::POLC: IDLS16 Position            */
+#define TK_POLC_IDLS16_Msk               (0x3ul << TK_POLC_IDLS16_Pos)                     /*!< TK_T::POLC: IDLS16 Mask                */
+
+#define TK_IDLSC1_IDLS17_Pos             (0)                                               /*!< TK_T::IDLSC1: IDLS17 Position          */
+#define TK_IDLSC1_IDLS17_Msk             (0x3ul << TK_IDLSC1_IDLS17_Pos)                   /*!< TK_T::IDLSC1: IDLS17 Mask              */
+
+#define TK_IDLSC1_IDLS18_Pos             (2)                                               /*!< TK_T::IDLSC1: IDLS18 Position          */
+#define TK_IDLSC1_IDLS18_Msk             (0x3ul << TK_IDLSC1_IDLS18_Pos)                   /*!< TK_T::IDLSC1: IDLS18 Mask              */
+
+#define TK_IDLSC1_IDLS19_Pos             (4)                                               /*!< TK_T::IDLSC1: IDLS19 Position          */
+#define TK_IDLSC1_IDLS19_Msk             (0x3ul << TK_IDLSC1_IDLS19_Pos)                   /*!< TK_T::IDLSC1: IDLS19 Mask              */
+
+#define TK_IDLSC1_IDLS20_Pos             (6)                                               /*!< TK_T::IDLSC1: IDLS20 Position          */
+#define TK_IDLSC1_IDLS20_Msk             (0x3ul << TK_IDLSC1_IDLS20_Pos)                   /*!< TK_T::IDLSC1: IDLS20 Mask              */
+
+#define TK_IDLSC1_IDLS21_Pos             (8)                                               /*!< TK_T::IDLSC1: IDLS21 Position          */
+#define TK_IDLSC1_IDLS21_Msk             (0x3ul << TK_IDLSC1_IDLS21_Pos)                   /*!< TK_T::IDLSC1: IDLS21 Mask              */
+
+#define TK_IDLSC1_IDLS22_Pos             (10)                                              /*!< TK_T::IDLSC1: IDLS22 Position          */
+#define TK_IDLSC1_IDLS22_Msk             (0x3ul << TK_IDLSC1_IDLS22_Pos)                   /*!< TK_T::IDLSC1: IDLS22 Mask              */
+
+#define TK_IDLSC1_IDLS23_Pos             (12)                                              /*!< TK_T::IDLSC1: IDLS23 Position          */
+#define TK_IDLSC1_IDLS23_Msk             (0x3ul << TK_IDLSC1_IDLS23_Pos)                   /*!< TK_T::IDLSC1: IDLS23 Mask              */
+
+#define TK_IDLSC1_IDLS24_Pos             (14)                                              /*!< TK_T::IDLSC1: IDLS24 Position          */
+#define TK_IDLSC1_IDLS24_Msk             (0x3ul << TK_IDLSC1_IDLS24_Pos)                   /*!< TK_T::IDLSC1: IDLS24 Mask              */
+
+#define TK_IDLSC1_IDLS25_Pos             (16)                                              /*!< TK_T::IDLSC1: IDLS25 Position          */
+#define TK_IDLSC1_IDLS25_Msk             (0x3ul << TK_IDLSC1_IDLS25_Pos)                   /*!< TK_T::IDLSC1: IDLS25 Mask              */
+
+#define TK_POLSEL_POL0_Pos               (0)                                               /*!< TK_T::POLSEL: POL0 Position            */
+#define TK_POLSEL_POL0_Msk               (0x3ul << TK_POLSEL_POL0_Pos)                     /*!< TK_T::POLSEL: POL0 Mask                */
+
+#define TK_POLSEL_POL1_Pos               (2)                                               /*!< TK_T::POLSEL: POL1 Position            */
+#define TK_POLSEL_POL1_Msk               (0x3ul << TK_POLSEL_POL1_Pos)                     /*!< TK_T::POLSEL: POL1 Mask                */
+
+#define TK_POLSEL_POL2_Pos               (4)                                               /*!< TK_T::POLSEL: POL2 Position            */
+#define TK_POLSEL_POL2_Msk               (0x3ul << TK_POLSEL_POL2_Pos)                     /*!< TK_T::POLSEL: POL2 Mask                */
+
+#define TK_POLSEL_POL3_Pos               (6)                                               /*!< TK_T::POLSEL: POL3 Position            */
+#define TK_POLSEL_POL3_Msk               (0x3ul << TK_POLSEL_POL3_Pos)                     /*!< TK_T::POLSEL: POL3 Mask                */
+
+#define TK_POLSEL_POL4_Pos               (8)                                               /*!< TK_T::POLSEL: POL4 Position            */
+#define TK_POLSEL_POL4_Msk               (0x3ul << TK_POLSEL_POL4_Pos)                     /*!< TK_T::POLSEL: POL4 Mask                */
+
+#define TK_POLSEL_POL5_Pos               (10)                                              /*!< TK_T::POLSEL: POL5 Position            */
+#define TK_POLSEL_POL5_Msk               (0x3ul << TK_POLSEL_POL5_Pos)                     /*!< TK_T::POLSEL: POL5 Mask                */
+
+#define TK_POLSEL_POL6_Pos               (12)                                              /*!< TK_T::POLSEL: POL6 Position            */
+#define TK_POLSEL_POL6_Msk               (0x3ul << TK_POLSEL_POL6_Pos)                     /*!< TK_T::POLSEL: POL6 Mask                */
+
+#define TK_POLSEL_POL7_Pos               (14)                                              /*!< TK_T::POLSEL: POL7 Position            */
+#define TK_POLSEL_POL7_Msk               (0x3ul << TK_POLSEL_POL7_Pos)                     /*!< TK_T::POLSEL: POL7 Mask                */
+
+#define TK_POLSEL_POL8_Pos               (16)                                              /*!< TK_T::POLSEL: POL8 Position            */
+#define TK_POLSEL_POL8_Msk               (0x3ul << TK_POLSEL_POL8_Pos)                     /*!< TK_T::POLSEL: POL8 Mask                */
+
+#define TK_POLSEL_POL9_Pos               (18)                                              /*!< TK_T::POLSEL: POL9 Position            */
+#define TK_POLSEL_POL9_Msk               (0x3ul << TK_POLSEL_POL9_Pos)                     /*!< TK_T::POLSEL: POL9 Mask                */
+
+#define TK_POLSEL_POL10_Pos              (20)                                              /*!< TK_T::POLSEL: POL10 Position           */
+#define TK_POLSEL_POL10_Msk              (0x3ul << TK_POLSEL_POL10_Pos)                    /*!< TK_T::POLSEL: POL10 Mask               */
+
+#define TK_POLSEL_POL11_Pos              (22)                                              /*!< TK_T::POLSEL: POL11 Position           */
+#define TK_POLSEL_POL11_Msk              (0x3ul << TK_POLSEL_POL11_Pos)                    /*!< TK_T::POLSEL: POL11 Mask               */
+
+#define TK_POLSEL_POL12_Pos              (24)                                              /*!< TK_T::POLSEL: POL12 Position           */
+#define TK_POLSEL_POL12_Msk              (0x3ul << TK_POLSEL_POL12_Pos)                    /*!< TK_T::POLSEL: POL12 Mask               */
+
+#define TK_POLSEL_POL13_Pos              (26)                                              /*!< TK_T::POLSEL: POL13 Position           */
+#define TK_POLSEL_POL13_Msk              (0x3ul << TK_POLSEL_POL13_Pos)                    /*!< TK_T::POLSEL: POL13 Mask               */
+
+#define TK_POLSEL_POL14_Pos              (28)                                              /*!< TK_T::POLSEL: POL14 Position           */
+#define TK_POLSEL_POL14_Msk              (0x3ul << TK_POLSEL_POL14_Pos)                    /*!< TK_T::POLSEL: POL14 Mask               */
+
+#define TK_POLSEL_POL15_Pos              (30)                                              /*!< TK_T::POLSEL: POL15 Position           */
+#define TK_POLSEL_POL15_Msk              (0x3ul << TK_POLSEL_POL15_Pos)                    /*!< TK_T::POLSEL: POL15 Mask               */
+
+#define TK_POLC_IDLS16_Pos               (0)                                               /*!< TK_T::POLC: IDLS16 Position            */
+#define TK_POLC_IDLS16_Msk               (0x3ul << TK_POLC_IDLS16_Pos)                     /*!< TK_T::POLC: IDLS16 Mask                */
+
+#define TK_POLC_POL16_Pos                (2)                                               /*!< TK_T::POLC: POL16 Position             */
+#define TK_POLC_POL16_Msk                (0x3ul << TK_POLC_POL16_Pos)                      /*!< TK_T::POLC: POL16 Mask                 */
+
+#define TK_POLSEL1_POL17_Pos             (0)                                               /*!< TK_T::POLSEL1: POL17 Position          */
+#define TK_POLSEL1_POL17_Msk             (0x3ul << TK_POLSEL1_POL17_Pos)                   /*!< TK_T::POLSEL1: POL17 Mask              */
+
+#define TK_POLSEL1_POL18_Pos             (2)                                               /*!< TK_T::POLSEL1: POL18 Position          */
+#define TK_POLSEL1_POL18_Msk             (0x3ul << TK_POLSEL1_POL18_Pos)                   /*!< TK_T::POLSEL1: POL18 Mask              */
+
+#define TK_POLSEL1_POL19_Pos             (4)                                               /*!< TK_T::POLSEL1: POL19 Position          */
+#define TK_POLSEL1_POL19_Msk             (0x3ul << TK_POLSEL1_POL19_Pos)                   /*!< TK_T::POLSEL1: POL19 Mask              */
+
+#define TK_POLSEL1_POL20_Pos             (6)                                               /*!< TK_T::POLSEL1: POL20 Position          */
+#define TK_POLSEL1_POL20_Msk             (0x3ul << TK_POLSEL1_POL20_Pos)                   /*!< TK_T::POLSEL1: POL20 Mask              */
+
+#define TK_POLSEL1_POL21_Pos             (8)                                               /*!< TK_T::POLSEL1: POL21 Position          */
+#define TK_POLSEL1_POL21_Msk             (0x3ul << TK_POLSEL1_POL21_Pos)                   /*!< TK_T::POLSEL1: POL21 Mask              */
+
+#define TK_POLSEL1_POL22_Pos             (10)                                              /*!< TK_T::POLSEL1: POL22 Position          */
+#define TK_POLSEL1_POL22_Msk             (0x3ul << TK_POLSEL1_POL22_Pos)                   /*!< TK_T::POLSEL1: POL22 Mask              */
+
+#define TK_POLSEL1_POL23_Pos             (12)                                              /*!< TK_T::POLSEL1: POL23 Position          */
+#define TK_POLSEL1_POL23_Msk             (0x3ul << TK_POLSEL1_POL23_Pos)                   /*!< TK_T::POLSEL1: POL23 Mask              */
+
+#define TK_POLSEL1_POL24_Pos             (14)                                              /*!< TK_T::POLSEL1: POL24 Position          */
+#define TK_POLSEL1_POL24_Msk             (0x3ul << TK_POLSEL1_POL24_Pos)                   /*!< TK_T::POLSEL1: POL24 Mask              */
+
+#define TK_POLSEL1_POL25_Pos             (16)                                              /*!< TK_T::POLSEL1: POL25 Position          */
+#define TK_POLSEL1_POL25_Msk             (0x3ul << TK_POLSEL1_POL25_Pos)                   /*!< TK_T::POLSEL1: POL25 Mask              */
+
+#define TK_POLC_POL_CAP_Pos              (4)                                               /*!< TK_T::POLC: POL_CAP Position           */
+#define TK_POLC_POL_CAP_Msk              (0x3ul << TK_POLC_POL_CAP_Pos)                    /*!< TK_T::POLC: POL_CAP Mask               */
+
+#define TK_POLC_POLEN0_Pos               (8)                                               /*!< TK_T::POLC: POLEN0 Position            */
+#define TK_POLC_POLEN0_Msk               (0x1ul << TK_POLC_POLEN0_Pos)                     /*!< TK_T::POLC: POLEN0 Mask                */
+
+#define TK_POLC_POLEN1_Pos               (9)                                               /*!< TK_T::POLC: POLEN1 Position            */
+#define TK_POLC_POLEN1_Msk               (0x1ul << TK_POLC_POLEN1_Pos)                     /*!< TK_T::POLC: POLEN1 Mask                */
+
+#define TK_POLC_POLEN2_Pos               (10)                                              /*!< TK_T::POLC: POLEN2 Position            */
+#define TK_POLC_POLEN2_Msk               (0x1ul << TK_POLC_POLEN2_Pos)                     /*!< TK_T::POLC: POLEN2 Mask                */
+
+#define TK_POLC_POLEN3_Pos               (11)                                              /*!< TK_T::POLC: POLEN3 Position            */
+#define TK_POLC_POLEN3_Msk               (0x1ul << TK_POLC_POLEN3_Pos)                     /*!< TK_T::POLC: POLEN3 Mask                */
+
+#define TK_POLC_POLEN4_Pos               (12)                                              /*!< TK_T::POLC: POLEN4 Position            */
+#define TK_POLC_POLEN4_Msk               (0x1ul << TK_POLC_POLEN4_Pos)                     /*!< TK_T::POLC: POLEN4 Mask                */
+
+#define TK_POLC_POLEN5_Pos               (13)                                              /*!< TK_T::POLC: POLEN5 Position            */
+#define TK_POLC_POLEN5_Msk               (0x1ul << TK_POLC_POLEN5_Pos)                     /*!< TK_T::POLC: POLEN5 Mask                */
+
+#define TK_POLC_POLEN6_Pos               (14)                                              /*!< TK_T::POLC: POLEN6 Position            */
+#define TK_POLC_POLEN6_Msk               (0x1ul << TK_POLC_POLEN6_Pos)                     /*!< TK_T::POLC: POLEN6 Mask                */
+
+#define TK_POLC_POLEN7_Pos               (15)                                              /*!< TK_T::POLC: POLEN7 Position            */
+#define TK_POLC_POLEN7_Msk               (0x1ul << TK_POLC_POLEN7_Pos)                     /*!< TK_T::POLC: POLEN7 Mask                */
+
+#define TK_POLC_POLEN8_Pos               (16)                                              /*!< TK_T::POLC: POLEN8 Position            */
+#define TK_POLC_POLEN8_Msk               (0x1ul << TK_POLC_POLEN8_Pos)                     /*!< TK_T::POLC: POLEN8 Mask                */
+
+#define TK_POLC_POLEN9_Pos               (17)                                              /*!< TK_T::POLC: POLEN9 Position            */
+#define TK_POLC_POLEN9_Msk               (0x1ul << TK_POLC_POLEN9_Pos)                     /*!< TK_T::POLC: POLEN9 Mask                */
+
+#define TK_POLC_POLEN10_Pos              (18)                                              /*!< TK_T::POLC: POLEN10 Position           */
+#define TK_POLC_POLEN10_Msk              (0x1ul << TK_POLC_POLEN10_Pos)                    /*!< TK_T::POLC: POLEN10 Mask               */
+
+#define TK_POLC_POLEN11_Pos              (19)                                              /*!< TK_T::POLC: POLEN11 Position           */
+#define TK_POLC_POLEN11_Msk              (0x1ul << TK_POLC_POLEN11_Pos)                    /*!< TK_T::POLC: POLEN11 Mask               */
+
+#define TK_POLC_POLEN12_Pos              (20)                                              /*!< TK_T::POLC: POLEN12 Position           */
+#define TK_POLC_POLEN12_Msk              (0x1ul << TK_POLC_POLEN12_Pos)                    /*!< TK_T::POLC: POLEN12 Mask               */
+
+#define TK_POLC_POLEN13_Pos              (21)                                              /*!< TK_T::POLC: POLEN13 Position           */
+#define TK_POLC_POLEN13_Msk              (0x1ul << TK_POLC_POLEN13_Pos)                    /*!< TK_T::POLC: POLEN13 Mask               */
+
+#define TK_POLC_POLEN14_Pos              (22)                                              /*!< TK_T::POLC: POLEN14 Position           */
+#define TK_POLC_POLEN14_Msk              (0x1ul << TK_POLC_POLEN14_Pos)                    /*!< TK_T::POLC: POLEN14 Mask               */
+
+#define TK_POLC_POLEN15_Pos              (23)                                              /*!< TK_T::POLC: POLEN15 Position           */
+#define TK_POLC_POLEN15_Msk              (0x1ul << TK_POLC_POLEN15_Pos)                    /*!< TK_T::POLC: POLEN15 Mask               */
+
+#define TK_POLC_POLEN16_Pos              (24)                                              /*!< TK_T::POLC: POLEN16 Position           */
+#define TK_POLC_POLEN16_Msk              (0x1ul << TK_POLC_POLEN16_Pos)                    /*!< TK_T::POLC: POLEN16 Mask               */
+
+#define TK_POLC1_POLEN17_Pos             (0)                                               /*!< TK_T::POLC1: POLEN17 Position          */
+#define TK_POLC1_POLEN17_Msk             (0x1ul << TK_POLC1_POLEN17_Pos)                   /*!< TK_T::POLC1: POLEN17 Mask              */
+
+#define TK_POLC1_POLEN18_Pos             (1)                                               /*!< TK_T::POLC1: POLEN18 Position          */
+#define TK_POLC1_POLEN18_Msk             (0x1ul << TK_POLC1_POLEN18_Pos)                   /*!< TK_T::POLC1: POLEN18 Mask              */
+
+#define TK_POLC1_POLEN19_Pos             (2)                                               /*!< TK_T::POLC1: POLEN19 Position          */
+#define TK_POLC1_POLEN19_Msk             (0x1ul << TK_POLC1_POLEN19_Pos)                   /*!< TK_T::POLC1: POLEN19 Mask              */
+
+#define TK_POLC1_POLEN20_Pos             (3)                                               /*!< TK_T::POLC1: POLEN20 Position          */
+#define TK_POLC1_POLEN20_Msk             (0x1ul << TK_POLC1_POLEN20_Pos)                   /*!< TK_T::POLC1: POLEN20 Mask              */
+
+#define TK_POLC1_POLEN21_Pos             (4)                                               /*!< TK_T::POLC1: POLEN21 Position          */
+#define TK_POLC1_POLEN21_Msk             (0x1ul << TK_POLC1_POLEN21_Pos)                   /*!< TK_T::POLC1: POLEN21 Mask              */
+
+#define TK_POLC1_POLEN22_Pos             (5)                                               /*!< TK_T::POLC1: POLEN22 Position          */
+#define TK_POLC1_POLEN22_Msk             (0x1ul << TK_POLC1_POLEN22_Pos)                   /*!< TK_T::POLC1: POLEN22 Mask              */
+
+#define TK_POLC1_POLEN23_Pos             (6)                                               /*!< TK_T::POLC1: POLEN23 Position          */
+#define TK_POLC1_POLEN23_Msk             (0x1ul << TK_POLC1_POLEN23_Pos)                   /*!< TK_T::POLC1: POLEN23 Mask              */
+
+#define TK_POLC1_POLEN24_Pos             (7)                                               /*!< TK_T::POLC1: POLEN24 Position          */
+#define TK_POLC1_POLEN24_Msk             (0x1ul << TK_POLC1_POLEN24_Pos)                   /*!< TK_T::POLC1: POLEN24 Mask              */
+
+#define TK_POLC1_POLEN25_Pos             (8)                                               /*!< TK_T::POLC1: POLEN25 Position          */
+#define TK_POLC1_POLEN25_Msk             (0x1ul << TK_POLC1_POLEN25_Pos)                   /*!< TK_T::POLC1: POLEN25 Mask              */
+
+#define TK_POLC_POL_INIT_Pos             (31)                                              /*!< TK_T::POLC: POL_INIT Position          */
+#define TK_POLC_POL_INIT_Msk             (0x1ul << TK_POLC_POL_INIT_Pos)                   /*!< TK_T::POLC: POL_INIT Mask              */
+
+#define TK_STA_BUSY_Pos                  (0)                                               /*!< TK_T::STA: BUSY Position               */
+#define TK_STA_BUSY_Msk                  (0x1ul << TK_STA_BUSY_Pos)                        /*!< TK_T::STA: BUSY Mask                   */
+
+#define TK_STA_SCIF_Pos                  (1)                                               /*!< TK_T::STA: SCIF Position               */
+#define TK_STA_SCIF_Msk                  (0x1ul << TK_STA_SCIF_Pos)                        /*!< TK_T::STA: SCIF Mask                   */
+
+#define TK_STA_TKIF_Pos                  (6)                                               /*!< TK_T::STA: TKIF Position               */
+#define TK_STA_TKIF_Msk                  (0x1ul << TK_STA_TKIF_Pos)                        /*!< TK_T::STA: TKIF Mask                   */
+
+#define TK_STA_TKIF_ALL_Pos              (7)                                               /*!< TK_T::STA: TKIF_ALL Position           */
+#define TK_STA_TKIF_ALL_Msk              (0x1ul << TK_STA_TKIF_ALL_Pos)                    /*!< TK_T::STA: TKIF_ALL Mask               */
+
+#define TK_STA_TKIF0_Pos                 (8)                                               /*!< TK_T::STA: TKIF0 Position              */
+#define TK_STA_TKIF0_Msk                 (0x1ul << TK_STA_TKIF0_Pos)                       /*!< TK_T::STA: TKIF0 Mask                  */
+
+#define TK_STA_TKIF1_Pos                 (9)                                               /*!< TK_T::STA: TKIF1 Position              */
+#define TK_STA_TKIF1_Msk                 (0x1ul << TK_STA_TKIF1_Pos)                       /*!< TK_T::STA: TKIF1 Mask                  */
+
+#define TK_STA_TKIF2_Pos                 (10)                                              /*!< TK_T::STA: TKIF2 Position              */
+#define TK_STA_TKIF2_Msk                 (0x1ul << TK_STA_TKIF2_Pos)                       /*!< TK_T::STA: TKIF2 Mask                  */
+
+#define TK_STA_TKIF3_Pos                 (11)                                              /*!< TK_T::STA: TKIF3 Position              */
+#define TK_STA_TKIF3_Msk                 (0x1ul << TK_STA_TKIF3_Pos)                       /*!< TK_T::STA: TKIF3 Mask                  */
+
+#define TK_STA_TKIF4_Pos                 (12)                                              /*!< TK_T::STA: TKIF4 Position              */
+#define TK_STA_TKIF4_Msk                 (0x1ul << TK_STA_TKIF4_Pos)                       /*!< TK_T::STA: TKIF4 Mask                  */
+
+#define TK_STA_TKIF5_Pos                 (13)                                              /*!< TK_T::STA: TKIF5 Position              */
+#define TK_STA_TKIF5_Msk                 (0x1ul << TK_STA_TKIF5_Pos)                       /*!< TK_T::STA: TKIF5 Mask                  */
+
+#define TK_STA_TKIF6_Pos                 (14)                                              /*!< TK_T::STA: TKIF6 Position              */
+#define TK_STA_TKIF6_Msk                 (0x1ul << TK_STA_TKIF6_Pos)                       /*!< TK_T::STA: TKIF6 Mask                  */
+
+#define TK_STA_TKIF7_Pos                 (15)                                              /*!< TK_T::STA: TKIF7 Position              */
+#define TK_STA_TKIF7_Msk                 (0x1ul << TK_STA_TKIF7_Pos)                       /*!< TK_T::STA: TKIF7 Mask                  */
+
+#define TK_STA_TKIF8_Pos                 (16)                                              /*!< TK_T::STA: TKIF8 Position              */
+#define TK_STA_TKIF8_Msk                 (0x1ul << TK_STA_TKIF8_Pos)                       /*!< TK_T::STA: TKIF8 Mask                  */
+
+#define TK_STA_TKIF9_Pos                 (17)                                              /*!< TK_T::STA: TKIF9 Position              */
+#define TK_STA_TKIF9_Msk                 (0x1ul << TK_STA_TKIF9_Pos)                       /*!< TK_T::STA: TKIF9 Mask                  */
+
+#define TK_STA_TKIF10_Pos                (18)                                              /*!< TK_T::STA: TKIF10 Position             */
+#define TK_STA_TKIF10_Msk                (0x1ul << TK_STA_TKIF10_Pos)                      /*!< TK_T::STA: TKIF10 Mask                 */
+
+#define TK_STA_TKIF11_Pos                (19)                                              /*!< TK_T::STA: TKIF11 Position             */
+#define TK_STA_TKIF11_Msk                (0x1ul << TK_STA_TKIF11_Pos)                      /*!< TK_T::STA: TKIF11 Mask                 */
+
+#define TK_STA_TKIF12_Pos                (20)                                              /*!< TK_T::STA: TKIF12 Position             */
+#define TK_STA_TKIF12_Msk                (0x1ul << TK_STA_TKIF12_Pos)                      /*!< TK_T::STA: TKIF12 Mask                 */
+
+#define TK_STA_TKIF13_Pos                (21)                                              /*!< TK_T::STA: TKIF13 Position             */
+#define TK_STA_TKIF13_Msk                (0x1ul << TK_STA_TKIF13_Pos)                      /*!< TK_T::STA: TKIF13 Mask                 */
+
+#define TK_STA_TKIF14_Pos                (22)                                              /*!< TK_T::STA: TKIF14 Position             */
+#define TK_STA_TKIF14_Msk                (0x1ul << TK_STA_TKIF14_Pos)                      /*!< TK_T::STA: TKIF14 Mask                 */
+
+#define TK_STA_TKIF15_Pos                (23)                                              /*!< TK_T::STA: TKIF15 Position             */
+#define TK_STA_TKIF15_Msk                (0x1ul << TK_STA_TKIF15_Pos)                      /*!< TK_T::STA: TKIF15 Mask                 */
+
+#define TK_STA_TKIF16_Pos                (24)                                              /*!< TK_T::STA: TKIF16 Position             */
+#define TK_STA_TKIF16_Msk                (0x1ul << TK_STA_TKIF16_Pos)                      /*!< TK_T::STA: TKIF16 Mask                 */
+
+#define TK_STA_TKIF17_Pos                (0)                                               /*!< TK_T::STA: TKIF17 Position             */
+#define TK_STA_TKIF17_Msk                (0x1ul << TK_STA_TKIF17_Pos)                      /*!< TK_T::STA: TKIF17 Mask                 */
+
+#define TK_STA_TKIF18_Pos                (1)                                               /*!< TK_T::STA: TKIF18 Position             */
+#define TK_STA_TKIF18_Msk                (0x1ul << TK_STA_TKIF18_Pos)                      /*!< TK_T::STA: TKIF18 Mask                 */
+
+#define TK_STA_TKIF19_Pos                (2)                                               /*!< TK_T::STA: TKIF19 Position             */
+#define TK_STA_TKIF19_Msk                (0x1ul << TK_STA_TKIF19_Pos)                      /*!< TK_T::STA: TKIF19 Mask                 */
+
+#define TK_STA_TKIF20_Pos                (3)                                               /*!< TK_T::STA: TKIF20 Position             */
+#define TK_STA_TKIF20_Msk                (0x1ul << TK_STA_TKIF20_Pos)                      /*!< TK_T::STA: TKIF20 Mask                 */
+
+#define TK_STA_TKIF21_Pos                (4)                                               /*!< TK_T::STA: TKIF21 Position             */
+#define TK_STA_TKIF21_Msk                (0x1ul << TK_STA_TKIF21_Pos)                      /*!< TK_T::STA: TKIF21 Mask                 */
+
+#define TK_STA_TKIF22_Pos                (5)                                               /*!< TK_T::STA: TKIF22 Position             */
+#define TK_STA_TKIF22_Msk                (0x1ul << TK_STA_TKIF22_Pos)                      /*!< TK_T::STA: TKIF22 Mask                 */
+
+#define TK_STA_TKIF23_Pos                (6)                                               /*!< TK_T::STA: TKIF23 Position             */
+#define TK_STA_TKIF23_Msk                (0x1ul << TK_STA_TKIF23_Pos)                      /*!< TK_T::STA: TKIF23 Mask                 */
+
+#define TK_STA_TKIF24_Pos                (7)                                               /*!< TK_T::STA: TKIF24 Position             */
+#define TK_STA_TKIF24_Msk                (0x1ul << TK_STA_TKIF24_Pos)                      /*!< TK_T::STA: TKIF24 Mask                 */
+
+#define TK_STA_TKIF25_Pos                (8)                                               /*!< TK_T::STA: TKIF25 Position             */
+#define TK_STA_TKIF25_Msk                (0x1ul << TK_STA_TKIF25_Pos)                      /*!< TK_T::STA: TKIF25 Mask                 */
+
+#define TK_DAT0_TKDAT0_Pos               (0)                                               /*!< TK_T::DAT0: TKDAT0 Position            */
+#define TK_DAT0_TKDAT0_Msk               (0xfful << TK_DAT0_TKDAT0_Pos)                    /*!< TK_T::DAT0: TKDAT0 Mask                */
+
+#define TK_DAT0_TKDAT1_Pos               (8)                                               /*!< TK_T::DAT0: TKDAT1 Position            */
+#define TK_DAT0_TKDAT1_Msk               (0xfful << TK_DAT0_TKDAT1_Pos)                    /*!< TK_T::DAT0: TKDAT1 Mask                */
+
+#define TK_DAT0_TKDAT2_Pos               (16)                                              /*!< TK_T::DAT0: TKDAT2 Position            */
+#define TK_DAT0_TKDAT2_Msk               (0xfful << TK_DAT0_TKDAT2_Pos)                    /*!< TK_T::DAT0: TKDAT2 Mask                */
+
+#define TK_DAT0_TKDAT3_Pos               (24)                                              /*!< TK_T::DAT0: TKDAT3 Position            */
+#define TK_DAT0_TKDAT3_Msk               (0xfful << TK_DAT0_TKDAT3_Pos)                    /*!< TK_T::DAT0: TKDAT3 Mask                */
+
+#define TK_DAT1_TKDAT4_Pos               (0)                                               /*!< TK_T::DAT1: TKDAT4 Position            */
+#define TK_DAT1_TKDAT4_Msk               (0xfful << TK_DAT1_TKDAT4_Pos)                    /*!< TK_T::DAT1: TKDAT4 Mask                */
+
+#define TK_DAT1_TKDAT5_Pos               (8)                                               /*!< TK_T::DAT1: TKDAT5 Position            */
+#define TK_DAT1_TKDAT5_Msk               (0xfful << TK_DAT1_TKDAT5_Pos)                    /*!< TK_T::DAT1: TKDAT5 Mask                */
+
+#define TK_DAT1_TKDAT6_Pos               (16)                                              /*!< TK_T::DAT1: TKDAT6 Position            */
+#define TK_DAT1_TKDAT6_Msk               (0xfful << TK_DAT1_TKDAT6_Pos)                    /*!< TK_T::DAT1: TKDAT6 Mask                */
+
+#define TK_DAT1_TKDAT7_Pos               (24)                                              /*!< TK_T::DAT1: TKDAT7 Position            */
+#define TK_DAT1_TKDAT7_Msk               (0xfful << TK_DAT1_TKDAT7_Pos)                    /*!< TK_T::DAT1: TKDAT7 Mask                */
+
+#define TK_DAT2_TKDAT8_Pos               (0)                                               /*!< TK_T::DAT2: TKDAT8 Position            */
+#define TK_DAT2_TKDAT8_Msk               (0xfful << TK_DAT2_TKDAT8_Pos)                    /*!< TK_T::DAT2: TKDAT8 Mask                */
+
+#define TK_DAT2_TKDAT9_Pos               (8)                                               /*!< TK_T::DAT2: TKDAT9 Position            */
+#define TK_DAT2_TKDAT9_Msk               (0xfful << TK_DAT2_TKDAT9_Pos)                    /*!< TK_T::DAT2: TKDAT9 Mask                */
+
+#define TK_DAT2_TKDAT10_Pos              (16)                                              /*!< TK_T::DAT2: TKDAT10 Position           */
+#define TK_DAT2_TKDAT10_Msk              (0xfful << TK_DAT2_TKDAT10_Pos)                   /*!< TK_T::DAT2: TKDAT10 Mask               */
+
+#define TK_DAT2_TKDAT11_Pos              (24)                                              /*!< TK_T::DAT2: TKDAT11 Position           */
+#define TK_DAT2_TKDAT11_Msk              (0xfful << TK_DAT2_TKDAT11_Pos)                   /*!< TK_T::DAT2: TKDAT11 Mask               */
+
+#define TK_DAT3_TKDAT12_Pos              (0)                                               /*!< TK_T::DAT3: TKDAT12 Position           */
+#define TK_DAT3_TKDAT12_Msk              (0xfful << TK_DAT3_TKDAT12_Pos)                   /*!< TK_T::DAT3: TKDAT12 Mask               */
+
+#define TK_DAT3_TKDAT13_Pos              (8)                                               /*!< TK_T::DAT3: TKDAT13 Position           */
+#define TK_DAT3_TKDAT13_Msk              (0xfful << TK_DAT3_TKDAT13_Pos)                   /*!< TK_T::DAT3: TKDAT13 Mask               */
+
+#define TK_DAT3_TKDAT14_Pos              (16)                                              /*!< TK_T::DAT3: TKDAT14 Position           */
+#define TK_DAT3_TKDAT14_Msk              (0xfful << TK_DAT3_TKDAT14_Pos)                   /*!< TK_T::DAT3: TKDAT14 Mask               */
+
+#define TK_DAT3_TKDAT15_Pos              (24)                                              /*!< TK_T::DAT3: TKDAT15 Position           */
+#define TK_DAT3_TKDAT15_Msk              (0xfful << TK_DAT3_TKDAT15_Pos)                   /*!< TK_T::DAT3: TKDAT15 Mask               */
+
+#define TK_DAT4_TKDAT16_Pos              (0)                                               /*!< TK_T::DAT4: TKDAT16 Position           */
+#define TK_DAT4_TKDAT16_Msk              (0xfful << TK_DAT4_TKDAT16_Pos)                   /*!< TK_T::DAT4: TKDAT16 Mask               */
+
+#define TK_DAT4_TKDAT_ALL_Pos            (8)                                               /*!< TK_T::DAT4: TKDAT_ALL Position         */
+#define TK_DAT4_TKDAT_ALL_Msk            (0xfful << TK_DAT4_TKDAT_ALL_Pos)                 /*!< TK_T::DAT4: TKDAT_ALL Mask             */
+
+#define TK_DAT5_TKDAT17_Pos              (0)                                               /*!< TK_T::DAT5: TKDAT17 Position           */
+#define TK_DAT5_TKDAT17_Msk              (0xfful << TK_DAT5_TKDAT17_Pos)                   /*!< TK_T::DAT5: TKDAT17 Mask               */
+
+#define TK_DAT5_TKDAT18_Pos              (8)                                               /*!< TK_T::DAT5: TKDAT18 Position           */
+#define TK_DAT5_TKDAT18_Msk              (0xfful << TK_DAT5_TKDAT18_Pos)                   /*!< TK_T::DAT5: TKDAT18 Mask               */
+
+#define TK_DAT5_TKDAT19_Pos              (16)                                              /*!< TK_T::DAT5: TKDAT19 Position           */
+#define TK_DAT5_TKDAT19_Msk              (0xfful << TK_DAT5_TKDAT19_Pos)                   /*!< TK_T::DAT5: TKDAT19 Mask               */
+
+#define TK_DAT5_TKDAT20_Pos              (24)                                              /*!< TK_T::DAT5: TKDAT20 Position           */
+#define TK_DAT5_TKDAT20_Msk              (0xfful << TK_DAT5_TKDAT20_Pos)                   /*!< TK_T::DAT5: TKDAT20 Mask               */
+
+#define TK_DAT6_TKDAT21_Pos              (0)                                               /*!< TK_T::DAT6: TKDAT21 Position           */
+#define TK_DAT6_TKDAT21_Msk              (0xfful << TK_DAT6_TKDAT21_Pos)                   /*!< TK_T::DAT6: TKDAT21 Mask               */
+
+#define TK_DAT6_TKDAT22_Pos              (8)                                               /*!< TK_T::DAT6: TKDAT22 Position           */
+#define TK_DAT6_TKDAT22_Msk              (0xfful << TK_DAT6_TKDAT22_Pos)                   /*!< TK_T::DAT6: TKDAT22 Mask               */
+
+#define TK_DAT6_TKDAT23_Pos              (16)                                              /*!< TK_T::DAT6: TKDAT23 Position           */
+#define TK_DAT6_TKDAT23_Msk              (0xfful << TK_DAT6_TKDAT23_Pos)                   /*!< TK_T::DAT6: TKDAT23 Mask               */
+
+#define TK_DAT6_TKDAT24_Pos              (24)                                              /*!< TK_T::DAT6: TKDAT24 Position           */
+#define TK_DAT6_TKDAT24_Msk              (0xfful << TK_DAT6_TKDAT24_Pos)                   /*!< TK_T::DAT6: TKDAT24 Mask               */
+
+#define TK_DAT7_TKDAT25_Pos              (0)                                               /*!< TK_T::DAT7: TKDAT25 Position           */
+#define TK_DAT7_TKDAT25_Msk              (0xfful << TK_DAT7_TKDAT25_Pos)                   /*!< TK_T::DAT7: TKDAT25 Mask               */
+
+#define TK_INTEN_SCTHIE_Pos              (0)                                               /*!< TK_T::INTEN: SCTHIE Position           */
+#define TK_INTEN_SCTHIE_Msk              (0x1ul << TK_INTEN_SCTHIE_Pos)                    /*!< TK_T::INTEN: SCTHIE Mask               */
+
+#define TK_INTEN_SCIE_Pos                (1)                                               /*!< TK_T::INTEN: SCIE Position             */
+#define TK_INTEN_SCIE_Msk                (0x1ul << TK_INTEN_SCIE_Pos)                      /*!< TK_T::INTEN: SCIE Mask                 */
+
+#define TK_THC01_HTH0_Pos                (8)                                               /*!< TK_T::THC01: HTH0 Position             */
+#define TK_THC01_HTH0_Msk                (0xfful << TK_THC01_HTH0_Pos)                     /*!< TK_T::THC01: HTH0 Mask                 */
+
+#define TK_THC01_HTH1_Pos                (24)                                              /*!< TK_T::THC01: HTH1 Position             */
+#define TK_THC01_HTH1_Msk                (0xfful << TK_THC01_HTH1_Pos)                     /*!< TK_T::THC01: HTH1 Mask                 */
+
+#define TK_THC23_HTH2_Pos                (8)                                               /*!< TK_T::THC23: HTH2 Position             */
+#define TK_THC23_HTH2_Msk                (0xfful << TK_THC23_HTH2_Pos)                     /*!< TK_T::THC23: HTH2 Mask                 */
+
+#define TK_THC23_HTH3_Pos                (24)                                              /*!< TK_T::THC23: HTH3 Position             */
+#define TK_THC23_HTH3_Msk                (0xfful << TK_THC23_HTH3_Pos)                     /*!< TK_T::THC23: HTH3 Mask                 */
+
+#define TK_THC45_HTH4_Pos                (8)                                               /*!< TK_T::THC45: HTH4 Position             */
+#define TK_THC45_HTH4_Msk                (0xfful << TK_THC45_HTH4_Pos)                     /*!< TK_T::THC45: HTH4 Mask                 */
+
+#define TK_THC45_HTH5_Pos                (24)                                              /*!< TK_T::THC45: HTH5 Position             */
+#define TK_THC45_HTH5_Msk                (0xfful << TK_THC45_HTH5_Pos)                     /*!< TK_T::THC45: HTH5 Mask                 */
+
+#define TK_THC67_HTH6_Pos                (8)                                               /*!< TK_T::THC67: HTH6 Position             */
+#define TK_THC67_HTH6_Msk                (0xfful << TK_THC67_HTH6_Pos)                     /*!< TK_T::THC67: HTH6 Mask                 */
+
+#define TK_THC67_HTH7_Pos                (24)                                              /*!< TK_T::THC67: HTH7 Position             */
+#define TK_THC67_HTH7_Msk                (0xfful << TK_THC67_HTH7_Pos)                     /*!< TK_T::THC67: HTH7 Mask                 */
+
+#define TK_THC89_HTH8_Pos                (8)                                               /*!< TK_T::THC89: HTH8 Position             */
+#define TK_THC89_HTH8_Msk                (0xfful << TK_THC89_HTH8_Pos)                     /*!< TK_T::THC89: HTH8 Mask                 */
+
+#define TK_THC89_HTH9_Pos                (24)                                              /*!< TK_T::THC89: HTH9 Position             */
+#define TK_THC89_HTH9_Msk                (0xfful << TK_THC89_HTH9_Pos)                     /*!< TK_T::THC89: HTH9 Mask                 */
+
+#define TK_THC1011_HTH10_Pos             (8)                                               /*!< TK_T::THC1011: HTH10 Position          */
+#define TK_THC1011_HTH10_Msk             (0xfful << TK_THC1011_HTH10_Pos)                  /*!< TK_T::THC1011: HTH10 Mask              */
+
+#define TK_THC1011_HTH11_Pos             (24)                                              /*!< TK_T::THC1011: HTH11 Position          */
+#define TK_THC1011_HTH11_Msk             (0xfful << TK_THC1011_HTH11_Pos)                  /*!< TK_T::THC1011: HTH11 Mask              */
+
+#define TK_THC1213_HTH12_Pos             (8)                                               /*!< TK_T::THC1213: HTH12 Position          */
+#define TK_THC1213_HTH12_Msk             (0xfful << TK_THC1213_HTH12_Pos)                  /*!< TK_T::THC1213: HTH12 Mask              */
+
+#define TK_THC1213_HTH13_Pos             (24)                                              /*!< TK_T::THC1213: HTH13 Position          */
+#define TK_THC1213_HTH13_Msk             (0xfful << TK_THC1213_HTH13_Pos)                  /*!< TK_T::THC1213: HTH13 Mask              */
+
+#define TK_THC1415_HTH14_Pos             (8)                                               /*!< TK_T::THC1415: HTH14 Position          */
+#define TK_THC1415_HTH14_Msk             (0xfful << TK_THC1415_HTH14_Pos)                  /*!< TK_T::THC1415: HTH14 Mask              */
+
+#define TK_THC1415_HTH15_Pos             (24)                                              /*!< TK_T::THC1415: HTH15 Position          */
+#define TK_THC1415_HTH15_Msk             (0xfful << TK_THC1415_HTH15_Pos)                  /*!< TK_T::THC1415: HTH15 Mask              */
+
+#define TK_THC16_HTH16_Pos               (8)                                               /*!< TK_T::THC16: HTH16 Position            */
+#define TK_THC16_HTH16_Msk               (0xfful << TK_THC16_HTH16_Pos)                    /*!< TK_T::THC16: HTH16 Mask                */
+
+#define TK_THC16_HTH_ALL_Pos             (24)                                              /*!< TK_T::THC16: HTH_ALL Position          */
+#define TK_THC16_HTH_ALL_Msk             (0xfful << TK_THC16_HTH_ALL_Pos)                  /*!< TK_T::THC16: HTH_ALL Mask              */
+
+#define TK_THC1718_HTH17_Pos             (8)                                               /*!< TK_T::THC1718: HTH17 Position          */
+#define TK_THC1718_HTH17_Msk             (0xfful << TK_THC1718_HTH17_Pos)                  /*!< TK_T::THC1718: HTH17 Mask              */
+
+#define TK_THC1718_HTH18_Pos             (24)                                              /*!< TK_T::THC1718: HTH18 Position          */
+#define TK_THC1718_HTH18_Msk             (0xfful << TK_THC1718_HTH18_Pos)                  /*!< TK_T::THC1718: HTH18 Mask              */
+
+#define TK_THC1920_HTH19_Pos             (8)                                               /*!< TK_T::THC1920: HTH19 Position          */
+#define TK_THC1920_HTH19_Msk             (0xfful << TK_THC1920_HTH19_Pos)                  /*!< TK_T::THC1920: HTH19 Mask              */
+
+#define TK_THC1920_HTH20_Pos             (24)                                              /*!< TK_T::THC1920: HTH20 Position          */
+#define TK_THC1920_HTH20_Msk             (0xfful << TK_THC1920_HTH20_Pos)                  /*!< TK_T::THC1920: HTH20 Mask              */
+
+#define TK_THC2122_HTH21_Pos             (8)                                               /*!< TK_T::THC2122: HTH21 Position          */
+#define TK_THC2122_HTH21_Msk             (0xfful << TK_THC2122_HTH21_Pos)                  /*!< TK_T::THC2122: HTH21 Mask              */
+
+#define TK_THC2122_HTH22_Pos             (24)                                              /*!< TK_T::THC2122: HTH22 Position          */
+#define TK_THC2122_HTH22_Msk             (0xfful << TK_THC2122_HTH22_Pos)                  /*!< TK_T::THC2122: HTH22 Mask              */
+
+#define TK_THC2324_HTH23_Pos             (8)                                               /*!< TK_T::THC2324: HTH23 Position          */
+#define TK_THC2324_HTH23_Msk             (0xfful << TK_THC2324_HTH23_Pos)                  /*!< TK_T::THC2324: HTH23 Mask              */
+
+#define TK_THC2324_HTH24_Pos             (24)                                              /*!< TK_T::THC2324: HTH24 Position          */
+#define TK_THC2324_HTH24_Msk             (0xfful << TK_THC2324_HTH24_Pos)                  /*!< TK_T::THC2324: HTH24 Mask              */
+
+#define TK_THC25_HTH25_Pos               (8)                                               /*!< TK_T::THC25: HTH25 Position            */
+#define TK_THC25_HTH25_Msk               (0xfful << TK_THC25_HTH25_Pos)                    /*!< TK_T::THC25: HTH25 Mask                */
+
+#define TK_REFCBD0_CBD0_Pos              (0)                                               /*!< TK_T::REFCBD0: CBD0 Position           */
+#define TK_REFCBD0_CBD0_Msk              (0xfful << TK_REFCBD0_CBD0_Pos)                   /*!< TK_T::REFCBD0: CBD0 Mask               */
+
+#define TK_REFCBD0_CBD1_Pos              (8)                                               /*!< TK_T::REFCBD0: CBD1 Position           */
+#define TK_REFCBD0_CBD1_Msk              (0xfful << TK_REFCBD0_CBD1_Pos)                   /*!< TK_T::REFCBD0: CBD1 Mask               */
+
+#define TK_REFCBD0_CBD2_Pos              (16)                                              /*!< TK_T::REFCBD0: CBD2 Position           */
+#define TK_REFCBD0_CBD2_Msk              (0xfful << TK_REFCBD0_CBD2_Pos)                   /*!< TK_T::REFCBD0: CBD2 Mask               */
+
+#define TK_REFCBD0_CBD3_Pos              (24)                                              /*!< TK_T::REFCBD0: CBD3 Position           */
+#define TK_REFCBD0_CBD3_Msk              (0xfful << TK_REFCBD0_CBD3_Pos)                   /*!< TK_T::REFCBD0: CBD3 Mask               */
+
+#define TK_REFCBD1_CBD4_Pos              (0)                                               /*!< TK_T::REFCBD1: CBD4 Position           */
+#define TK_REFCBD1_CBD4_Msk              (0xfful << TK_REFCBD1_CBD4_Pos)                   /*!< TK_T::REFCBD1: CBD4 Mask               */
+
+#define TK_REFCBD1_CBD5_Pos              (8)                                               /*!< TK_T::REFCBD1: CBD5 Position           */
+#define TK_REFCBD1_CBD5_Msk              (0xfful << TK_REFCBD1_CBD5_Pos)                   /*!< TK_T::REFCBD1: CBD5 Mask               */
+
+#define TK_REFCBD1_CBD6_Pos              (16)                                              /*!< TK_T::REFCBD1: CBD6 Position           */
+#define TK_REFCBD1_CBD6_Msk              (0xfful << TK_REFCBD1_CBD6_Pos)                   /*!< TK_T::REFCBD1: CBD6 Mask               */
+
+#define TK_REFCBD1_CBD7_Pos              (24)                                              /*!< TK_T::REFCBD1: CBD7 Position           */
+#define TK_REFCBD1_CBD7_Msk              (0xfful << TK_REFCBD1_CBD7_Pos)                   /*!< TK_T::REFCBD1: CBD7 Mask               */
+
+#define TK_REFCBD2_CBD8_Pos              (0)                                               /*!< TK_T::REFCBD2: CBD8 Position           */
+#define TK_REFCBD2_CBD8_Msk              (0xfful << TK_REFCBD2_CBD8_Pos)                   /*!< TK_T::REFCBD2: CBD8 Mask               */
+
+#define TK_REFCBD2_CBD9_Pos              (8)                                               /*!< TK_T::REFCBD2: CBD9 Position           */
+#define TK_REFCBD2_CBD9_Msk              (0xfful << TK_REFCBD2_CBD9_Pos)                   /*!< TK_T::REFCBD2: CBD9 Mask               */
+
+#define TK_REFCBD2_CBD10_Pos             (16)                                              /*!< TK_T::REFCBD2: CBD10 Position          */
+#define TK_REFCBD2_CBD10_Msk             (0xfful << TK_REFCBD2_CBD10_Pos)                  /*!< TK_T::REFCBD2: CBD10 Mask              */
+
+#define TK_REFCBD2_CBD11_Pos             (24)                                              /*!< TK_T::REFCBD2: CBD11 Position          */
+#define TK_REFCBD2_CBD11_Msk             (0xfful << TK_REFCBD2_CBD11_Pos)                  /*!< TK_T::REFCBD2: CBD11 Mask              */
+
+#define TK_REFCBD3_CBD12_Pos             (0)                                               /*!< TK_T::REFCBD3: CBD12 Position          */
+#define TK_REFCBD3_CBD12_Msk             (0xfful << TK_REFCBD3_CBD12_Pos)                  /*!< TK_T::REFCBD3: CBD12 Mask              */
+
+#define TK_REFCBD3_CBD13_Pos             (8)                                               /*!< TK_T::REFCBD3: CBD13 Position          */
+#define TK_REFCBD3_CBD13_Msk             (0xfful << TK_REFCBD3_CBD13_Pos)                  /*!< TK_T::REFCBD3: CBD13 Mask              */
+
+#define TK_REFCBD3_CBD14_Pos             (16)                                              /*!< TK_T::REFCBD3: CBD14 Position          */
+#define TK_REFCBD3_CBD14_Msk             (0xfful << TK_REFCBD3_CBD14_Pos)                  /*!< TK_T::REFCBD3: CBD14 Mask              */
+
+#define TK_REFCBD3_CBD15_Pos             (24)                                              /*!< TK_T::REFCBD2: CBD15 Position          */
+#define TK_REFCBD3_CBD15_Msk             (0xfful << TK_REFCBD3_CBD15_Pos)                  /*!< TK_T::REFCBD2: CBD15 Mask              */
+
+#define TK_REFCBD4_CBD16_Pos             (0)                                               /*!< TK_T::REFCBD4: CBD16 Position          */
+#define TK_REFCBD4_CBD16_Msk             (0xfful << TK_REFCBD4_CBD16_Pos)                  /*!< TK_T::REFCBD4: CBD16 Mask              */
+
+#define TK_REFCBD4_CBD_ALL_Pos           (8)                                               /*!< TK_T::REFCBD4: CBD ALL Position        */
+#define TK_REFCBD4_CBD_ALL_Msk           (0xfful << TK_REFCBD4_CBD_ALL_Pos)                /*!< TK_T::REFCBD4: CBD ALL Mask            */
+
+#define TK_REFCBD5_CBD17_Pos             (0)                                               /*!< TK_T::REFCBD5: CBD17 Position          */
+#define TK_REFCBD5_CBD17_Msk             (0xfful << TK_REFCBD5_CBD17_Pos)                  /*!< TK_T::REFCBD5: CBD17 Mask              */
+
+#define TK_REFCBD5_CBD18_Pos             (8)                                               /*!< TK_T::REFCBD5: CBD18 Position          */
+#define TK_REFCBD5_CBD18_Msk             (0xfful << TK_REFCBD5_CBD18_Pos)                  /*!< TK_T::REFCBD5: CBD18 Mask              */
+
+#define TK_REFCBD5_CBD19_Pos             (16)                                              /*!< TK_T::REFCBD5: CBD19 Position          */
+#define TK_REFCBD5_CBD19_Msk             (0xfful << TK_REFCBD5_CBD19_Pos)                  /*!< TK_T::REFCBD5: CBD19 Mask              */
+
+#define TK_REFCBD5_CBD20_Pos             (24)                                              /*!< TK_T::REFCBD5: CBD20 Position          */
+#define TK_REFCBD5_CBD20_Msk             (0xfful << TK_REFCBD5_CBD20_Pos)                  /*!< TK_T::REFCBD5: CBD10 Mask              */
+
+#define TK_REFCBD6_CBD21_Pos             (0)                                               /*!< TK_T::REFCBD6: CBD21 Position          */
+#define TK_REFCBD6_CBD21_Msk             (0xfful << TK_REFCBD6_CBD21_Pos)                  /*!< TK_T::REFCBD6: CBD21 Mask              */
+
+#define TK_REFCBD6_CBD22_Pos             (8)                                               /*!< TK_T::REFCBD6: CBD22 Position          */
+#define TK_REFCBD6_CBD22_Msk             (0xfful << TK_REFCBD6_CBD22_Pos)                  /*!< TK_T::REFCBD6: CBD22 Mask              */
+
+#define TK_REFCBD6_CBD23_Pos             (16)                                              /*!< TK_T::REFCBD6: CBD23 Position          */
+#define TK_REFCBD6_CBD23_Msk             (0xfful << TK_REFCBD6_CBD23_Pos)                  /*!< TK_T::REFCBD6: CBD23 Mask              */
+
+#define TK_REFCBD6_CBD24_Pos             (24)                                              /*!< TK_T::REFCBD6: CBD24 Position          */
+#define TK_REFCBD6_CBD24_Msk             (0xfful << TK_REFCBD6_CBD24_Pos)                  /*!< TK_T::REFCBD6: CBD24 Mask              */
+
+#define TK_REFCBD7_CBD25_Pos             (0)                                               /*!< TK_T::REFCBD7: CBD25 Position          */
+#define TK_REFCBD7_CBD25_Msk             (0xfful << TK_REFCBD7_CBD25_Pos)                  /*!< TK_T::REFCBD7: CBD25 Mask              */
+
+/** @} TK_CONST */
+/** @} end of TK register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __TK_REG_H__ */

--- a/hal/m258ke/nuvoton/uart_reg.h
+++ b/hal/m258ke/nuvoton/uart_reg.h
@@ -1,0 +1,1303 @@
+/**************************************************************************//**
+ * @file     uart_reg.h
+ * @version  V1.00
+ * @brief    UART register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __UART_REG_H__
+#define __UART_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup UART Universal Asynchronous Receiver/Transmitter Controller (UART)
+    Memory Mapped Structure for UART Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var UART_T::DAT
+     * Offset: 0x00  UART Receive/Transmit Buffer Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |DAT       |Data Receive/Transmit Buffer
+     * |        |          |Write Operation:
+     * |        |          |By writing one byte to this register, the data byte will be stored in transmitter FIFO.
+     * |        |          |The UART controller will send out the data stored in transmitter FIFO top location through the UART_TXD.
+     * |        |          |Read Operation:
+     * |        |          |By reading this register, the UART controller will return an 8-bit data received from receiver FIFO.
+     * |[8]     |PARITY    |Parity Bit Receive/Transmit Buffer
+     * |        |          |Write Operation:
+     * |        |          |By writing to this bit, the PARITY bit will be stored in transmitter FIFO.
+     * |        |          |If PBE (UART_LINE[3]) and PSS (UART_LINE[7]) are set, the UART controller will send out this bit follow the DAT (UART_DAT[7:0]) through the UART_TXD.
+     * |        |          |Read Operation:
+     * |        |          |If PBE (UART_LINE[3]) and PSS (UART_LINE[7]) are enabled, the PARITY bit can be read by this bit.
+     * |        |          |Note: This bit has effect only when PBE (UART_LINE[3]) and PSS (UART_LINE[7]) are set.
+     * @var UART_T::INTEN
+     * Offset: 0x04  UART Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RDAIEN    |Receive Data Available Interrupt Enable Bit
+     * |        |          |0 = Receive data available interrupt Disabled.
+     * |        |          |1 = Receive data available interrupt Enabled.
+     * |[1]     |THREIEN   |Transmit Holding Register Empty Interrupt Enable Bit
+     * |        |          |0 = Transmit holding register empty interrupt Disabled.
+     * |        |          |1 = Transmit holding register empty interrupt Enabled.
+     * |[2]     |RLSIEN    |Receive Line Status Interrupt Enable Bit
+     * |        |          |0 = Receive Line Status interrupt Disabled.
+     * |        |          |1 = Receive Line Status interrupt Enabled.
+     * |[3]     |MODEMIEN  |Modem Status Interrupt Enable Bit
+     * |        |          |0 = Modem status interrupt Disabled.
+     * |        |          |1 = Modem status interrupt Enabled.
+     * |[4]     |RXTOIEN   |RX Time-out Interrupt Enable Bit
+     * |        |          |0 = RX time-out interrupt Disabled.
+     * |        |          |1 = RX time-out interrupt Enabled.
+     * |[5]     |BUFERRIEN |Buffer Error Interrupt Enable Bit
+     * |        |          |0 = Buffer error interrupt Disabled.
+     * |        |          |1 = Buffer error interrupt Enabled.
+     * |[6]     |WKIEN     |Wake-up Interrupt Enable Bit
+     * |        |          |0 = Wake-up Interrupt Disabled.
+     * |        |          |1 = Wake-up Interrupt Enabled.
+     * |[8]     |LINIEN    |LIN Bus Interrupt Enable Bit
+     * |        |          |0 = LIN bus interrupt Disabled.
+     * |        |          |1 = LIN bus interrupt Enabled.
+     * |        |          |Note: This bit is used for LIN function mode.
+     * |[11]    |TOCNTEN   |Receive Buffer Time-out Counter Enable Bit
+     * |        |          |0 = Receive Buffer Time-out counter Disabled.
+     * |        |          |1 = Receive Buffer Time-out counter Enabled.
+     * |[12]    |ATORTSEN  |nRTS Auto-flow Control Enable Bit
+     * |        |          |0 = nRTS auto-flow control Disabled.
+     * |        |          |1 = nRTS auto-flow control Enabled.
+     * |        |          |Note: When nRTS auto-flow is enabled, if the number of bytes in the RX FIFO equals the RTSTRGLV (UART_FIFO[19:16]), the UART will de-assert nRTS signal.
+     * |[13]    |ATOCTSEN  |nCTS Auto-flow Control Enable Bit
+     * |        |          |0 = nCTS auto-flow control Disabled.
+     * |        |          |1 = nCTS auto-flow control Enabled.
+     * |        |          |Note: When nCTS auto-flow is enabled, the UART will send data to external device if nCTS input assert (UART will not send data to device until nCTS is asserted).
+     * |[14]    |TXPDMAEN  |TX PDMA Enable Bit
+     * |        |          |0 = TX PDMA Disabled.
+     * |        |          |1 = TX PDMA Enabled.
+     * |        |          |Note: If RLSIEN (UART_INTEN[2]) is enabled and HWRLSINT (UART_INTSTS[26]) is set to 1, the RLS (Receive Line Status) Interrupt is caused.
+     * |        |          |If RLS interrupt is caused by Break Error Flag BIF(UART_FIFOSTS[6]), Frame Error Flag FEF(UART_FIFO[5]) or Parity Error Flag PEF(UART_FIFOSTS[4]), UART PDMA transmit request operation is stopped.
+     * |        |          |Clear Break Error Flag BIF or Frame Error Flag FEF or Parity Error Flag PEF by writing "1" to corresponding BIF, FEF and PEF to make UART PDMA transmit request operation continue.
+     * |[15]    |RXPDMAEN  |RX PDMA Enable Bit
+     * |        |          |This bit can enable or disable RX PDMA service.
+     * |        |          |0 = RX PDMA Disabled.
+     * |        |          |1 = RX PDMA Enabled.
+     * |        |          |Note: If RLSIEN (UART_INTEN[2]) is enabled and HWRLSINT (UART_INTSTS[26]) is set to 1, the RLS (Receive Line Status) Interrupt is caused
+     * |        |          |If RLS interrupt is caused by Break Error Flag BIF(UART_FIFOSTS[6]), Frame Error Flag FEF(UART_FIFO[5]) or Parity Error Flag PEF(UART_FIFOSTS[4]), UART PDMA receive request operation is stopped.
+     * |        |          |Clear Break Error Flag BIF or Frame Error Flag FEF or Parity Error Flag PEF by writing "1" to corresponding BIF, FEF and PEF to make UART PDMA receive request operation continue.
+     * |[16]    |SWBEIEN   |Single-wire Bit Error Detection Interrupt Enable Bit
+     * |        |          |Set this bit, the Single-wire Half Duplex Bit Error Detection Interrupt SWBEINT(UART_INTSTS[24]) is generated when Single-wire Bit Error Detection SWBEIF(UART_INTSTS[16]) is set.
+     * |        |          |0 = Single-wire Bit Error Detect Inerrupt Disabled.
+     * |        |          |1 = Single-wire Bit Error Detect Inerrupt Enabled.
+     * |        |          |Note: This bit is valid when FUNCSEL (UART_FUNCSEL[2:0]) is select UART Single-wire mode.
+     * |[18]    |ABRIEN    |Auto-baud Rate Interrupt Enable Bit
+     * |        |          |0 = Auto-baud rate interrupt Disabled.
+     * |        |          |1 = Auto-baud rate interrupt Enabled.
+     * |[22]    |TXENDIEN  |Transmitter Empty Interrupt Enable Bit
+     * |        |          |If TXENDIEN (UART_INTEN[22]) is enabled, the Transmitter Empty interrupt TXENDINT (UART_INTSTS[30]) will be generated when TXENDIF (UART_INTSTS[22])
+     * |        |          |is set (TX FIFO (UART_DAT) is empty and the STOP bit of the last byte has been transmitted).
+     * |        |          |0 = Transmitter empty interrupt Disabled.
+     * |        |          |1 = Transmitter empty interrupt Enabled.
+     * @var UART_T::FIFO
+     * Offset: 0x08  UART FIFO Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |RXRST     |RX Field Software Reset
+     * |        |          |When RXRST (UART_FIFO[1]) is set, all the byte in the receiver FIFO and RX internal state machine are cleared.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the RX internal state machine and pointers.
+     * |        |          |Note1: This bit will automatically clear at least 3 UART peripheral clock cycles.
+     * |        |          |Note2: Before setting this bit, it should wait for the RXIDLE (UART_FIFOSTS[29]) be set.
+     * |[2]     |TXRST     |TX Field Software Reset
+     * |        |          |When TXRST (UART_FIFO[2]) is set, all the byte in the transmit FIFO and TX internal state machine are cleared.
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the TX internal state machine and pointers.
+     * |        |          |Note1: This bit will automatically clear at least 3 UART peripheral clock cycles.
+     * |        |          |Note2: Before setting this bit, it should wait for the TXEMPTYF (UART_FIFOSTS[28]) be set.
+     * |[7:4]   |RFITL     |RX FIFO Interrupt Trigger Level
+     * |        |          |When the number of bytes in the receive FIFO equals the RFITL, the RDAIF (UART_INTSTS[0]) will be set (if RDAIEN (UART_INTEN [0]) enabled, and an interrupt will be generated).
+     * |        |          |0000 = RX FIFO Interrupt Trigger Level is 1 byte.
+     * |        |          |0001 = RX FIFO Interrupt Trigger Level is 4 bytes.
+     * |        |          |0010 = RX FIFO Interrupt Trigger Level is 8 bytes.
+     * |        |          |0011 = RX FIFO Interrupt Trigger Level is 14 bytes.
+     * |        |          |Others = Reserved.
+     * |[8]     |RXOFF     |Receiver Disable Bit
+     * |        |          |The receiver is disabled or not (set 1 to disable receiver).
+     * |        |          |0 = Receiver Enabled.
+     * |        |          |1 = Receiver Disabled.
+     * |        |          |Note: This bit is used for RS-485 Normal Multi-drop mode.
+     * |        |          |It should be programmed before RS485NMM (UART_ALTCTL [8]) is programmed.
+     * |[19:16] |RTSTRGLV  |nRTS Trigger Level for Auto-flow Control
+     * |        |          |0000 = nRTS Trigger Level is 1 byte.
+     * |        |          |0001 = nRTS Trigger Level is 4 bytes.
+     * |        |          |0010 = nRTS Trigger Level is 8 bytes.
+     * |        |          |0011 = nRTS Trigger Level is 14 bytes.
+     * |        |          |Others = Reserved.
+     * |        |          |Note: This field is used for auto nRTS flow control.
+     * @var UART_T::LINE
+     * Offset: 0x0C  UART Line Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |WLS       |Word Length Selection
+     * |        |          |This field sets UART word length.
+     * |        |          |00 = 5 bits.
+     * |        |          |01 = 6 bits.
+     * |        |          |10 = 7 bits.
+     * |        |          |11 = 8 bits.
+     * |[2]     |NSB       |Number of "STOP Bit"
+     * |        |          |0 = One "STOP bit" is generated in the transmitted data.
+     * |        |          |1 = When select 5-bit word length, 1.5 "STOP bit" is generated in the transmitted data.
+     * |        |          |When select 6-, 7- and 8-bit word length, 2 "STOP bit" is generated in the transmitted data.
+     * |[3]     |PBE       |Parity Bit Enable Bit
+     * |        |          |0 = PARITY bit generated Disabled.
+     * |        |          |1 = PARITY bit generated Enabled.
+     * |        |          |Note: PARITY bit is generated on each outgoing character and is checked on each incoming data.
+     * |[4]     |EPE       |Even Parity Enable Bit
+     * |        |          |0 = Odd number of logic 1's is transmitted and checked in each word.
+     * |        |          |1 = Even number of logic 1's is transmitted and checked in each word.
+     * |        |          |Note: This bit has effect only when PBE (UART_LINE[3]) is set.
+     * |[5]     |SPE       |Stick Parity Enable Bit
+     * |        |          |0 = Stick parity Disabled.
+     * |        |          |1 = Stick parity Enabled.
+     * |        |          |Note: If PBE (UART_LINE[3]) and EPE (UART_LINE[4]) are logic 1, the PARITY bit is transmitted and checked as logic 0.
+     * |        |          |If PBE (UART_LINE[3]) is 1 and EPE (UART_LINE[4]) is 0 then the PARITY bit is transmitted and checked as 1.
+     * |[6]     |BCB       |Break Control Bit
+     * |        |          |0 = Break Control Disabled.
+     * |        |          |1 = Break Control Enabled.
+     * |        |          |Note: When this bit is set to logic 1, the transmitted serial data output (TX) is forced to the Spacing State (logic 0)
+     * |        |          |This bit acts only on TX line and has no effect on the transmitter logic.
+     * |[7]     |PSS       |PARITY Bit Source Selection
+     * |        |          |The PARITY bit can be selected to be generated and checked automatically or by software.
+     * |        |          |0 = PARITY bit is generated by EPE (UART_LINE[4]) and SPE (UART_LINE[5]) setting and checked automatically.
+     * |        |          |1 = PARITY bit generated and checked by software.
+     * |        |          |Note1: This bit has effect only when PBE (UART_LINE[3]) is set.
+     * |        |          |Note2: If PSS is 0, the PARITY bit is transmitted and checked automatically.
+     * |        |          |If PSS is 1, the transmitted PARITY bit value can be determined by writing PARITY (UART_DAT[8]) and the PARITY bit can be read by reading PARITY (UART_DAT[8]).
+     * |[8]     |TXDINV    |TX Data Inverted
+     * |        |          |0 = Transmitted data signal inverted Disabled.
+     * |        |          |1 = Transmitted data signal inverted Enabled.
+     * |        |          |Note1: Before setting this bit, TXRXDIS (UART_FUNCSEL[3]) should be set then waited for TXRXACT (UART_FIFOSTS[31]) is cleared.
+     * |        |          |When the configuration is done, cleared TXRXDIS (UART_FUNCSEL[3]) to activate UART controller.
+     * |        |          |Note2: This bit is valid when FUNCSEL (UART_FUNCSEL[1:0]) is select UART, LIN or RS485 function.
+     * |[9]     |RXDINV    |RX Data Inverted
+     * |        |          |0 = Received data signal inverted Disabled.
+     * |        |          |1 = Received data signal inverted Enabled.
+     * |        |          |Note1: Before setting this bit, TXRXDIS (UART_FUNCSEL[3]) should be set then waited for TXRXACT (UART_FIFOSTS[31]) is cleared.
+     * |        |          |When the configuration is done, cleared TXRXDIS (UART_FUNCSEL[3]) to activate UART controller.
+     * |        |          |Note2: This bit is valid when FUNCSEL (UART_FUNCSEL[1:0]) is select UART, LIN or RS485 function.
+     * @var UART_T::MODEM
+     * Offset: 0x10  UART Modem Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |RTS       |nRTS (Request-to-send) Signal Control
+     * |        |          |This bit is direct control internal nRTS signal active or not, and then drive the nRTS pin output with RTSACTLV bit configuration.
+     * |        |          |0 = nRTS signal is active.
+     * |        |          |1 = nRTS signal is inactive.
+     * |        |          |Note1: The nRTS signal control bit is not effective when nRTS auto-flow control is enabled in UART function mode.
+     * |        |          |Note2: The nRTS signal control bit is not effective when RS-485 auto direction mode (AUD) is enabled in RS-485 function mode.
+     * |        |          |Note3: Single-wire mode is support this feature.
+     * |[9]     |RTSACTLV  |nRTS Pin Active Level
+     * |        |          |This bit defines the active level state of nRTS pin output.
+     * |        |          |0 = nRTS pin output is high level active.
+     * |        |          |1 = nRTS pin output is low level active. (Default)
+     * |        |          |Note1: Refer to Figure 7.13-13 and Figure 7.13-14 for UART function mode.
+     * |        |          |Note2: Refer to Figure 7.13-24 and Figure 7.13-25 for RS-485 function mode.
+     * |        |          |Note3: Before setting this bit, TXRXDIS (UART_FUNCSEL[3]) should be set then waited for TXRXACT (UART_FIFOSTS[31]) is cleared.
+     * |        |          |When the configuration is done, cleared TXRXDIS (UART_FUNCSEL[3]) to activate UART controller.
+     * |[13]    |RTSSTS    |nRTS Pin Status (Read Only)
+     * |        |          |This bit mirror from nRTS pin output of voltage logic status.
+     * |        |          |0 = nRTS pin output is low level voltage logic state.
+     * |        |          |1 = nRTS pin output is high level voltage logic state.
+     * @var UART_T::MODEMSTS
+     * Offset: 0x14  UART Modem Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CTSDETF   |Detect nCTS State Change Flag
+     * |        |          |This bit is set whenever nCTS input has change state, and it will generate Modem interrupt to CPU when MODEMIEN (UART_INTEN [3]) is set to 1.
+     * |        |          |0 = nCTS input has not change state.
+     * |        |          |1 = nCTS input has change state.
+     * |        |          |Note: This bit can be cleared by writing '1' to it.
+     * |[4]     |CTSSTS    |nCTS Pin Status (Read Only)
+     * |        |          |This bit mirror from nCTS pin input of voltage logic status.
+     * |        |          |0 = nCTS pin input is low level voltage logic state.
+     * |        |          |1 = nCTS pin input is high level voltage logic state.
+     * |        |          |Note: This bit echoes when UART controller peripheral clock is enabled, and nCTS multi-function port is selected.
+     * |[8]     |CTSACTLV  |nCTS Pin Active Level
+     * |        |          |This bit defines the active level state of nCTS pin input.
+     * |        |          |0 = nCTS pin input is high level active.
+     * |        |          |1 = nCTS pin input is low level active. (Default)
+     * |        |          |Note: Before setting this bit, TXRXDIS (UART_FUNCSEL[3]) should be set then waited for TXRXACT (UART_FIFOSTS[31]) is cleared.
+     * |        |          |When the configuration is done, cleared TXRXDIS (UART_FUNCSEL[3]) to activate UART controller.
+     * @var UART_T::FIFOSTS
+     * Offset: 0x18  UART FIFO Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RXOVIF    |RX Overflow Error Interrupt Flag
+     * |        |          |This bit is set when RX FIFO overflow.
+     * |        |          |If the number of bytes of received data is greater than RX_FIFO (UART_DAT) size 16 bytes, this bit will be set.
+     * |        |          |0 = RX FIFO is not overflow.
+     * |        |          |1 = RX FIFO is overflow.
+     * |        |          |Note: This bit can be cleared by writing "1" to it.
+     * |[1]     |ABRDIF    |Auto-baud Rate Detect Interrupt Flag
+     * |        |          |This bit is set to logic "1" when auto-baud rate detect function is finished.
+     * |        |          |0 = Auto-baud rate detect function is not finished.
+     * |        |          |1 = Auto-baud rate detect function is finished.
+     * |        |          |Note: This bit can be cleared by writing "1" to it.
+     * |[2]     |ABRDTOIF  |Auto-baud Rate Detect Time-out Interrupt Flag
+     * |        |          |This bit is set to logic "1" in Auto-baud Rate Detect mode when the baud rate counter is overflow.
+     * |        |          |0 = Auto-baud rate counter is underflow.
+     * |        |          |1 = Auto-baud rate counter is overflow.
+     * |        |          |Note: This bit can be cleared by writing "1" to it.
+     * |[3]     |ADDRDETF  |RS-485 Address Byte Detect Flag
+     * |        |          |0 = Receiver detects a data that is not an address bit (bit 9 = '0').
+     * |        |          |1 = Receiver detects a data that is an address bit (bit 9 = '1').
+     * |        |          |Note1: This field is used for RS-485 function mode and ADDRDEN (UART_ALTCTL[15]) is set to "1" to enable Address detection mode.
+     * |        |          |Note2: This bit can be cleared by writing "1" to it.
+     * |[4]     |PEF       |Parity Error Flag
+     * |        |          |This bit is set to logic "1" whenever the received character does not have a valid "PARITY bit".
+     * |        |          |0 = No parity error is generated.
+     * |        |          |1 = Parity error is generated.
+     * |        |          |Note: This bit can be cleared by writing "1" to it.
+     * |[5]     |FEF       |Framing Error Flag
+     * |        |          |This bit is set to logic "1" whenever the received character does not have a valid "STOP bit" (that is, the STOP bit following the last data bit or PARITY bit is detected as logic 0).
+     * |        |          |0 = No framing error is generated.
+     * |        |          |1 = Framing error is generated.
+     * |        |          |Note: This bit can be cleared by writing "1" to it.
+     * |[6]     |BIF       |Break Interrupt Flag
+     * |        |          |This bit is set to logic "1" whenever the received data input (RX) is held in the "spacing state" (logic 0) for longer than a full word transmission time (that is, the total time of "START bit" + data bits + parity + STOP bits).
+     * |        |          |0 = No Break interrupt is generated.
+     * |        |          |1 = Break interrupt is generated.
+     * |        |          |Note: This bit can be cleared by writing "1" to it.
+     * |[13:8]  |RXPTR     |RX FIFO Pointer (Read Only)
+     * |        |          |This field indicates the RX FIFO Buffer Pointer.
+     * |        |          |When UART receives one byte from external device, RXPTR increases one.
+     * |        |          |When one byte of RX FIFO is read by CPU, RXPTR decreases one.
+     * |        |          |The Maximum value shown in RXPTR is 15
+     * |        |          |When the using level of RX FIFO Buffer equal to 16, the RXFULL bit is set to 1 and RXPTR will show 0.
+     * |        |          |As one byte of RX FIFO is read by CPU, the RXFULL bit is cleared to 0 and RXPTR will show 15.
+     * |[14]    |RXEMPTY   |Receiver FIFO Empty (Read Only)
+     * |        |          |This bit initiate RX FIFO empty or not.
+     * |        |          |0 = RX FIFO is not empty.
+     * |        |          |1 = RX FIFO is empty.
+     * |        |          |Note: When the last byte of RX FIFO has been read by CPU, hardware sets this bit high.
+     * |        |          |It will be cleared when UART receives any new data.
+     * |[15]    |RXFULL    |Receiver FIFO Full (Read Only)
+     * |        |          |This bit initiates RX FIFO full or not.
+     * |        |          |0 = RX FIFO is not full.
+     * |        |          |1 = RX FIFO is full.
+     * |        |          |Note: This bit is set when the number of usage in RX FIFO Buffer is equal to 16, otherwise it is cleared by hardware.
+     * |[21:16] |TXPTR     |TX FIFO Pointer (Read Only)
+     * |        |          |This field indicates the TX FIFO Buffer Pointer.
+     * |        |          |When CPU writes one byte into UART_DAT, TXPTR increases one.
+     * |        |          |When one byte of TX FIFO is transferred to Transmitter Shift Register, TXPTR decreases one.
+     * |        |          |The Maximum value shown in TXPTR is 15.
+     * |        |          |When the using level of TX FIFO Buffer equal to 16, the TXFULL bit is set to 1 and TXPTR will show 0.
+     * |        |          |As one byte of TX FIFO is transferred to Transmitter Shift Register, the TXFULL bit is cleared to 0 and TXPTR will show 15.
+     * |[22]    |TXEMPTY   |Transmitter FIFO Empty (Read Only)
+     * |        |          |This bit indicates TX FIFO empty or not.
+     * |        |          |0 = TX FIFO is not empty.
+     * |        |          |1 = TX FIFO is empty.
+     * |        |          |Note: When the last byte of TX FIFO has been transferred to Transmitter Shift Register, hardware sets this bit high
+     * |        |          |It will be cleared when writing data into UART_DAT (TX FIFO not empty).
+     * |[23]    |TXFULL    |Transmitter FIFO Full (Read Only)
+     * |        |          |This bit indicates TX FIFO full or not.
+     * |        |          |0 = TX FIFO is not full.
+     * |        |          |1 = TX FIFO is full.
+     * |        |          |Note: This bit is set when the number of usage in TX FIFO Buffer is equal to 16, otherwise it is cleared by hardware.
+     * |[24]    |TXOVIF    |TX Overflow Error Interrupt Flag
+     * |        |          |If TX FIFO (UART_DAT) is full, an additional write to UART_DAT will cause this bit to logic 1.
+     * |        |          |0 = TX FIFO is not overflow.
+     * |        |          |1 = TX FIFO is overflow.
+     * |        |          |Note: This bit can be cleared by writing "1" to it.
+     * |[28]    |TXEMPTYF  |Transmitter Empty Flag (Read Only)
+     * |        |          |This bit is set by hardware when TX FIFO (UART_DAT) is empty and the STOP bit of the last byte has been transmitted.
+     * |        |          |0 = TX FIFO is not empty or the STOP bit of the last byte has been not transmitted.
+     * |        |          |1 = TX FIFO is empty and the STOP bit of the last byte has been transmitted.
+     * |        |          |Note: This bit is cleared automatically when TX FIFO is not empty or the last byte transmission has not completed.
+     * |[29]    |RXIDLE    |RX Idle Status (Read Only)
+     * |        |          |This bit is set by hardware when RX is idle.
+     * |        |          |0 = RX is busy.
+     * |        |          |1 = RX is idle. (Default)
+     * |[31]    |TXRXACT   |TX and RX Active Status (Read Only)
+     * |        |          |This bit indicates TX and RX are active or inactive.
+     * |        |          |0 = TX and RX are inactive.
+     * |        |          |1 = TX and RX are active. (Default)
+     * |        |          |Note: When TXRXDIS (UART_FUNCSEL[3]) is set and both TX and RX are in idle state, this bit is cleared.
+     * |        |          |The UART controller can not transmit or receive data at this moment.
+     * |        |          |Otherwise this bit is set.
+     * @var UART_T::INTSTS
+     * Offset: 0x1C  UART Interrupt Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RDAIF     |Receive Data Available Interrupt Flag
+     * |        |          |When the number of bytes in the RX FIFO equals the RFITL then the RDAIF(UART_INTSTS[0]) will be set.
+     * |        |          |If RDAIEN (UART_INTEN [0]) is enabled, the RDA interrupt will be generated.
+     * |        |          |0 = No RDA interrupt flag is generated.
+     * |        |          |1 = RDA interrupt flag is generated.
+     * |        |          |Note: This bit is read only and it will be cleared when the number of unread bytes of RX FIFO drops below the threshold level (RFITL(UART_FIFO[7:4]).
+     * |[1]     |THREIF    |Transmit Holding Register Empty Interrupt Flag
+     * |        |          |This bit is set when the last data of TX FIFO is transferred to Transmitter Shift Register.
+     * |        |          |If THREIEN (UART_INTEN[1]) is enabled, the THRE interrupt will be generated.
+     * |        |          |0 = No THRE interrupt flag is generated.
+     * |        |          |1 = THRE interrupt flag is generated.
+     * |        |          |Note: This bit is read only and it will be cleared when writing data into UART_DAT (TX FIFO not empty).
+     * |[2]     |RLSIF     |Receive Line Interrupt Flag (Read Only)
+     * |        |          |This bit is set when the RX receive data have parity error, frame error or break error (at least one of 3 bits, BIF(UART_FIFOSTS[6]), FEF(UART_FIFOSTS[5]) and PEF(UART_FIFOSTS[4]), is set).
+     * |        |          |If RLSIEN (UART_INTEN [2]) is enabled, the RLS interrupt will be generated.
+     * |        |          |0 = No RLS interrupt flag is generated.
+     * |        |          |1 = RLS interrupt flag is generated.
+     * |        |          |Note1: In RS-485 function mode, this field is set include "receiver detect and received address byte character (bit9 = "1") bit".
+     * |        |          |At the same time, the bit of ADDRDETF (UART_FIFOSTS[3]) is also set.
+     * |        |          |Note2: This bit is read only and reset to 0 when all bits of BIF (UART_FIFOSTS[6]), FEF(UART_FIFOSTS[5]) and PEF(UART_FIFOSTS[4]) are cleared.
+     * |        |          |Note3: In RS-485 function mode, this bit is read only and reset to 0 when all bits of BIF (UART_FIFOSTS[6]), FEF(UART_FIFOSTS[5]), PEF(UART_FIFOSTS[4]) and ADDRDETF (UART_FIFOSTS[3]) are cleared.
+     * |[3]     |MODEMIF   |MODEM Interrupt Flag (Read Only)
+     * |        |          |This bit is set when the nCTS pin has state change (CTSDETF (UART_MODEMSTS[0]) = 1).
+     * |        |          |If MODEMIEN (UART_INTEN [3]) is enabled, the Modem interrupt will be generated.
+     * |        |          |0 = No Modem interrupt flag is generated.
+     * |        |          |1 = Modem interrupt flag is generated.
+     * |        |          |Note: This bit is read only and reset to 0 when bit CTSDETF is cleared by a write 1 on CTSDETF(UART_MODEMSTS[0]).
+     * |[4]     |RXTOIF    |RX Time-out Interrupt Flag (Read Only)
+     * |        |          |This bit is set when the RX FIFO is not empty and no activities occurred in the RX FIFO and the time-out counter equal to TOIC (UART_TOUT[7:0]).
+     * |        |          |If RXTOIEN (UART_INTEN [4]) is enabled, the RX time-out interrupt will be generated.
+     * |        |          |0 = No RX time-out interrupt flag is generated.
+     * |        |          |1 = RX time-out interrupt flag is generated.
+     * |        |          |Note: This bit is read only and user can read UART_DAT (RX is in active) to clear it.
+     * |[5]     |BUFERRIF  |Buffer Error Interrupt Flag (Read Only)
+     * |        |          |This bit is set when the TX FIFO or RX FIFO overflows (TXOVIF (UART_FIFOSTS[24]) or RXOVIF (UART_FIFOSTS[0]) is set).
+     * |        |          |When BUFERRIF (UART_INTSTS[5]) is set, the transfer is not correct.
+     * |        |          |If BUFERRIEN (UART_INTEN [5]) is enabled, the buffer error interrupt will be generated.
+     * |        |          |0 = No buffer error interrupt flag is generated.
+     * |        |          |1 = Buffer error interrupt flag is generated.
+     * |        |          |Note: This bit is cleared if both of RXOVIF(UART_FIFOSTS[0]) and TXOVIF(UART_FIFOSTS[24]) are cleared to 0 by writing 1 to RXOVIF(UART_FIFOSTS[0]) and TXOVIF(UART_FIFOSTS[24]).
+     * |[6]     |WKIF      |UART Wake-up Interrupt Flag (Read Only)
+     * |        |          |This bit is set when TOUTWKF (UART_WKSTS[4]), RS485WKF (UART_WKSTS[3]), RFRTWKF (UART_WKSTS[2]), DATWKF (UART_WKSTS[1]) or CTSWKF(UART_WKSTS[0]) is set to 1.
+     * |        |          |0 = No UART wake-up interrupt flag is generated.
+     * |        |          |1 = UART wake-up interrupt flag is generated.
+     * |        |          |Note: This bit is cleared if all of TOUTWKF, RS485WKF, RFRTWKF, DATWKF and CTSWKF are cleared to 0 by writing 1 to the corresponding interrupt flag.
+     * |[7]     |LINIF     |LIN Bus Interrupt Flag
+     * |        |          |This bit is set when LIN slave header detect (SLVHDETF (UART_LINSTS[0] =1)), LIN break detect (BRKDETF(UART_LINSTS[8]=1)), bit error detect (BITEF(UART_LINSTS[9]=1)),
+     * |        |          |LIN slave ID parity error (SLVIDPEF(UART_LINSTS[2] = 1)) or LIN slave header error detect (SLVHEF (UART_LINSTS[1])).
+     * |        |          |If LINIEN (UART_INTEN [8]) is enabled the LIN interrupt will be generated.
+     * |        |          |0 = None of SLVHDETF, BRKDETF, BITEF, SLVIDPEF and SLVHEF is generated.
+     * |        |          |1 = At least one of SLVHDETF, BRKDETF, BITEF, SLVIDPEF and SLVHEF is generated.
+     * |        |          |Note: This bit is cleared when SLVHDETF(UART_LINSTS[0]), BRKDETF(UART_LINSTS[8]), BITEF(UART_LINSTS[9]), SLVIDPEF (UART_LINSTS[2])
+     * |        |          |and SLVHEF(UART_LINSTS[1]) all are cleared and software writing "1" to LINIF(UART_INTSTS[7]).
+     * |[8]     |RDAINT    |Receive Data Available Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if RDAIEN (UART_INTEN[0]) and RDAIF (UART_INTSTS[0]) are both set to 1.
+     * |        |          |0 = No RDA interrupt is generated.
+     * |        |          |1 = RDA interrupt is generated.
+     * |[9]     |THREINT   |Transmit Holding Register Empty Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if THREIEN (UART_INTEN[1]) and THREIF(UART_INTSTS[1]) are both set to 1.
+     * |        |          |0 = No THRE interrupt is generated.
+     * |        |          |1 = THRE interrupt is generated.
+     * |[10]    |RLSINT    |Receive Line Status Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if RLSIEN (UART_INTEN[2]) and RLSIF(UART_INTSTS[2]) are both set to 1.
+     * |        |          |0 = No RLS interrupt is generated.
+     * |        |          |1 = RLS interrupt is generated.
+     * |[11]    |MODEMINT  |MODEM Status Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if MODEMIEN(UART_INTEN[3]) and MODEMIF(UART_INTSTS[3]) are both set to 1.
+     * |        |          |0 = No Modem interrupt is generated.
+     * |        |          |1 = Modem interrupt is generated.
+     * |[12]    |RXTOINT   |RX Time-out Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if RXTOIEN (UART_INTEN[4]) and RXTOIF(UART_INTSTS[4]) are both set to 1.
+     * |        |          |0 = No RX time-out interrupt is generated.
+     * |        |          |1 = RX time-out interrupt is generated.
+     * |[13]    |BUFERRINT |Buffer Error Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if BUFERRIEN(UART_INTEN[5]) and BUFERRIF(UART_ INTSTS[5]) are both set to 1.
+     * |        |          |0 = No buffer error interrupt is generated.
+     * |        |          |1 = Buffer error interrupt is generated.
+     * |[14]    |WKINT     |UART Wake-up Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if WKIEN (UART_INTEN[6]) and WKIF (UART_INTSTS[6]) are both set to 1.
+     * |        |          |0 = No UART wake-up interrupt is generated.
+     * |        |          |1 = UART wake-up interrupt is generated.
+     * |[15]    |LININT    |LIN Bus Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if LINIEN (UART_INTEN[8]) and LINIF(UART_INTSTS[7]) are both set to 1.
+     * |        |          |0 = No LIN Bus interrupt is generated.
+     * |        |          |1 = The LIN Bus interrupt is generated.
+     * |[16]    |SBEIF     |Single-wire Bit Error Detection Interrupt Flag
+     * |        |          |This bit is set when the single wire bus state not equals to UART controller TX state in Single-wire mode.
+     * |        |          |0 = No single-wire bit error detection interrupt flag is generated.
+     * |        |          |1 = Single-wire bit error detection interrupt flag is generated.
+     * |        |          |Note1: This bit is active when FUNCSEL (UART_FUNCSEL[2:0]) is select UART Single-wire mode.
+     * |        |          |Note2: This bit can be cleared by writing "1" to it.
+     * |[18]    |HWRLSIF   |PDMA Mode Receive Line Status Flag (Read Only)
+     * |        |          |This bit is set when the RX receive data have parity error, frame error or break error (at least one of 3 bits, BIF (UART_FIFOSTS[6]), FEF (UART_FIFOSTS[5]) and PEF (UART_FIFOSTS[4]) is set).
+     * |        |          |If RLSIEN (UART_INTEN [2]) is enabled, the RLS interrupt will be generated.
+     * |        |          |0 = No RLS interrupt flag is generated in PDMA mode.
+     * |        |          |1 = RLS interrupt flag is generated in PDMA mode.
+     * |        |          |Note1: In RS-485 function mode, this field include "receiver detect any address byte received address byte character (bit9 = "1") bit".
+     * |        |          |Note2: In UART function mode, this bit is read only and reset to 0 when all bits of BIF(UART_FIFOSTS[6]), FEF(UART_FIFOSTS[5]) and PEF(UART_FIFOSTS[4]) are cleared.
+     * |        |          |Note3: In RS-485 function mode, this bit is read only and reset to 0 when all bits of BIF(UART_FIFOSTS[6]), FEF(UART_FIFOSTS[5]), PEF(UART_FIFOSTS[4]) and ADDRDETF (UART_FIFOSTS[3]) are cleared.
+     * |[19]    |HWMODIF   |PDMA Mode MODEM Interrupt Flag (Read Only)
+     * |        |          |This bit is set when the nCTS pin has state change (CTSDETF (UART_MODEMSTS [0] =1)).
+     * |        |          |If MODEMIEN (UART_INTEN [3]) is enabled, the Modem interrupt will be generated.
+     * |        |          |0 = No Modem interrupt flag is generated in PDMA mode.
+     * |        |          |1 = Modem interrupt flag is generated in PDMA mode.
+     * |        |          |Note: This bit is read only and reset to 0 when the bit CTSDETF (UART_MODEMSTS[0]) is cleared by writing 1 on CTSDETF (UART_MODEMSTS [0]).
+     * |[20]    |HWTOIF    |PDMA Mode RX Time-out Interrupt Flag (Read Only)
+     * |        |          |This bit is set when the RX FIFO is not empty and no activities occurred in the RX FIFO and the time-out counter equal to TOIC (UART_TOUT[7:0]).
+     * |        |          |If RXTOIEN (UART_INTEN [4]) is enabled, the RX time-out interrupt will be generated .
+     * |        |          |0 = No RX time-out interrupt flag is generated in PDMA mode.
+     * |        |          |1 = RX time-out interrupt flag is generated in PDMA mode.
+     * |        |          |Note: This bit is read only and user can read UART_DAT (RX is in active) to clear it.
+     * |[21]    |HWBUFEIF  |PDMA Mode Buffer Error Interrupt Flag (Read Only)
+     * |        |          |This bit is set when the TX or RX FIFO overflows (TXOVIF (UART_FIFOSTS [24]) or RXOVIF (UART_FIFOSTS[0]) is set).
+     * |        |          |When BUFERRIF (UART_INTSTS[5]) is set, the transfer maybe is not correct.
+     * |        |          |If BUFERRIEN (UART_INTEN [5]) is enabled, the buffer error interrupt will be generated.
+     * |        |          |0 = No buffer error interrupt flag is generated in PDMA mode.
+     * |        |          |1 = Buffer error interrupt flag is generated in PDMA mode.
+     * |        |          |Note: This bit is cleared when both TXOVIF (UART_FIFOSTS[24]]) and RXOVIF (UART_FIFOSTS[0]) are cleared.
+     * |[22]    |TXENDIF   |Transmitter Empty Interrupt Flag
+     * |        |          |This bit is set when TX FIFO (UART_DAT) is empty and the STOP bit of the last byte has been transmitted (TXEMPTYF (UART_FIFOSTS[28]) is set)
+     * |        |          |If TXENDIEN (UART_INTEN[22]) is enabled, the Transmitter Empty interrupt will be generated.
+     * |        |          |0 = No transmitter empty interrupt flag is generated.
+     * |        |          |1 = Transmitter empty interrupt flag is generated.
+     * |        |          |Note: This bit is cleared automatically when TX FIFO is not empty or the last byte transmission has not completed.
+     * |[24]    |SWBEINT   |Single-wire Bit Error Detect Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if SWBEIEN (UART_INTEN[16]) and SWBEIF (UART_INTSTS[16]) are both set to 1.
+     * |        |          |0 = No Single-wire Bit Error Detection Interrupt generated.
+     * |        |          |1 = Single-wire Bit Error Detection Interrupt generated.
+     * |[26]    |HWRLSINT  |PDMA Mode Receive Line Status Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if RLSIEN (UART_INTEN[2]) and HWRLSIF(UART_INTSTS[18]) are both set to 1.
+     * |        |          |0 = No RLS interrupt is generated in PDMA mode.
+     * |        |          |1 = RLS interrupt is generated in PDMA mode.
+     * |[27]    |HWMODINT  |PDMA Mode MODEM Status Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if MODEMIEN (UART_INTEN[3]) and HWMODIF(UART_INTSTS[19]) are both set to 1.
+     * |        |          |0 = No Modem interrupt is generated in PDMA mode.
+     * |        |          |1 = Modem interrupt is generated in PDMA mode.
+     * |[28]    |HWTOINT   |PDMA Mode RX Time-out Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if RXTOIEN (UART_INTEN[4]) and HWTOIF(UART_INTSTS[20]) are both set to 1.
+     * |        |          |0 = No RX time-out interrupt is generated in PDMA mode.
+     * |        |          |1 = RX time-out interrupt is generated in PDMA mode.
+     * |[29]    |HWBUFEINT |PDMA Mode Buffer Error Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if BUFERRIEN (UART_INTEN[5]) and HWBUFEIF (UART_INTSTS[21]) are both set to 1.
+     * |        |          |0 = No buffer error interrupt is generated in PDMA mode.
+     * |        |          |1 = Buffer error interrupt is generated in PDMA mode.
+     * |[30]    |TXENDINT  |Transmitter Empty Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if TXENDIEN (UART_INTEN[22]) and TXENDIF(UART_INTSTS[22]) are both set to 1.
+     * |        |          |0 = No Transmitter Empty interrupt is generated.
+     * |        |          |1 = Transmitter Empty interrupt is generated.
+     * |[31]    |ABRINT    |Auto-baud Rate Interrupt Indicator (Read Only)
+     * |        |          |This bit is set if ABRIEN (UART_INTEN[18]) and ABRIF (UART_ALTCTL[17]) are both set to 1.
+     * |        |          |0 = No Auto-baud Rate interrupt is generated.
+     * |        |          |1 = The Auto-baud Rate interrupt is generated.
+     * @var UART_T::TOUT
+     * Offset: 0x20  UART Time-out Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7:0]   |TOIC      |Time-out Interrupt Comparator
+     * |        |          |The time-out counter resets and starts counting (the counting clock = baud rate) whenever the RX FIFO receives a new data word if time out counter is enabled by setting TOCNTEN (UART_INTEN[11]).
+     * |        |          |Once the content of time-out counter is equal to that of time-out interrupt comparator (TOIC (UART_TOUT[7:0])), a receiver time-out interrupt (RXTOINT(UART_INTSTS[12])) is generated if RXTOIEN (UART_INTEN [4]) enabled.
+     * |        |          |A new incoming data word or RX FIFO empty will clear RXTOIF (UART_INTSTS[4]).
+     * |        |          |In order to avoid receiver time-out interrupt generation immediately during one character is being received, TOIC value should be set between 40 and 255.
+     * |        |          |So, for example, if TOIC is set with 40, the time-out interrupt is generated after four characters are not received when 1 stop bit and no parity check is set for UART transfer.
+     * |[15:8]  |DLY       |TX Delay Time Value
+     * |        |          |This field is used to programming the transfer delay time between the last STOP bit and next START bit.
+     * |        |          |The unit is bit time.
+     * @var UART_T::BAUD
+     * Offset: 0x24  UART Baud Rate Divider Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |BRD       |Baud Rate Divider
+     * |        |          |The field indicates the baud rate divider.
+     * |        |          |This filed is used in baud rate calculation.
+     * |        |          |The detail description is shown in Table 7.13-4.
+     * |[27:24] |EDIVM1    |Extra Divider for BAUD Rate Mode 1
+     * |        |          |This field is used for baud rate calculation in mode 1 and has no effect for baud rate calculation in mode 0 and mode 2.
+     * |        |          |The detail description is shown in Table 7.13-4.
+     * |[28]    |BAUDM0    |BAUD Rate Mode Selection Bit 0
+     * |        |          |This bit is baud rate mode selection bit 0.
+     * |        |          |UART provides three baud rate calculation modes.
+     * |        |          |This bit combines with BAUDM1 (UART_BAUD[29]) to select baud rate calculation mode.
+     * |        |          |The detail description is shown in Table 7.13-4.
+     * |[29]    |BAUDM1    |BAUD Rate Mode Selection Bit 1
+     * |        |          |This bit is baud rate mode selection bit 1.
+     * |        |          |UART provides three baud rate calculation modes.
+     * |        |          |This bit combines with BAUDM0 (UART_BAUD[28]) to select baud rate calculation mode.
+     * |        |          |The detail description is shown in Table 7.13-4.
+     * |        |          |Note: In IrDA mode must be operated in mode 0.
+     * @var UART_T::IRDA
+     * Offset: 0x28  UART IrDA Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |TXEN      |IrDA Receiver/Transmitter Selection Enable Bit
+     * |        |          |0 = IrDA Transmitter Disabled and Receiver Enabled. (Default)
+     * |        |          |1 = IrDA Transmitter Enabled and Receiver Disabled.
+     * |[5]     |TXINV     |IrDA Inverse Transmitting Output Signal
+     * |        |          |0 = None inverse transmitting signal. (Default).
+     * |        |          |1 = Inverse transmitting output signal.
+     * |        |          |Note1: Before setting this bit, TXRXDIS (UART_FUNCSEL[3]) should be set then waited for TXRXACT (UART_FIFOSTS[31]) is cleared.
+     * |        |          |When the configuration is done, cleared TXRXDIS (UART_FUNCSEL[3]) to activate UART controller.
+     * |        |          |Note2: This bit is valid when FUNCSEL (UART_FUNCSEL[1:0]) is select IrDA function.
+     * |[6]     |RXINV     |IrDA Inverse Receive Input Signal
+     * |        |          |0 = None inverse receiving input signal.
+     * |        |          |1 = Inverse receiving input signal. (Default)
+     * |        |          |Note1: Before setting this bit, TXRXDIS (UART_FUNCSEL[3]) should be set then waited for TXRXACT (UART_FIFOSTS[31]) is cleared.
+     * |        |          |When the configuration is done, cleared TXRXDIS (UART_FUNCSEL[3]) to activate UART controller.
+     * |        |          |Note2: This bit is valid when FUNCSEL (UART_FUNCSEL[1:0]) is select IrDA function.
+     * @var UART_T::ALTCTL
+     * Offset: 0x2C  UART Alternate Control/Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |BRKFL     |UART LIN Break Field Length
+     * |        |          |This field indicates a 4-bit LIN TX break field count.
+     * |        |          |Note1: This break field length is BRKFL + 1.
+     * |        |          |Note2: According to LIN spec, the reset value is 0xC (break field length = 13).
+     * |[6]     |LINRXEN   |LIN RX Enable Bit
+     * |        |          |0 = LIN RX mode Disabled.
+     * |        |          |1 = LIN RX mode Enabled.
+     * |[7]     |LINTXEN   |LIN TX Break Mode Enable Bit
+     * |        |          |0 = LIN TX Break mode Disabled.
+     * |        |          |1 = LIN TX Break mode Enabled.
+     * |        |          |Note: When TX break field transfer operation finished, this bit will be cleared automatically.
+     * |[8]     |RS485NMM  |RS-485 Normal Multi-drop Operation Mode (NMM)
+     * |        |          |0 = RS-485 Normal Multi-drop Operation mode (NMM) Disabled.
+     * |        |          |1 = RS-485 Normal Multi-drop Operation mode (NMM) Enabled.
+     * |        |          |Note: It cannot be active with RS-485_AAD operation mode.
+     * |[9]     |RS485AAD  |RS-485 Auto Address Detection Operation Mode (AAD)
+     * |        |          |0 = RS-485 Auto Address Detection Operation mode (AAD) Disabled.
+     * |        |          |1 = RS-485 Auto Address Detection Operation mode (AAD) Enabled.
+     * |        |          |Note: It cannot be active with RS-485_NMM operation mode.
+     * |[10]    |RS485AUD  |RS-485 Auto Direction Function (AUD)
+     * |        |          |0 = RS-485 Auto Direction Operation function (AUD) Disabled.
+     * |        |          |1 = RS-485 Auto Direction Operation function (AUD) Enabled.
+     * |        |          |Note: It can be active with RS-485_AAD or RS-485_NMM operation mode.
+     * |[15]    |ADDRDEN   |RS-485 Address Detection Enable Bit
+     * |        |          |This bit is used to enable RS-485 Address Detection mode.
+     * |        |          |0 = Address detection mode Disabled.
+     * |        |          |1 = Address detection mode Enabled.
+     * |        |          |Note: This bit is used for RS-485 any operation mode.
+     * |[17]    |ABRIF     |Auto-baud Rate Interrupt Flag (Read Only)
+     * |        |          |This bit is set when auto-baud rate detection function finished or the auto-baud rate counter was overflow and if ABRIEN(UART_INTEN [18]) is set then the auto-baud rate interrupt will be generated.
+     * |        |          |0 = No auto-baud rate interrupt flag is generated.
+     * |        |          |1 = Auto-baud rate interrupt flag is generated.
+     * |        |          |Note: This bit is read only, but it can be cleared by writing "1" to ABRDTOIF (UART_FIFOSTS[2]) and ABRDIF(UART_FIFOSTS[1]).
+     * |[18]    |ABRDEN    |Auto-baud Rate Detect Enable Bit
+     * |        |          |0 = Auto-baud rate detect function Disabled.
+     * |        |          |1 = Auto-baud rate detect function Enabled.
+     * |        |          |Note : This bit is cleared automatically after auto-baud detection is finished.
+     * |[20:19] |ABRDBITS  |Auto-baud Rate Detect Bit Length
+     * |        |          |00 = 1-bit time from Start bit to the 1st rising edge. The input pattern shall be 0x01.
+     * |        |          |01 = 2-bit time from Start bit to the 1st rising edge. The input pattern shall be 0x02.
+     * |        |          |10 = 4-bit time from Start bit to the 1st rising edge. The input pattern shall be 0x08.
+     * |        |          |11 = 8-bit time from Start bit to the 1st rising edge. The input pattern shall be 0x80.
+     * |        |          |Note : The calculation of bit number includes the START bit.
+     * |[31:24] |ADDRMV    |Address Match Value
+     * |        |          |This field contains the RS-485 address match values.
+     * |        |          |Note: This field is used for RS-485 auto address detection mode.
+     * @var UART_T::FUNCSEL
+     * Offset: 0x30  UART Function Select Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |FUNCSEL   |Function Select
+     * |        |          |000 = UART function.
+     * |        |          |001 = LIN function.
+     * |        |          |010 = IrDA function.
+     * |        |          |011 = RS-485 function.
+     * |        |          |100 = UART Single-wire function.
+     * |        |          |Others = Reserved.
+     * |[3]     |TXRXDIS   |TX and RX Disable Bit
+     * |        |          |Setting this bit can disable TX and RX.
+     * |        |          |0 = TX and RX Enabled.
+     * |        |          |1 = TX and RX Disabled.
+     * |        |          |Note: The TX and RX will not disable immediately when this bit is set.
+     * |        |          |The TX and RX compelet current task before disable TX and RX.
+     * |        |          |When TX and RX disable, the TXRXACT (UART_FIFOSTS[31]) is cleared.
+     * |[6]     |DGE       |Deglitch Enable Bit
+     * |        |          |0 = Deglitch Disabled.
+     * |        |          |1 = Deglitch Enabled.
+     * |        |          |Note: When this bit is set to logic 1, any pulse width less than about 300 ns will be considered a
+     * |        |          |glitch and will be removed in the serial data input (RX). This bit acts only on RX line and has no
+     * |        |          |effect on the transmitter logic.
+     * @var UART_T::LINCTL
+     * Offset: 0x34  UART LIN Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SLVEN     |LIN Slave Mode Enable Bit
+     * |        |          |0 = LIN slave mode Disabled.
+     * |        |          |1 = LIN slave mode Enabled.
+     * |[1]     |SLVHDEN   |LIN Slave Header Detection Enable Bit
+     * |        |          |0 = LIN slave header detection Disabled.
+     * |        |          |1 = LIN slave header detection Enabled.
+     * |        |          |Note1: This bit is only valid in LIN slave mode (SLVEN (UART_LINCTL[0]) = 1).
+     * |        |          |Note2: In LIN function mode, when detect header field (break + sync + frame ID), SLVHDETF (UART_LINSTS [0]) flag will be asserted.
+     * |        |          |If the LINIEN (UART_INTEN[8]) = 1, an interrupt will be generated.
+     * |[2]     |SLVAREN   |LIN Slave Automatic Resynchronization Mode Enable Bit
+     * |        |          |0 = LIN automatic resynchronization Disabled.
+     * |        |          |1 = LIN automatic resynchronization Enabled.
+     * |        |          |Note1: This bit only is valid in LIN slave mode (SLVEN (UART_LINCTL[0]) = 1).
+     * |        |          |Note2: When operation in Automatic Resynchronization mode, the baud rate setting must be mode2 (BAUDM1 (UART_BAUD [29]) and BAUDM0 (UART_BAUD [28]) must be 1).
+     * |        |          |Note3: The control and interactions of this field are explained in 7.13.5.10 (Slave mode with automatic resynchronization).
+     * |[3]     |SLVDUEN   |LIN Slave Divider Update Method Enable Bit
+     * |        |          |0 = UART_BAUD updated is written by software (if no automatic resynchronization update occurs at the same time).
+     * |        |          |1 = UART_BAUD is updated at the next received character.User must set the bit before checksum reception.
+     * |        |          |Note1: This bit only is valid in LIN slave mode (SLVEN (UART_LINCTL[0]) = 1).
+     * |        |          |Note2: This bit used for LIN Slave Automatic Resynchronization mode.
+     * |        |          |(for Non-Automatic Resynchronization mode, this bit should be kept cleared)
+     * |        |          |Note3: The control and interactions of this field are explained in 7.13.5.10 (Slave mode with automatic resynchronization).
+     * |[4]     |MUTE      |LIN Mute Mode Enable Bit
+     * |        |          |0 = LIN mute mode Disabled.
+     * |        |          |1 = LIN mute mode Enabled.
+     * |        |          |Note: The exit from mute mode condition and each control and interactions of this field are explained in 7.13.5.10 (LIN slave mode).
+     * |[8]     |SENDH     |LIN TX Send Header Enable Bit
+     * |        |          |The LIN TX header can be "break field" or "break and sync field" or "break, sync and frame ID field", it is depend on setting HSEL (UART_LINCTL[23:22]).
+     * |        |          |0 = Send LIN TX header Disabled.
+     * |        |          |1 = Send LIN TX header Enabled.
+     * |        |          |Note1: This bit is shadow bit of LINTXEN (UART_ALTCTL [7]); user can read/write it by setting LINTXEN (UART_ALTCTL [7]) or SENDH (UART_LINCTL [8]).
+     * |        |          |Note2: When transmitter header field (it may be "break" or "break + sync" or "break + sync + frame ID" selected by HSEL (UART_LINCTL[23:22]) field) transfer operation finished, this bit will be cleared automatically.
+     * |[9]     |IDPEN     |LIN ID Parity Enable Bit
+     * |        |          |0 = LIN frame ID parity Disabled.
+     * |        |          |1 = LIN frame ID parity Enabled.
+     * |        |          |Note1: This bit can be used for LIN master to sending header field (SENDH (UART_LINCTL[8])) = 1 and HSEL (UART_LINCTL[23:22]) = 10 or be used for enable LIN slave received frame ID parity checked.
+     * |        |          |Note2: This bit is only used when the operation header transmitter is in HSEL (UART_LINCTL[23:22]) = 10.
+     * |[10]    |BRKDETEN  |LIN Break Detection Enable Bit
+     * |        |          |When detect consecutive dominant greater than 11 bits, and are followed by a delimiter character, the BRKDETF (UART_LINSTS[8]) flag is set at the end of break field.
+     * |        |          |If the LINIEN (UART_INTEN [8])=1, an interrupt will be generated.
+     * |        |          |0 = LIN break detection Disabled .
+     * |        |          |1 = LIN break detection Enabled.
+     * |[11]    |LINRXOFF  |LIN Receiver Disable Bit
+     * |        |          |If the receiver is enabled (LINRXOFF (UART_LINCTL[11]) = 0), all received byte data will be accepted and stored in the RX FIFO, and if the receiver is disabled (LINRXOFF (UART_LINCTL[11] = 1), all received byte data will be ignore.
+     * |        |          |0 = LIN receiver Enabled.
+     * |        |          |1 = LIN receiver Disabled.
+     * |        |          |Note: This bit is only valid when operating in LIN function mode (FUNCSEL (UART_FUNCSEL[1:0]) = 01).
+     * |[12]    |BITERREN  |Bit Error Detect Enable Bit
+     * |        |          |0 = Bit error detection function Disabled.
+     * |        |          |1 = Bit error detection function Enabled.
+     * |        |          |Note: In LIN function mode, when occur bit error, the BITEF (UART_LINSTS[9]) flag will be asserted.
+     * |        |          |If the LINIEN (UART_INTEN[8]) = 1, an interrupt will be generated.
+     * |[19:16] |BRKFL     |LIN Break Field Length
+     * |        |          |This field indicates a 4-bit LIN TX break field count.
+     * |        |          |Note1: These registers are shadow registers of BRKFL (UART_ALTCTL[3:0]), User can read/write it by setting BRKFL (UART_ALTCTL[3:0]) or BRKFL (UART_LINCTL[19:16]).
+     * |        |          |Note2: This break field length is BRKFL + 1.
+     * |        |          |Note3: According to LIN spec, the reset value is 12 (break field length = 13).
+     * |[21:20] |BSL       |LIN Break/Sync Delimiter Length
+     * |        |          |00 = The LIN break/sync delimiter length is 1-bit time.
+     * |        |          |01 = The LIN break/sync delimiter length is 2-bit time.
+     * |        |          |10 = The LIN break/sync delimiter length is 3-bit time.
+     * |        |          |11 = The LIN break/sync delimiter length is 4-bit time.
+     * |        |          |Note: This bit used for LIN master to sending header field.
+     * |[23:22] |HSEL      |LIN Header Select
+     * |        |          |00 = The LIN header includes "break field".
+     * |        |          |01 = The LIN header includes "break field" and "sync field".
+     * |        |          |10 = The LIN header includes "break field", "sync field" and "frame ID field".
+     * |        |          |11 = Reserved.
+     * |        |          |Note: This bit is used to master mode for LIN to send header field (SENDH (UART_LINCTL [8]) = 1) or used to slave to indicates exit from mute mode condition (MUTE (UART_LINCTL[4] = 1).
+     * |[31:24] |PID       |LIN PID Bits
+     * |        |          |This field contains the LIN frame ID value in LIN function mode, and the frame ID parity can be generated by software or hardware depends on IDPEN (UART_LINCTL[9]) = 1.
+     * |        |          |If the parity generated by hardware, user fill ID0~ID5 (PID [29:24]), hardware will calculate P0 (PID[30]) and P1 (PID[31]), otherwise user must filled frame ID and parity in this field.
+     * |        |          |Note1: User can fill any 8-bit value to this field and the bit 24 indicates ID0 (LSB first).
+     * |        |          |Note2: This field can be used for LIN master mode or slave mode.
+     * @var UART_T::LINSTS
+     * Offset: 0x38  UART LIN Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SLVHDETF  |LIN Slave Header Detection Flag
+     * |        |          |This bit is set by hardware when a LIN header is detected in LIN slave mode and be cleared by writing 1 to it.
+     * |        |          |0 = LIN header not detected.
+     * |        |          |1 = LIN header detected (break + sync + frame ID).
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: This bit is only valid in LIN slave mode (SLVEN (UART_LINCTL [0]) = 1) and enable LIN slave header detection function (SLVHDEN (UART_LINCTL [1])).
+     * |        |          |Note3: When enable ID parity check IDPEN (UART_LINCTL [9]), if hardware detect complete header ("break + sync + frame ID"), the SLVHDETF will be set whether the frame ID correct or not.
+     * |[1]     |SLVHEF    |LIN Slave Header Error Flag
+     * |        |          |This bit is set by hardware when a LIN header error is detected in LIN slave mode and be cleared by writing 1 to it.
+     * |        |          |The header errors include "break delimiter is too short (less than 0.5 bit time)", "frame error in sync field or Identifier field", "sync field data is not 0x55 in Non-Automatic Resynchronization mode",
+     * |        |          |"sync field deviation error with Automatic Resynchronization mode", "sync field measure time-out with Automatic Resynchronization mode" and "LIN header reception time-out".
+     * |        |          |0 = LIN header error not detected.
+     * |        |          |1 = LIN header error detected.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: This bit is only valid when UART is operated in LIN slave mode (SLVEN (UART_LINCTL [0]) = 1) and enables LIN slave header detection function (SLVHDEN (UART_LINCTL [1])).
+     * |[2]     |SLVIDPEF  |LIN Slave ID Parity Error Flag
+     * |        |          |This bit is set by hardware when receipted frame ID parity is not correct.
+     * |        |          |0 = No active.
+     * |        |          |1 = Receipted frame ID parity is not correct.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: This bit is only valid in LIN slave mode (SLVEN (UART_LINCTL [0])= 1) and enable LIN frame ID parity check function IDPEN (UART_LINCTL [9]).
+     * |[3]     |SLVSYNCF  |LIN Slave Sync Field
+     * |        |          |This bit indicates that the LIN sync field is being analyzed in Automatic Resynchronization mode.
+     * |        |          |When the receiver header have some error been detect, user must reset the internal circuit to re-search new frame header by writing 1 to this bit.
+     * |        |          |0 = The current character is not at LIN sync state.
+     * |        |          |1 = The current character is at LIN sync state.
+     * |        |          |Note1: This bit is only valid in LIN Slave mode (SLVEN(UART_LINCTL[0]) = 1).
+     * |        |          |Note2: This bit can be cleared by writing 1 to it.
+     * |        |          |Note3: When writing 1 to it, hardware will reload the initial baud rate and re-search a new frame header.
+     * |[8]     |BRKDETF   |LIN Break Detection Flag
+     * |        |          |This bit is set by hardware when a break is detected and be cleared by writing 1 to it through software.
+     * |        |          |0 = LIN break not detected.
+     * |        |          |1 = LIN break detected.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: This bit is only valid when LIN break detection function is enabled (BRKDETEN (UART_LINCTL[10]) =1).
+     * |[9]     |BITEF     |Bit Error Detect Status Flag
+     * |        |          |At TX transfer state, hardware will monitor the bus state, if the input pin (UART_RXD) state not equals to the output pin (UART_TXD) state, BITEF (UART_LINSTS[9]) will be set.
+     * |        |          |When occur bit error, if the LINIEN (UART_INTEN[8]) = 1, an interrupt will be generated.
+     * |        |          |0 = Bit error not detected.
+     * |        |          |1 = Bit error detected.
+     * |        |          |Note1: This bit can be cleared by writing 1 to it.
+     * |        |          |Note2: This bit is only valid when enable bit error detection function (BITERREN (UART_LINCTL [12]) = 1).
+     * @var UART_T::BRCOMP
+     * Offset: 0x3C  UART Baud Rate Compensation Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |BRCOMP    |Baud Rate Compensation Patten
+     * |        |          |These 9-bits are used to define the relative bit is compensated or not.
+     * |        |          |BRCOMP[7:0] is used to define the compensation of UART_DAT[7:0] and BRCOM[8] is used to define the PARITY bit.
+     * |[31]    |BRCOMPDEC |Baud Rate Compensation Decrease
+     * |        |          |0 = Positive (increase one module clock) compensation for each compensated bit.
+     * |        |          |1 = Negative (decrease one module clock) compensation for each compensated bit.
+     * @var UART_T::WKCTL
+     * Offset: 0x40  UART Wake-up Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKCTSEN   |nCTS Wake-up Enable Bit
+     * |        |          |0 = nCTS Wake-up system function Disabled.
+     * |        |          |1 = nCTS Wake-up system function Enabled.
+     * |        |          |Note:When the system is in Power-down mode, an external.nCTS change will wake up system from Power-down mode.
+     * |[1]     |WKDATEN   |Incoming Data Wake-up Enable Bit
+     * |        |          |0 = Incoming data wake-up system function Disabled.
+     * |        |          |1 = Incoming data wake-up system function Enabled.
+     * |        |          |Note:When the system is in Power-down mode, incoming data will wake-up system from Power-down mode.
+     * |[2]     |WKRFRTEN  |Received Data FIFO Reached Threshold Wake-up Enable Bit
+     * |        |          |0 = Received Data FIFO reached threshold wake-up system function Disabled.
+     * |        |          |1 = Received Data FIFO reached threshold wake-up system function Enabled.
+     * |        |          |Note: When the system is in Power-down mode, Received Data FIFO reached threshold will wake-up system from Power-down mode.
+     * |[3]     |WKRS485EN |RS-485 Address Match (AAD Mode) Wake-up Enable Bit
+     * |        |          |0 = RS-485 Address Match (AAD mode) wake-up system function Disabled.
+     * |        |          |1 = RS-485 Address Match (AAD mode) wake-up system function Enabled.
+     * |        |          |Note1: When the system is in.Power-down mode, RS-485 Address Match will wake-up system from Power-down mode.
+     * |        |          |Note2: This bit is used for RS-485 Auto Address Detection (AAD) mode in RS-485 function mode and ADDRDEN (UART_ALTCTL[15]) is set to 1.
+     * |[4]     |WKTOUTEN  |Received Data FIFO Reached Threshold Time-out Wake-up Enable Bit
+     * |        |          |0 = Received Data FIFO reached threshold time-out wake-up system function Disabled.
+     * |        |          |1 = Received Data FIFO reached threshold time-out wake-up system function Enabled.
+     * |        |          |Note1: When the system is in Power-down mode, Received Data FIFO reached threshold time-out will wake up system from Power-down mode.
+     * |        |          |Note2: It is suggested the function is enabled when the WKRFRTEN (UART_WKCTL[2]) is set to 1.
+     * @var UART_T::WKSTS
+     * Offset: 0x44  UART Wake-up Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CTSWKF    |nCTS Wake-up Flag
+     * |        |          |This bit is set if chip wake-up from power-down state by nCTS wake-up.
+     * |        |          |0 = Chip stays in power-down state.
+     * |        |          |1 = Chip wake-up from power-down state by nCTS wake-up.
+     * |        |          |Note1: If WKCTSEN (UART_WKCTL[0]) is enabled, the nCTS wake-up cause this bit is set to "1".
+     * |        |          |Note2: This bit can be cleared by writing "1" to it.
+     * |[1]     |DATWKF    |Incoming Data Wake-up Flag
+     * |        |          |This bit is set if chip wake-up from power-down state by data wake-up.
+     * |        |          |0 = Chip stays in power-down state.
+     * |        |          |1 = Chip wake-up from power-down state by Incoming Data wake-up.
+     * |        |          |Note1: If WKDATEN (UART_WKCTL[1]) is enabled, the Incoming Data wake-up cause this bit is set to "1".
+     * |        |          |Note2: This bit can be cleared by writing "1" to it.
+     * |[2]     |RFRTWKF   |Received Data FIFO Reached Threshold Wake-up Flag
+     * |        |          |This bit is set if chip wake-up from power-down state by Received Data FIFO reached threshold wake-up.
+     * |        |          |0 = Chip stays in power-down state.
+     * |        |          |1 = Chip wake-up from power-down state by Received Data FIFO Reached Threshold wake-up.
+     * |        |          |Note1: If WKRFRTEN (UART_WKCTL[2]) is enabled, the Received Data FIFO Reached Threshold wake-up cause this bit is set to "1".
+     * |        |          |Note2: This bit can be cleared by writing "1" to it.
+     * |[3]     |RS485WKF  |RS-485 Address Match (AAD Mode) Wake-up Flag
+     * |        |          |This bit is set if chip wake-up from power-down state by RS-485 Address Match (AAD mode).
+     * |        |          |0 = Chip stays in power-down state.
+     * |        |          |1 = Chip wake-up from power-down state by RS-485 Address Match (AAD mode) wake-up.
+     * |        |          |Note1: If WKRS485EN (UART_WKCTL[3]) is enabled, the RS-485 Address Match (AAD mode) wake-up cause this bit is set to "1".
+     * |        |          |Note2: This bit can be cleared by writing "1" to it.
+     * |[4]     |TOUTWKF   |Received Data FIFO Threshold Time-out Wake-up Flag
+     * |        |          |This bit is set if chip wake-up from power-down state by Received Data FIFO Threshold Time-out wake-up.
+     * |        |          |0 = Chip stays in power-down state.
+     * |        |          |1 = Chip wake-up from power-down state by Received Data FIFO reached threshold time-out.
+     * |        |          |Note1: If WKTOUTEN (UART_WKCTL[4]) is enabled, the Received Data FIFO reached threshold time-out wake-up cause this bit is set to "1".
+     * |        |          |Note2: This bit can be cleared by writing "1" to it.
+     * @var UART_T::DWKCOMP
+     * Offset: 0x48  UART Incoming Data Wake-up Compensation Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |STCOMP    |Start Bit Compensation Value
+     * |        |          |These bits field indicate how many clock cycle selected by UART_CLK do the UART controller can get the 1st bit (START bit) when the device is wake-up from Power-down mode.
+     * |        |          |Note: It is valid only when WKDATEN (UART_WKCTL[1]) is set.
+     */
+    __IO uint32_t DAT;                   /*!< [0x0000] UART Receive/Transmit Buffer Register                            */
+    __IO uint32_t INTEN;                 /*!< [0x0004] UART Interrupt Enable Register                                   */
+    __IO uint32_t FIFO;                  /*!< [0x0008] UART FIFO Control Register                                       */
+    __IO uint32_t LINE;                  /*!< [0x000c] UART Line Control Register                                       */
+    __IO uint32_t MODEM;                 /*!< [0x0010] UART Modem Control Register                                      */
+    __IO uint32_t MODEMSTS;              /*!< [0x0014] UART Modem Status Register                                       */
+    __IO uint32_t FIFOSTS;               /*!< [0x0018] UART FIFO Status Register                                        */
+    __IO uint32_t INTSTS;                /*!< [0x001c] UART Interrupt Status Register                                   */
+    __IO uint32_t TOUT;                  /*!< [0x0020] UART Time-out Register                                           */
+    __IO uint32_t BAUD;                  /*!< [0x0024] UART Baud Rate Divider Register                                  */
+    __IO uint32_t IRDA;                  /*!< [0x0028] UART IrDA Control Register                                       */
+    __IO uint32_t ALTCTL;                /*!< [0x002c] UART Alternate Control/Status Register                           */
+    __IO uint32_t FUNCSEL;               /*!< [0x0030] UART Function Select Register                                    */
+    __IO uint32_t LINCTL;                /*!< [0x0034] UART LIN Control Register                                        */
+    __IO uint32_t LINSTS;                /*!< [0x0038] UART LIN Status Register                                         */
+    __IO uint32_t BRCOMP;                /*!< [0x003c] UART Baud Rate Compensation Register                             */
+    __IO uint32_t WKCTL;                 /*!< [0x0040] UART Wake-up Control Register                                    */
+    __IO uint32_t WKSTS;                 /*!< [0x0044] UART Wake-up Status Register                                     */
+    __IO uint32_t DWKCOMP;               /*!< [0x0048] UART Incoming Data Wake-up Compensation Register                 */
+
+} UART_T;
+
+/**
+    @addtogroup UART_CONST UART Bit Field Definition
+    Constant Definitions for UART Controller
+@{ */
+
+#define UART_DAT_DAT_Pos                 (0)                                               /*!< UART_T::DAT: DAT Position              */
+#define UART_DAT_DAT_Msk                 (0xfful << UART_DAT_DAT_Pos)                      /*!< UART_T::DAT: DAT Mask                  */
+
+#define UART_DAT_PARITY_Pos              (8)                                               /*!< UART_T::DAT: PARITY Position           */
+#define UART_DAT_PARITY_Msk              (0x1ul << UART_DAT_PARITY_Pos)                    /*!< UART_T::DAT: PARITY Mask               */
+
+#define UART_INTEN_RDAIEN_Pos            (0)                                               /*!< UART_T::INTEN: RDAIEN Position         */
+#define UART_INTEN_RDAIEN_Msk            (0x1ul << UART_INTEN_RDAIEN_Pos)                  /*!< UART_T::INTEN: RDAIEN Mask             */
+
+#define UART_INTEN_THREIEN_Pos           (1)                                               /*!< UART_T::INTEN: THREIEN Position        */
+#define UART_INTEN_THREIEN_Msk           (0x1ul << UART_INTEN_THREIEN_Pos)                 /*!< UART_T::INTEN: THREIEN Mask            */
+
+#define UART_INTEN_RLSIEN_Pos            (2)                                               /*!< UART_T::INTEN: RLSIEN Position         */
+#define UART_INTEN_RLSIEN_Msk            (0x1ul << UART_INTEN_RLSIEN_Pos)                  /*!< UART_T::INTEN: RLSIEN Mask             */
+
+#define UART_INTEN_MODEMIEN_Pos          (3)                                               /*!< UART_T::INTEN: MODEMIEN Position       */
+#define UART_INTEN_MODEMIEN_Msk          (0x1ul << UART_INTEN_MODEMIEN_Pos)                /*!< UART_T::INTEN: MODEMIEN Mask           */
+
+#define UART_INTEN_RXTOIEN_Pos           (4)                                               /*!< UART_T::INTEN: RXTOIEN Position        */
+#define UART_INTEN_RXTOIEN_Msk           (0x1ul << UART_INTEN_RXTOIEN_Pos)                 /*!< UART_T::INTEN: RXTOIEN Mask            */
+
+#define UART_INTEN_BUFERRIEN_Pos         (5)                                               /*!< UART_T::INTEN: BUFERRIEN Position      */
+#define UART_INTEN_BUFERRIEN_Msk         (0x1ul << UART_INTEN_BUFERRIEN_Pos)               /*!< UART_T::INTEN: BUFERRIEN Mask          */
+
+#define UART_INTEN_WKIEN_Pos             (6)                                               /*!< UART_T::INTEN: WKIEN Position          */
+#define UART_INTEN_WKIEN_Msk             (0x1ul << UART_INTEN_WKIEN_Pos)                   /*!< UART_T::INTEN: WKIEN Mask              */
+
+#define UART_INTEN_LINIEN_Pos            (8)                                               /*!< UART_T::INTEN: LINIEN Position         */
+#define UART_INTEN_LINIEN_Msk            (0x1ul << UART_INTEN_LINIEN_Pos)                  /*!< UART_T::INTEN: LINIEN Mask             */
+
+#define UART_INTEN_TOCNTEN_Pos           (11)                                              /*!< UART_T::INTEN: TOCNTEN Position        */
+#define UART_INTEN_TOCNTEN_Msk           (0x1ul << UART_INTEN_TOCNTEN_Pos)                 /*!< UART_T::INTEN: TOCNTEN Mask            */
+
+#define UART_INTEN_ATORTSEN_Pos          (12)                                              /*!< UART_T::INTEN: ATORTSEN Position       */
+#define UART_INTEN_ATORTSEN_Msk          (0x1ul << UART_INTEN_ATORTSEN_Pos)                /*!< UART_T::INTEN: ATORTSEN Mask           */
+
+#define UART_INTEN_ATOCTSEN_Pos          (13)                                              /*!< UART_T::INTEN: ATOCTSEN Position       */
+#define UART_INTEN_ATOCTSEN_Msk          (0x1ul << UART_INTEN_ATOCTSEN_Pos)                /*!< UART_T::INTEN: ATOCTSEN Mask           */
+
+#define UART_INTEN_TXPDMAEN_Pos          (14)                                              /*!< UART_T::INTEN: TXPDMAEN Position       */
+#define UART_INTEN_TXPDMAEN_Msk          (0x1ul << UART_INTEN_TXPDMAEN_Pos)                /*!< UART_T::INTEN: TXPDMAEN Mask           */
+
+#define UART_INTEN_RXPDMAEN_Pos          (15)                                              /*!< UART_T::INTEN: RXPDMAEN Position       */
+#define UART_INTEN_RXPDMAEN_Msk          (0x1ul << UART_INTEN_RXPDMAEN_Pos)                /*!< UART_T::INTEN: RXPDMAEN Mask           */
+
+#define UART_INTEN_SWBEIEN_Pos           (16)                                              /*!< UART_T::INTEN: SWBEIEN Position        */
+#define UART_INTEN_SWBEIEN_Msk           (0x1ul << UART_INTEN_SWBEIEN_Pos)                 /*!< UART_T::INTEN: SWBEIEN Mask            */
+
+#define UART_INTEN_ABRIEN_Pos            (18)                                              /*!< UART_T::INTEN: ABRIEN Position         */
+#define UART_INTEN_ABRIEN_Msk            (0x1ul << UART_INTEN_ABRIEN_Pos)                  /*!< UART_T::INTEN: ABRIEN Mask             */
+
+#define UART_INTEN_TXENDIEN_Pos          (22)                                              /*!< UART_T::INTEN: TXENDIEN Position       */
+#define UART_INTEN_TXENDIEN_Msk          (0x1ul << UART_INTEN_TXENDIEN_Pos)                /*!< UART_T::INTEN: TXENDIEN Mask           */
+
+#define UART_FIFO_RXRST_Pos              (1)                                               /*!< UART_T::FIFO: RXRST Position           */
+#define UART_FIFO_RXRST_Msk              (0x1ul << UART_FIFO_RXRST_Pos)                    /*!< UART_T::FIFO: RXRST Mask               */
+
+#define UART_FIFO_TXRST_Pos              (2)                                               /*!< UART_T::FIFO: TXRST Position           */
+#define UART_FIFO_TXRST_Msk              (0x1ul << UART_FIFO_TXRST_Pos)                    /*!< UART_T::FIFO: TXRST Mask               */
+
+#define UART_FIFO_RFITL_Pos              (4)                                               /*!< UART_T::FIFO: RFITL Position           */
+#define UART_FIFO_RFITL_Msk              (0xful << UART_FIFO_RFITL_Pos)                    /*!< UART_T::FIFO: RFITL Mask               */
+
+#define UART_FIFO_RXOFF_Pos              (8)                                               /*!< UART_T::FIFO: RXOFF Position           */
+#define UART_FIFO_RXOFF_Msk              (0x1ul << UART_FIFO_RXOFF_Pos)                    /*!< UART_T::FIFO: RXOFF Mask               */
+
+#define UART_FIFO_RTSTRGLV_Pos           (16)                                              /*!< UART_T::FIFO: RTSTRGLV Position        */
+#define UART_FIFO_RTSTRGLV_Msk           (0xful << UART_FIFO_RTSTRGLV_Pos)                 /*!< UART_T::FIFO: RTSTRGLV Mask            */
+
+#define UART_LINE_WLS_Pos                (0)                                               /*!< UART_T::LINE: WLS Position             */
+#define UART_LINE_WLS_Msk                (0x3ul << UART_LINE_WLS_Pos)                      /*!< UART_T::LINE: WLS Mask                 */
+
+#define UART_LINE_NSB_Pos                (2)                                               /*!< UART_T::LINE: NSB Position             */
+#define UART_LINE_NSB_Msk                (0x1ul << UART_LINE_NSB_Pos)                      /*!< UART_T::LINE: NSB Mask                 */
+
+#define UART_LINE_PBE_Pos                (3)                                               /*!< UART_T::LINE: PBE Position             */
+#define UART_LINE_PBE_Msk                (0x1ul << UART_LINE_PBE_Pos)                      /*!< UART_T::LINE: PBE Mask                 */
+
+#define UART_LINE_EPE_Pos                (4)                                               /*!< UART_T::LINE: EPE Position             */
+#define UART_LINE_EPE_Msk                (0x1ul << UART_LINE_EPE_Pos)                      /*!< UART_T::LINE: EPE Mask                 */
+
+#define UART_LINE_SPE_Pos                (5)                                               /*!< UART_T::LINE: SPE Position             */
+#define UART_LINE_SPE_Msk                (0x1ul << UART_LINE_SPE_Pos)                      /*!< UART_T::LINE: SPE Mask                 */
+
+#define UART_LINE_BCB_Pos                (6)                                               /*!< UART_T::LINE: BCB Position             */
+#define UART_LINE_BCB_Msk                (0x1ul << UART_LINE_BCB_Pos)                      /*!< UART_T::LINE: BCB Mask                 */
+
+#define UART_LINE_PSS_Pos                (7)                                               /*!< UART_T::LINE: PSS Position             */
+#define UART_LINE_PSS_Msk                (0x1ul << UART_LINE_PSS_Pos)                      /*!< UART_T::LINE: PSS Mask                 */
+
+#define UART_LINE_TXDINV_Pos             (8)                                               /*!< UART_T::LINE: TXDINV Position          */
+#define UART_LINE_TXDINV_Msk             (0x1ul << UART_LINE_TXDINV_Pos)                   /*!< UART_T::LINE: TXDINV Mask              */
+
+#define UART_LINE_RXDINV_Pos             (9)                                               /*!< UART_T::LINE: RXDINV Position          */
+#define UART_LINE_RXDINV_Msk             (0x1ul << UART_LINE_RXDINV_Pos)                   /*!< UART_T::LINE: RXDINV Mask              */
+
+#define UART_MODEM_RTS_Pos               (1)                                               /*!< UART_T::MODEM: RTS Position            */
+#define UART_MODEM_RTS_Msk               (0x1ul << UART_MODEM_RTS_Pos)                     /*!< UART_T::MODEM: RTS Mask                */
+
+#define UART_MODEM_RTSACTLV_Pos          (9)                                               /*!< UART_T::MODEM: RTSACTLV Position       */
+#define UART_MODEM_RTSACTLV_Msk          (0x1ul << UART_MODEM_RTSACTLV_Pos)                /*!< UART_T::MODEM: RTSACTLV Mask           */
+
+#define UART_MODEM_RTSSTS_Pos            (13)                                              /*!< UART_T::MODEM: RTSSTS Position         */
+#define UART_MODEM_RTSSTS_Msk            (0x1ul << UART_MODEM_RTSSTS_Pos)                  /*!< UART_T::MODEM: RTSSTS Mask             */
+
+#define UART_MODEMSTS_CTSDETF_Pos        (0)                                               /*!< UART_T::MODEMSTS: CTSDETF Position     */
+#define UART_MODEMSTS_CTSDETF_Msk        (0x1ul << UART_MODEMSTS_CTSDETF_Pos)              /*!< UART_T::MODEMSTS: CTSDETF Mask         */
+
+#define UART_MODEMSTS_CTSSTS_Pos         (4)                                               /*!< UART_T::MODEMSTS: CTSSTS Position      */
+#define UART_MODEMSTS_CTSSTS_Msk         (0x1ul << UART_MODEMSTS_CTSSTS_Pos)               /*!< UART_T::MODEMSTS: CTSSTS Mask          */
+
+#define UART_MODEMSTS_CTSACTLV_Pos       (8)                                               /*!< UART_T::MODEMSTS: CTSACTLV Position    */
+#define UART_MODEMSTS_CTSACTLV_Msk       (0x1ul << UART_MODEMSTS_CTSACTLV_Pos)             /*!< UART_T::MODEMSTS: CTSACTLV Mask        */
+
+#define UART_FIFOSTS_RXOVIF_Pos          (0)                                               /*!< UART_T::FIFOSTS: RXOVIF Position       */
+#define UART_FIFOSTS_RXOVIF_Msk          (0x1ul << UART_FIFOSTS_RXOVIF_Pos)                /*!< UART_T::FIFOSTS: RXOVIF Mask           */
+
+#define UART_FIFOSTS_ABRDIF_Pos          (1)                                               /*!< UART_T::FIFOSTS: ABRDIF Position       */
+#define UART_FIFOSTS_ABRDIF_Msk          (0x1ul << UART_FIFOSTS_ABRDIF_Pos)                /*!< UART_T::FIFOSTS: ABRDIF Mask           */
+
+#define UART_FIFOSTS_ABRDTOIF_Pos        (2)                                               /*!< UART_T::FIFOSTS: ABRDTOIF Position     */
+#define UART_FIFOSTS_ABRDTOIF_Msk        (0x1ul << UART_FIFOSTS_ABRDTOIF_Pos)              /*!< UART_T::FIFOSTS: ABRDTOIF Mask         */
+
+#define UART_FIFOSTS_ADDRDETF_Pos        (3)                                               /*!< UART_T::FIFOSTS: ADDRDETF Position     */
+#define UART_FIFOSTS_ADDRDETF_Msk        (0x1ul << UART_FIFOSTS_ADDRDETF_Pos)              /*!< UART_T::FIFOSTS: ADDRDETF Mask         */
+
+#define UART_FIFOSTS_PEF_Pos             (4)                                               /*!< UART_T::FIFOSTS: PEF Position          */
+#define UART_FIFOSTS_PEF_Msk             (0x1ul << UART_FIFOSTS_PEF_Pos)                   /*!< UART_T::FIFOSTS: PEF Mask              */
+
+#define UART_FIFOSTS_FEF_Pos             (5)                                               /*!< UART_T::FIFOSTS: FEF Position          */
+#define UART_FIFOSTS_FEF_Msk             (0x1ul << UART_FIFOSTS_FEF_Pos)                   /*!< UART_T::FIFOSTS: FEF Mask              */
+
+#define UART_FIFOSTS_BIF_Pos             (6)                                               /*!< UART_T::FIFOSTS: BIF Position          */
+#define UART_FIFOSTS_BIF_Msk             (0x1ul << UART_FIFOSTS_BIF_Pos)                   /*!< UART_T::FIFOSTS: BIF Mask              */
+
+#define UART_FIFOSTS_RXPTR_Pos           (8)                                               /*!< UART_T::FIFOSTS: RXPTR Position        */
+#define UART_FIFOSTS_RXPTR_Msk           (0x3ful << UART_FIFOSTS_RXPTR_Pos)                /*!< UART_T::FIFOSTS: RXPTR Mask            */
+
+#define UART_FIFOSTS_RXEMPTY_Pos         (14)                                              /*!< UART_T::FIFOSTS: RXEMPTY Position      */
+#define UART_FIFOSTS_RXEMPTY_Msk         (0x1ul << UART_FIFOSTS_RXEMPTY_Pos)               /*!< UART_T::FIFOSTS: RXEMPTY Mask          */
+
+#define UART_FIFOSTS_RXFULL_Pos          (15)                                              /*!< UART_T::FIFOSTS: RXFULL Position       */
+#define UART_FIFOSTS_RXFULL_Msk          (0x1ul << UART_FIFOSTS_RXFULL_Pos)                /*!< UART_T::FIFOSTS: RXFULL Mask           */
+
+#define UART_FIFOSTS_TXPTR_Pos           (16)                                              /*!< UART_T::FIFOSTS: TXPTR Position        */
+#define UART_FIFOSTS_TXPTR_Msk           (0x3ful << UART_FIFOSTS_TXPTR_Pos)                /*!< UART_T::FIFOSTS: TXPTR Mask            */
+
+#define UART_FIFOSTS_TXEMPTY_Pos         (22)                                              /*!< UART_T::FIFOSTS: TXEMPTY Position      */
+#define UART_FIFOSTS_TXEMPTY_Msk         (0x1ul << UART_FIFOSTS_TXEMPTY_Pos)               /*!< UART_T::FIFOSTS: TXEMPTY Mask          */
+
+#define UART_FIFOSTS_TXFULL_Pos          (23)                                              /*!< UART_T::FIFOSTS: TXFULL Position       */
+#define UART_FIFOSTS_TXFULL_Msk          (0x1ul << UART_FIFOSTS_TXFULL_Pos)                /*!< UART_T::FIFOSTS: TXFULL Mask           */
+
+#define UART_FIFOSTS_TXOVIF_Pos          (24)                                              /*!< UART_T::FIFOSTS: TXOVIF Position       */
+#define UART_FIFOSTS_TXOVIF_Msk          (0x1ul << UART_FIFOSTS_TXOVIF_Pos)                /*!< UART_T::FIFOSTS: TXOVIF Mask           */
+
+#define UART_FIFOSTS_TXEMPTYF_Pos        (28)                                              /*!< UART_T::FIFOSTS: TXEMPTYF Position     */
+#define UART_FIFOSTS_TXEMPTYF_Msk        (0x1ul << UART_FIFOSTS_TXEMPTYF_Pos)              /*!< UART_T::FIFOSTS: TXEMPTYF Mask         */
+
+#define UART_FIFOSTS_RXIDLE_Pos          (29)                                              /*!< UART_T::FIFOSTS: RXIDLE Position       */
+#define UART_FIFOSTS_RXIDLE_Msk          (0x1ul << UART_FIFOSTS_RXIDLE_Pos)                /*!< UART_T::FIFOSTS: RXIDLE Mask           */
+
+#define UART_FIFOSTS_TXRXACT_Pos         (31)                                              /*!< UART_T::FIFOSTS: TXRXACT Position      */
+#define UART_FIFOSTS_TXRXACT_Msk         (0x1ul << UART_FIFOSTS_TXRXACT_Pos)               /*!< UART_T::FIFOSTS: TXRXACT Mask          */
+
+#define UART_INTSTS_RDAIF_Pos            (0)                                               /*!< UART_T::INTSTS: RDAIF Position         */
+#define UART_INTSTS_RDAIF_Msk            (0x1ul << UART_INTSTS_RDAIF_Pos)                  /*!< UART_T::INTSTS: RDAIF Mask             */
+
+#define UART_INTSTS_THREIF_Pos           (1)                                               /*!< UART_T::INTSTS: THREIF Position        */
+#define UART_INTSTS_THREIF_Msk           (0x1ul << UART_INTSTS_THREIF_Pos)                 /*!< UART_T::INTSTS: THREIF Mask            */
+
+#define UART_INTSTS_RLSIF_Pos            (2)                                               /*!< UART_T::INTSTS: RLSIF Position         */
+#define UART_INTSTS_RLSIF_Msk            (0x1ul << UART_INTSTS_RLSIF_Pos)                  /*!< UART_T::INTSTS: RLSIF Mask             */
+
+#define UART_INTSTS_MODEMIF_Pos          (3)                                               /*!< UART_T::INTSTS: MODEMIF Position       */
+#define UART_INTSTS_MODEMIF_Msk          (0x1ul << UART_INTSTS_MODEMIF_Pos)                /*!< UART_T::INTSTS: MODEMIF Mask           */
+
+#define UART_INTSTS_RXTOIF_Pos           (4)                                               /*!< UART_T::INTSTS: RXTOIF Position        */
+#define UART_INTSTS_RXTOIF_Msk           (0x1ul << UART_INTSTS_RXTOIF_Pos)                 /*!< UART_T::INTSTS: RXTOIF Mask            */
+
+#define UART_INTSTS_BUFERRIF_Pos         (5)                                               /*!< UART_T::INTSTS: BUFERRIF Position      */
+#define UART_INTSTS_BUFERRIF_Msk         (0x1ul << UART_INTSTS_BUFERRIF_Pos)               /*!< UART_T::INTSTS: BUFERRIF Mask          */
+
+#define UART_INTSTS_WKIF_Pos             (6)                                               /*!< UART_T::INTSTS: WKIF Position          */
+#define UART_INTSTS_WKIF_Msk             (0x1ul << UART_INTSTS_WKIF_Pos)                   /*!< UART_T::INTSTS: WKIF Mask              */
+
+#define UART_INTSTS_LINIF_Pos            (7)                                               /*!< UART_T::INTSTS: LINIF Position         */
+#define UART_INTSTS_LINIF_Msk            (0x1ul << UART_INTSTS_LINIF_Pos)                  /*!< UART_T::INTSTS: LINIF Mask             */
+
+#define UART_INTSTS_RDAINT_Pos           (8)                                               /*!< UART_T::INTSTS: RDAINT Position        */
+#define UART_INTSTS_RDAINT_Msk           (0x1ul << UART_INTSTS_RDAINT_Pos)                 /*!< UART_T::INTSTS: RDAINT Mask            */
+
+#define UART_INTSTS_THREINT_Pos          (9)                                               /*!< UART_T::INTSTS: THREINT Position       */
+#define UART_INTSTS_THREINT_Msk          (0x1ul << UART_INTSTS_THREINT_Pos)                /*!< UART_T::INTSTS: THREINT Mask           */
+
+#define UART_INTSTS_RLSINT_Pos           (10)                                              /*!< UART_T::INTSTS: RLSINT Position        */
+#define UART_INTSTS_RLSINT_Msk           (0x1ul << UART_INTSTS_RLSINT_Pos)                 /*!< UART_T::INTSTS: RLSINT Mask            */
+
+#define UART_INTSTS_MODEMINT_Pos         (11)                                              /*!< UART_T::INTSTS: MODEMINT Position      */
+#define UART_INTSTS_MODEMINT_Msk         (0x1ul << UART_INTSTS_MODEMINT_Pos)               /*!< UART_T::INTSTS: MODEMINT Mask          */
+
+#define UART_INTSTS_RXTOINT_Pos          (12)                                              /*!< UART_T::INTSTS: RXTOINT Position       */
+#define UART_INTSTS_RXTOINT_Msk          (0x1ul << UART_INTSTS_RXTOINT_Pos)                /*!< UART_T::INTSTS: RXTOINT Mask           */
+
+#define UART_INTSTS_BUFERRINT_Pos        (13)                                              /*!< UART_T::INTSTS: BUFERRINT Position     */
+#define UART_INTSTS_BUFERRINT_Msk        (0x1ul << UART_INTSTS_BUFERRINT_Pos)              /*!< UART_T::INTSTS: BUFERRINT Mask         */
+
+#define UART_INTSTS_WKINT_Pos            (14)                                              /*!< UART_T::INTSTS: WKINT Position         */
+#define UART_INTSTS_WKINT_Msk            (0x1ul << UART_INTSTS_WKINT_Pos)                  /*!< UART_T::INTSTS: WKINT Mask             */
+
+#define UART_INTSTS_LININT_Pos           (15)                                              /*!< UART_T::INTSTS: LININT Position        */
+#define UART_INTSTS_LININT_Msk           (0x1ul << UART_INTSTS_LININT_Pos)                 /*!< UART_T::INTSTS: LININT Mask            */
+
+#define UART_INTSTS_SWBEIF_Pos           (16)                                              /*!< UART_T::INTSTS: SWBEIF Position         */
+#define UART_INTSTS_SWBEIF_Msk           (0x1ul << UART_INTSTS_SWBEIF_Pos)                 /*!< UART_T::INTSTS: SWBEIF Mask             */
+
+#define UART_INTSTS_HWRLSIF_Pos          (18)                                              /*!< UART_T::INTSTS: HWRLSIF Position       */
+#define UART_INTSTS_HWRLSIF_Msk          (0x1ul << UART_INTSTS_HWRLSIF_Pos)                /*!< UART_T::INTSTS: HWRLSIF Mask           */
+
+#define UART_INTSTS_HWMODIF_Pos          (19)                                              /*!< UART_T::INTSTS: HWMODIF Position       */
+#define UART_INTSTS_HWMODIF_Msk          (0x1ul << UART_INTSTS_HWMODIF_Pos)                /*!< UART_T::INTSTS: HWMODIF Mask           */
+
+#define UART_INTSTS_HWTOIF_Pos           (20)                                              /*!< UART_T::INTSTS: HWTOIF Position        */
+#define UART_INTSTS_HWTOIF_Msk           (0x1ul << UART_INTSTS_HWTOIF_Pos)                 /*!< UART_T::INTSTS: HWTOIF Mask            */
+
+#define UART_INTSTS_HWBUFEIF_Pos         (21)                                              /*!< UART_T::INTSTS: HWBUFEIF Position      */
+#define UART_INTSTS_HWBUFEIF_Msk         (0x1ul << UART_INTSTS_HWBUFEIF_Pos)               /*!< UART_T::INTSTS: HWBUFEIF Mask          */
+
+#define UART_INTSTS_TXENDIF_Pos          (22)                                              /*!< UART_T::INTSTS: TXENDIF Position       */
+#define UART_INTSTS_TXENDIF_Msk          (0x1ul << UART_INTSTS_TXENDIF_Pos)                /*!< UART_T::INTSTS: TXENDIF Mask           */
+
+#define UART_INTSTS_SWBEINT_Pos          (24)                                              /*!< UART_T::INTSTS: SWBEINT Position       */
+#define UART_INTSTS_SWBEINT_Msk          (0x1ul << UART_INTSTS_SWBEINT_Pos)                /*!< UART_T::INTSTS: SWBEINT Mask           */
+
+#define UART_INTSTS_HWRLSINT_Pos         (26)                                              /*!< UART_T::INTSTS: HWRLSINT Position      */
+#define UART_INTSTS_HWRLSINT_Msk         (0x1ul << UART_INTSTS_HWRLSINT_Pos)               /*!< UART_T::INTSTS: HWRLSINT Mask          */
+
+#define UART_INTSTS_HWMODINT_Pos         (27)                                              /*!< UART_T::INTSTS: HWMODINT Position      */
+#define UART_INTSTS_HWMODINT_Msk         (0x1ul << UART_INTSTS_HWMODINT_Pos)               /*!< UART_T::INTSTS: HWMODINT Mask          */
+
+#define UART_INTSTS_HWTOINT_Pos          (28)                                              /*!< UART_T::INTSTS: HWTOINT Position       */
+#define UART_INTSTS_HWTOINT_Msk          (0x1ul << UART_INTSTS_HWTOINT_Pos)                /*!< UART_T::INTSTS: HWTOINT Mask           */
+
+#define UART_INTSTS_HWBUFEINT_Pos        (29)                                              /*!< UART_T::INTSTS: HWBUFEINT Position     */
+#define UART_INTSTS_HWBUFEINT_Msk        (0x1ul << UART_INTSTS_HWBUFEINT_Pos)              /*!< UART_T::INTSTS: HWBUFEINT Mask         */
+
+#define UART_INTSTS_TXENDINT_Pos         (30)                                              /*!< UART_T::INTSTS: TXENDINT Position      */
+#define UART_INTSTS_TXENDINT_Msk         (0x1ul << UART_INTSTS_TXENDINT_Pos)               /*!< UART_T::INTSTS: TXENDINT Mask          */
+
+#define UART_INTSTS_ABRINT_Pos           (31)                                              /*!< UART_T::INTSTS: ABRINT Position        */
+#define UART_INTSTS_ABRINT_Msk           (0x1ul << UART_INTSTS_ABRINT_Pos)                 /*!< UART_T::INTSTS: ABRINT Mask            */
+
+#define UART_TOUT_TOIC_Pos               (0)                                               /*!< UART_T::TOUT: TOIC Position            */
+#define UART_TOUT_TOIC_Msk               (0xfful << UART_TOUT_TOIC_Pos)                    /*!< UART_T::TOUT: TOIC Mask                */
+
+#define UART_TOUT_DLY_Pos                (8)                                               /*!< UART_T::TOUT: DLY Position             */
+#define UART_TOUT_DLY_Msk                (0xfful << UART_TOUT_DLY_Pos)                     /*!< UART_T::TOUT: DLY Mask                 */
+
+#define UART_BAUD_BRD_Pos                (0)                                               /*!< UART_T::BAUD: BRD Position             */
+#define UART_BAUD_BRD_Msk                (0xfffful << UART_BAUD_BRD_Pos)                   /*!< UART_T::BAUD: BRD Mask                 */
+
+#define UART_BAUD_EDIVM1_Pos             (24)                                              /*!< UART_T::BAUD: EDIVM1 Position          */
+#define UART_BAUD_EDIVM1_Msk             (0xful << UART_BAUD_EDIVM1_Pos)                   /*!< UART_T::BAUD: EDIVM1 Mask              */
+
+#define UART_BAUD_BAUDM0_Pos             (28)                                              /*!< UART_T::BAUD: BAUDM0 Position          */
+#define UART_BAUD_BAUDM0_Msk             (0x1ul << UART_BAUD_BAUDM0_Pos)                   /*!< UART_T::BAUD: BAUDM0 Mask              */
+
+#define UART_BAUD_BAUDM1_Pos             (29)                                              /*!< UART_T::BAUD: BAUDM1 Position          */
+#define UART_BAUD_BAUDM1_Msk             (0x1ul << UART_BAUD_BAUDM1_Pos)                   /*!< UART_T::BAUD: BAUDM1 Mask              */
+
+#define UART_IRDA_TXEN_Pos               (1)                                               /*!< UART_T::IRDA: TXEN Position            */
+#define UART_IRDA_TXEN_Msk               (0x1ul << UART_IRDA_TXEN_Pos)                     /*!< UART_T::IRDA: TXEN Mask                */
+
+#define UART_IRDA_TXINV_Pos              (5)                                               /*!< UART_T::IRDA: TXINV Position           */
+#define UART_IRDA_TXINV_Msk              (0x1ul << UART_IRDA_TXINV_Pos)                    /*!< UART_T::IRDA: TXINV Mask               */
+
+#define UART_IRDA_RXINV_Pos              (6)                                               /*!< UART_T::IRDA: RXINV Position           */
+#define UART_IRDA_RXINV_Msk              (0x1ul << UART_IRDA_RXINV_Pos)                    /*!< UART_T::IRDA: RXINV Mask               */
+
+#define UART_ALTCTL_BRKFL_Pos            (0)                                               /*!< UART_T::ALTCTL: BRKFL Position         */
+#define UART_ALTCTL_BRKFL_Msk            (0xful << UART_ALTCTL_BRKFL_Pos)                  /*!< UART_T::ALTCTL: BRKFL Mask             */
+
+#define UART_ALTCTL_LINRXEN_Pos          (6)                                               /*!< UART_T::ALTCTL: LINRXEN Position       */
+#define UART_ALTCTL_LINRXEN_Msk          (0x1ul << UART_ALTCTL_LINRXEN_Pos)                /*!< UART_T::ALTCTL: LINRXEN Mask           */
+
+#define UART_ALTCTL_LINTXEN_Pos          (7)                                               /*!< UART_T::ALTCTL: LINTXEN Position       */
+#define UART_ALTCTL_LINTXEN_Msk          (0x1ul << UART_ALTCTL_LINTXEN_Pos)                /*!< UART_T::ALTCTL: LINTXEN Mask           */
+
+#define UART_ALTCTL_RS485NMM_Pos         (8)                                               /*!< UART_T::ALTCTL: RS485NMM Position      */
+#define UART_ALTCTL_RS485NMM_Msk         (0x1ul << UART_ALTCTL_RS485NMM_Pos)               /*!< UART_T::ALTCTL: RS485NMM Mask          */
+
+#define UART_ALTCTL_RS485AAD_Pos         (9)                                               /*!< UART_T::ALTCTL: RS485AAD Position      */
+#define UART_ALTCTL_RS485AAD_Msk         (0x1ul << UART_ALTCTL_RS485AAD_Pos)               /*!< UART_T::ALTCTL: RS485AAD Mask          */
+
+#define UART_ALTCTL_RS485AUD_Pos         (10)                                              /*!< UART_T::ALTCTL: RS485AUD Position      */
+#define UART_ALTCTL_RS485AUD_Msk         (0x1ul << UART_ALTCTL_RS485AUD_Pos)               /*!< UART_T::ALTCTL: RS485AUD Mask          */
+
+#define UART_ALTCTL_ADDRDEN_Pos          (15)                                              /*!< UART_T::ALTCTL: ADDRDEN Position       */
+#define UART_ALTCTL_ADDRDEN_Msk          (0x1ul << UART_ALTCTL_ADDRDEN_Pos)                /*!< UART_T::ALTCTL: ADDRDEN Mask           */
+
+#define UART_ALTCTL_ABRIF_Pos            (17)                                              /*!< UART_T::ALTCTL: ABRIF Position         */
+#define UART_ALTCTL_ABRIF_Msk            (0x1ul << UART_ALTCTL_ABRIF_Pos)                  /*!< UART_T::ALTCTL: ABRIF Mask             */
+
+#define UART_ALTCTL_ABRDEN_Pos           (18)                                              /*!< UART_T::ALTCTL: ABRDEN Position        */
+#define UART_ALTCTL_ABRDEN_Msk           (0x1ul << UART_ALTCTL_ABRDEN_Pos)                 /*!< UART_T::ALTCTL: ABRDEN Mask            */
+
+#define UART_ALTCTL_ABRDBITS_Pos         (19)                                              /*!< UART_T::ALTCTL: ABRDBITS Position      */
+#define UART_ALTCTL_ABRDBITS_Msk         (0x3ul << UART_ALTCTL_ABRDBITS_Pos)               /*!< UART_T::ALTCTL: ABRDBITS Mask          */
+
+#define UART_ALTCTL_ADDRMV_Pos           (24)                                              /*!< UART_T::ALTCTL: ADDRMV Position        */
+#define UART_ALTCTL_ADDRMV_Msk           (0xfful << UART_ALTCTL_ADDRMV_Pos)                /*!< UART_T::ALTCTL: ADDRMV Mask            */
+
+#define UART_FUNCSEL_FUNCSEL_Pos         (0)                                               /*!< UART_T::FUNCSEL: FUNCSEL Position      */
+#define UART_FUNCSEL_FUNCSEL_Msk         (0x7ul << UART_FUNCSEL_FUNCSEL_Pos)               /*!< UART_T::FUNCSEL: FUNCSEL Mask          */
+
+#define UART_FUNCSEL_TXRXDIS_Pos         (3)                                               /*!< UART_T::FUNCSEL: TXRXDIS Position      */
+#define UART_FUNCSEL_TXRXDIS_Msk         (0x1ul << UART_FUNCSEL_TXRXDIS_Pos)               /*!< UART_T::FUNCSEL: TXRXDIS Mask          */
+
+#define UART_FUNCSEL_DGE_Pos             (6)                                               /*!< UART_T::FUNCSEL: DGE Position          */
+#define UART_FUNCSEL_DGE_Msk             (0x1ul << UART_FUNCSEL_DGE_Pos)                   /*!< UART_T::FUNCSEL: DGE Mask              */
+
+#define UART_LINCTL_SLVEN_Pos            (0)                                               /*!< UART_T::LINCTL: SLVEN Position         */
+#define UART_LINCTL_SLVEN_Msk            (0x1ul << UART_LINCTL_SLVEN_Pos)                  /*!< UART_T::LINCTL: SLVEN Mask             */
+
+#define UART_LINCTL_SLVHDEN_Pos          (1)                                               /*!< UART_T::LINCTL: SLVHDEN Position       */
+#define UART_LINCTL_SLVHDEN_Msk          (0x1ul << UART_LINCTL_SLVHDEN_Pos)                /*!< UART_T::LINCTL: SLVHDEN Mask           */
+
+#define UART_LINCTL_SLVAREN_Pos          (2)                                               /*!< UART_T::LINCTL: SLVAREN Position       */
+#define UART_LINCTL_SLVAREN_Msk          (0x1ul << UART_LINCTL_SLVAREN_Pos)                /*!< UART_T::LINCTL: SLVAREN Mask           */
+
+#define UART_LINCTL_SLVDUEN_Pos          (3)                                               /*!< UART_T::LINCTL: SLVDUEN Position       */
+#define UART_LINCTL_SLVDUEN_Msk          (0x1ul << UART_LINCTL_SLVDUEN_Pos)                /*!< UART_T::LINCTL: SLVDUEN Mask           */
+
+#define UART_LINCTL_MUTE_Pos             (4)                                               /*!< UART_T::LINCTL: MUTE Position          */
+#define UART_LINCTL_MUTE_Msk             (0x1ul << UART_LINCTL_MUTE_Pos)                   /*!< UART_T::LINCTL: MUTE Mask              */
+
+#define UART_LINCTL_SENDH_Pos            (8)                                               /*!< UART_T::LINCTL: SENDH Position         */
+#define UART_LINCTL_SENDH_Msk            (0x1ul << UART_LINCTL_SENDH_Pos)                  /*!< UART_T::LINCTL: SENDH Mask             */
+
+#define UART_LINCTL_IDPEN_Pos            (9)                                               /*!< UART_T::LINCTL: IDPEN Position         */
+#define UART_LINCTL_IDPEN_Msk            (0x1ul << UART_LINCTL_IDPEN_Pos)                  /*!< UART_T::LINCTL: IDPEN Mask             */
+
+#define UART_LINCTL_BRKDETEN_Pos         (10)                                              /*!< UART_T::LINCTL: BRKDETEN Position      */
+#define UART_LINCTL_BRKDETEN_Msk         (0x1ul << UART_LINCTL_BRKDETEN_Pos)               /*!< UART_T::LINCTL: BRKDETEN Mask          */
+
+#define UART_LINCTL_LINRXOFF_Pos         (11)                                              /*!< UART_T::LINCTL: LINRXOFF Position      */
+#define UART_LINCTL_LINRXOFF_Msk         (0x1ul << UART_LINCTL_LINRXOFF_Pos)               /*!< UART_T::LINCTL: LINRXOFF Mask          */
+
+#define UART_LINCTL_BITERREN_Pos         (12)                                              /*!< UART_T::LINCTL: BITERREN Position      */
+#define UART_LINCTL_BITERREN_Msk         (0x1ul << UART_LINCTL_BITERREN_Pos)               /*!< UART_T::LINCTL: BITERREN Mask          */
+
+#define UART_LINCTL_BRKFL_Pos            (16)                                              /*!< UART_T::LINCTL: BRKFL Position         */
+#define UART_LINCTL_BRKFL_Msk            (0xful << UART_LINCTL_BRKFL_Pos)                  /*!< UART_T::LINCTL: BRKFL Mask             */
+
+#define UART_LINCTL_BSL_Pos              (20)                                              /*!< UART_T::LINCTL: BSL Position           */
+#define UART_LINCTL_BSL_Msk              (0x3ul << UART_LINCTL_BSL_Pos)                    /*!< UART_T::LINCTL: BSL Mask               */
+
+#define UART_LINCTL_HSEL_Pos             (22)                                              /*!< UART_T::LINCTL: HSEL Position          */
+#define UART_LINCTL_HSEL_Msk             (0x3ul << UART_LINCTL_HSEL_Pos)                   /*!< UART_T::LINCTL: HSEL Mask              */
+
+#define UART_LINCTL_PID_Pos              (24)                                              /*!< UART_T::LINCTL: PID Position           */
+#define UART_LINCTL_PID_Msk              (0xfful << UART_LINCTL_PID_Pos)                   /*!< UART_T::LINCTL: PID Mask               */
+
+#define UART_LINSTS_SLVHDETF_Pos         (0)                                               /*!< UART_T::LINSTS: SLVHDETF Position      */
+#define UART_LINSTS_SLVHDETF_Msk         (0x1ul << UART_LINSTS_SLVHDETF_Pos)               /*!< UART_T::LINSTS: SLVHDETF Mask          */
+
+#define UART_LINSTS_SLVHEF_Pos           (1)                                               /*!< UART_T::LINSTS: SLVHEF Position        */
+#define UART_LINSTS_SLVHEF_Msk           (0x1ul << UART_LINSTS_SLVHEF_Pos)                 /*!< UART_T::LINSTS: SLVHEF Mask            */
+
+#define UART_LINSTS_SLVIDPEF_Pos         (2)                                               /*!< UART_T::LINSTS: SLVIDPEF Position      */
+#define UART_LINSTS_SLVIDPEF_Msk         (0x1ul << UART_LINSTS_SLVIDPEF_Pos)               /*!< UART_T::LINSTS: SLVIDPEF Mask          */
+
+#define UART_LINSTS_SLVSYNCF_Pos         (3)                                               /*!< UART_T::LINSTS: SLVSYNCF Position      */
+#define UART_LINSTS_SLVSYNCF_Msk         (0x1ul << UART_LINSTS_SLVSYNCF_Pos)               /*!< UART_T::LINSTS: SLVSYNCF Mask          */
+
+#define UART_LINSTS_BRKDETF_Pos          (8)                                               /*!< UART_T::LINSTS: BRKDETF Position       */
+#define UART_LINSTS_BRKDETF_Msk          (0x1ul << UART_LINSTS_BRKDETF_Pos)                /*!< UART_T::LINSTS: BRKDETF Mask           */
+
+#define UART_LINSTS_BITEF_Pos            (9)                                               /*!< UART_T::LINSTS: BITEF Position         */
+#define UART_LINSTS_BITEF_Msk            (0x1ul << UART_LINSTS_BITEF_Pos)                  /*!< UART_T::LINSTS: BITEF Mask             */
+
+#define UART_BRCOMP_BRCOMP_Pos           (0)                                               /*!< UART_T::BRCOMP: BRCOMP Position        */
+#define UART_BRCOMP_BRCOMP_Msk           (0x1fful << UART_BRCOMP_BRCOMP_Pos)               /*!< UART_T::BRCOMP: BRCOMP Mask            */
+
+#define UART_BRCOMP_BRCOMPDEC_Pos        (31)                                              /*!< UART_T::BRCOMP: BRCOMPDEC Position     */
+#define UART_BRCOMP_BRCOMPDEC_Msk        (0x1ul << UART_BRCOMP_BRCOMPDEC_Pos)              /*!< UART_T::BRCOMP: BRCOMPDEC Mask         */
+
+#define UART_WKCTL_WKCTSEN_Pos           (0)                                               /*!< UART_T::WKCTL: WKCTSEN Position        */
+#define UART_WKCTL_WKCTSEN_Msk           (0x1ul << UART_WKCTL_WKCTSEN_Pos)                 /*!< UART_T::WKCTL: WKCTSEN Mask            */
+
+#define UART_WKCTL_WKDATEN_Pos           (1)                                               /*!< UART_T::WKCTL: WKDATEN Position        */
+#define UART_WKCTL_WKDATEN_Msk           (0x1ul << UART_WKCTL_WKDATEN_Pos)                 /*!< UART_T::WKCTL: WKDATEN Mask            */
+
+#define UART_WKCTL_WKRFRTEN_Pos          (2)                                               /*!< UART_T::WKCTL: WKRFRTEN Position       */
+#define UART_WKCTL_WKRFRTEN_Msk          (0x1ul << UART_WKCTL_WKRFRTEN_Pos)                /*!< UART_T::WKCTL: WKRFRTEN Mask           */
+
+#define UART_WKCTL_WKRS485EN_Pos         (3)                                               /*!< UART_T::WKCTL: WKRS485EN Position      */
+#define UART_WKCTL_WKRS485EN_Msk         (0x1ul << UART_WKCTL_WKRS485EN_Pos)               /*!< UART_T::WKCTL: WKRS485EN Mask          */
+
+#define UART_WKCTL_WKTOUTEN_Pos          (4)                                               /*!< UART_T::WKCTL: WKTOUTEN Position       */
+#define UART_WKCTL_WKTOUTEN_Msk          (0x1ul << UART_WKCTL_WKTOUTEN_Pos)                /*!< UART_T::WKCTL: WKTOUTEN Mask           */
+
+#define UART_WKSTS_CTSWKF_Pos            (0)                                               /*!< UART_T::WKSTS: CTSWKF Position         */
+#define UART_WKSTS_CTSWKF_Msk            (0x1ul << UART_WKSTS_CTSWKF_Pos)                  /*!< UART_T::WKSTS: CTSWKF Mask             */
+
+#define UART_WKSTS_DATWKF_Pos            (1)                                               /*!< UART_T::WKSTS: DATWKF Position         */
+#define UART_WKSTS_DATWKF_Msk            (0x1ul << UART_WKSTS_DATWKF_Pos)                  /*!< UART_T::WKSTS: DATWKF Mask             */
+
+#define UART_WKSTS_RFRTWKF_Pos           (2)                                               /*!< UART_T::WKSTS: RFRTWKF Position        */
+#define UART_WKSTS_RFRTWKF_Msk           (0x1ul << UART_WKSTS_RFRTWKF_Pos)                 /*!< UART_T::WKSTS: RFRTWKF Mask            */
+
+#define UART_WKSTS_RS485WKF_Pos          (3)                                               /*!< UART_T::WKSTS: RS485WKF Position       */
+#define UART_WKSTS_RS485WKF_Msk          (0x1ul << UART_WKSTS_RS485WKF_Pos)                /*!< UART_T::WKSTS: RS485WKF Mask           */
+
+#define UART_WKSTS_TOUTWKF_Pos           (4)                                               /*!< UART_T::WKSTS: TOUTWKF Position        */
+#define UART_WKSTS_TOUTWKF_Msk           (0x1ul << UART_WKSTS_TOUTWKF_Pos)                 /*!< UART_T::WKSTS: TOUTWKF Mask            */
+
+#define UART_DWKCOMP_STCOMP_Pos          (0)                                               /*!< UART_T::DWKCOMP: STCOMP Position       */
+#define UART_DWKCOMP_STCOMP_Msk          (0xfffful << UART_DWKCOMP_STCOMP_Pos)             /*!< UART_T::DWKCOMP: STCOMP Mask           */
+
+/** @} UART_CONST */
+/** @} end of UART register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __UART_REG_H__ */

--- a/hal/m258ke/nuvoton/ui2c_reg.h
+++ b/hal/m258ke/nuvoton/ui2c_reg.h
@@ -1,0 +1,584 @@
+/**************************************************************************//**
+ * @file     ui2c_reg.h
+ * @version  V1.00
+ * @brief    UI2C register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __UI2C_REG_H__
+#define __UI2C_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup UI2C I2C Mode of USCI Controller (UI2C)
+    Memory Mapped Structure for UI2C Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var UI2C_T::CTL
+     * Offset: 0x00  USCI Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |FUNMODE   |Function Mode
+     * |        |          |This bit field selects the protocol for this USCI controller
+     * |        |          |Selecting a protocol that is not available or a reserved combination disables the USCI
+     * |        |          |When switching between two protocols, the USCI has to be disabled before selecting a new protocol
+     * |        |          |Simultaneously, the USCI will be reset when user write 000 to FUNMODE.
+     * |        |          |000 = The USCI is disabled. All protocol related state machines are set to idle state.
+     * |        |          |001 = The SPI protocol is selected.
+     * |        |          |010 = The UART protocol is selected.
+     * |        |          |100 = The I2C protocol is selected.
+     * |        |          |Note: Other bit combinations are reserved.
+     * @var UI2C_T::BRGEN
+     * Offset: 0x08  USCI Baud Rate Generator Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RCLKSEL   |Reference Clock Source Selection
+     * |        |          |This bit selects the source signal of reference clock (fREF_CLK).
+     * |        |          |0 = Peripheral device clock fPCLK.
+     * |        |          |1 = Reserved.
+     * |[1]     |PTCLKSEL  |Protocol Clock Source Selection
+     * |        |          |This bit selects the source signal of protocol clock (fPROT_CLK).
+     * |        |          |0 = Reference clock fREF_CLK.
+     * |        |          |1 = fREF_CLK2 (its frequency is half of fREF_CLK).
+     * |[3:2]   |SPCLKSEL  |Sample Clock Source Selection
+     * |        |          |This bit field used for the clock source selection of a sample clock (fSAMP_CLK) for the protocol processor.
+     * |        |          |00 = fSAMP_CLK = fDIV_CLK.
+     * |        |          |01 = fSAMP_CLK = fPROT_CLK.
+     * |        |          |10 = fSAMP_CLK = fSCLK.
+     * |        |          |11 = fSAMP_CLK = fREF_CLK.
+     * |[4]     |TMCNTEN   |Time Measurement Counter Enable Bit
+     * |        |          |This bit enables the 10-bit timing measurement counter.
+     * |        |          |0 = Time measurement counter is Disabled.
+     * |        |          |1 = Time measurement counter is Enabled.
+     * |[5]     |TMCNTSRC  |Time Measurement Counter Clock Source Selection
+     * |        |          |0 = Time measurement counter with fPROT_CLK.
+     * |        |          |1 = Time measurement counter with fDIV_CLK.
+     * |[9:8]   |PDSCNT    |Pre-divider for Sample Counter
+     * |        |          |This bit field defines the divide ratio of the clock division from sample clock fSAMP_CLK
+     * |        |          |The divided frequency fPDS_CNT = fSAMP_CLK / (PDSCNT+1).
+     * |[14:10] |DSCNT     |Denominator for Sample Counter
+     * |        |          |This bit field defines the divide ratio of the sample clock fSAMP_CLK.
+     * |        |          |The divided frequency fDS_CNT = fPDS_CNT / (DSCNT+1).
+     * |        |          |Note: The maximum value of DSCNT is 0xF on UART mode and suggest to set over 4 to confirm the receiver data is sampled in right value
+     * |[25:16] |CLKDIV    |Clock Divider
+     * |        |          |This bit field defines the ratio between the protocol clock frequency fPROT_CLK and the clock divider frequency fDIV_CLK (fDIV_CLK = fPROT_CLK / (CLKDIV+1) ).
+     * |        |          |Note: In UART function, it can be updated by hardware in the 4th falling edge of the input data 0x55 when the auto baud rate function (ABREN(UI2C_PROTCTL[6])) is enabled
+     * |        |          |The revised value is the average bit time between bit 5 and bit 6
+     * |        |          |The user can use revised CLKDIV and new BRDETITV (UI2C_PROTCTL[24:16]) to calculate the precise baud rate.
+     * @var UI2C_T::LINECTL
+     * Offset: 0x2C  USCI Line Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |LSB       |LSB First Transmission Selection
+     * |        |          |0 = The MSB, which bit of transmit/receive data buffer depends on the setting of DWIDTH, is transmitted/received first.
+     * |        |          |1 = The LSB, the bit 0 of data buffer, will be transmitted/received first.
+     * |[11:8]  |DWIDTH    |Word Length of Transmission
+     * |        |          |This bit field defines the data word length (amount of bits) for reception and transmission
+     * |        |          |The data word is always right-aligned in the data buffer
+     * |        |          |USCI support word length from 4 to 16 bits.
+     * |        |          |0x0: The data word contains 16 bits located at bit positions [15:0].
+     * |        |          |0x1: Reserved.
+     * |        |          |0x2: Reserved.
+     * |        |          |0x3: Reserved.
+     * |        |          |0x4: The data word contains 4 bits located at bit positions [3:0].
+     * |        |          |0x5: The data word contains 5 bits located at bit positions [4:0].
+     * |        |          |...
+     * |        |          |0xF: The data word contains 15 bits located at bit positions [14:0].
+     * |        |          |Note: In UART protocol, the length can be configured as 6~13 bits
+     * |        |          |And in I2C protocol, the length fixed as 8 bits.
+     * @var UI2C_T::TXDAT
+     * Offset: 0x30  USCI Transmit Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |TXDAT     |Transmit Data
+     * |        |          |Software can use this bit field to write 16-bit transmit data for transmission.
+     * @var UI2C_T::RXDAT
+     * Offset: 0x34  USCI Receive Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |RXDAT     |Received Data
+     * |        |          |This bit field monitors the received data which stored in receive data buffer.
+     * |        |          |Note 1: In I2C protocol, RXDAT[12:8] indicate the different transmission conditions which defined in I2C.
+     * |        |          |Note 2: In UART protocol, RXDAT[15:13] indicate the same frame status of BREAK, FRMERR and PARITYERR (UI2C_PROTSTS[7:5]).
+     * @var UI2C_T::DEVADDR0
+     * Offset: 0x44  USCI Device Address Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9:0]   |DEVADDR   |Device   Address
+     * |        |          |In I2C   protocol, this bit field contains the programmed slave address
+     * |        |          |If the first   received address byte are 1111 0AAXB, the AA bits are compared to   the bits DEVADDR[9:8] to check for address match, where the X is R/W bit
+     * |        |          |Then   the second address byte is also compared to DEVADDR[7:0].
+     * |        |          |Note 1: The DEVADDR [9:7] must be set 3'b000 when I2C operating in   7-bit address mode.
+     * |        |          |Note 2: When software set 10'h000, the address can not be used.
+     * @var UI2C_T::DEVADDR1
+     * Offset: 0x48  USCI Device Address Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9:0]   |DEVADDR   |Device   Address
+     * |        |          |In I2C   protocol, this bit field contains the programmed slave address
+     * |        |          |If the first   received address byte are 1111 0AAXB, the AA bits are compared to   the bits DEVADDR[9:8] to check for address match, where the X is R/W bit
+     * |        |          |Then   the second address byte is also compared to DEVADDR[7:0].
+     * |        |          |Note 1: The DEVADDR [9:7] must be set 3'b000 when I2C operating in   7-bit address mode.
+     * |        |          |Note 2: When software set 10'h000, the address can not be used.
+     * @var UI2C_T::ADDRMSK0
+     * Offset: 0x4C  USCI Device Address Mask Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9:0]   |ADDRMSK   |USCI Device Address Mask
+     * |        |          |0 = Mask Disabled (the received corresponding register bit should be exact the same as address register.).
+     * |        |          |1 = Mask Enabled (the received corresponding address bit is don't care.).
+     * |        |          |USCI support multiple address recognition with two address mask register
+     * |        |          |When the bit in the address mask register is set to one, it means the received corresponding address bit is don't-care
+     * |        |          |If the bit is set to zero, that means the received corresponding register bit should be exact the same as address register.
+     * |        |          |Note: The wake-up function can not use address mask.
+     * @var UI2C_T::ADDRMSK1
+     * Offset: 0x50  USCI Device Address Mask Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[9:0]   |ADDRMSK   |USCI Device Address Mask
+     * |        |          |0 = Mask Disabled (the received corresponding register bit should be exact the same as address register.).
+     * |        |          |1 = Mask Enabled (the received corresponding address bit is don't care.).
+     * |        |          |USCI support multiple address recognition with two address mask register
+     * |        |          |When the bit in the address mask register is set to one, it means the received corresponding address bit is don't-care
+     * |        |          |If the bit is set to zero, that means the received corresponding register bit should be exact the same as address register.
+     * |        |          |Note: The wake-up function can not use address mask.
+     * @var UI2C_T::WKCTL
+     * Offset: 0x54  USCI Wake-up Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKEN      |Wake-up Enable Bit
+     * |        |          |0 = Wake-up function Disabled.
+     * |        |          |1 = Wake-up function Enabled.
+     * |[1]     |WKADDREN  |Wake-up Address Match Enable Bit
+     * |        |          |0 = The chip is woken up according data toggle.
+     * |        |          |1 = The chip is woken up according address match.
+     * @var UI2C_T::WKSTS
+     * Offset: 0x58  USCI Wake-up Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKF       |Wake-up Flag
+     * |        |          |When chip is woken up from Power-down mode, this bit is set to 1
+     * |        |          |Software can write 1 to clear this bit.
+     * @var UI2C_T::PROTCTL
+     * Offset: 0x5C  USCI Protocol Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |GCFUNC    |General Call Function
+     * |        |          |0 = General Call Function Disabled.
+     * |        |          |1 = General Call Function Enabled.
+     * |[1]     |AA        |Assert Acknowledge Control
+     * |        |          |When AA =1 prior to address or data received, an acknowledged (low level to SDA) will be returned during the acknowledge clock pulse on the SCL line when 1.) A slave is acknowledging the address sent from master, 2.) The receiver devices are acknowledging the data sent by transmitter
+     * |        |          |When AA=0 prior to address or data received, a Not acknowledged (high level to SDA) will be returned during the acknowledge clock pulse on the SCL line.
+     * |[2]     |STO       |I2C STOP Control
+     * |        |          |In Master mode, setting STO to transmit a STOP condition to bus then I2C hardware will check the bus condition if a STOP condition is detected this bit will be cleared by hardware automatically
+     * |        |          |In a slave mode, setting STO resets I2C hardware to the defined "not addressed" slave mode when bus error (UI2C_PROTSTS.ERRIF = 1).
+     * |[3]     |STA       |I2C START Control
+     * |        |          |Setting STA to logic 1 to enter Master mode, the I2C hardware sends a START or repeat START condition to bus when the bus is free.
+     * |[4]     |ADDR10EN  |Address 10-bit Function Enable Bit
+     * |        |          |0 = Address match 10 bit function is disabled.
+     * |        |          |1 = Address match 10 bit function is enabled.
+     * |[5]     |PTRG      |I2C Protocol Trigger (Write Only)
+     * |        |          |When a new state is present in the UI2C_PROTSTS register, if the related interrupt enable bits are set, the I2C interrupt is requested
+     * |        |          |It must write one by software to this bit after the related interrupt flags are set to 1 and the I2C protocol function will go ahead until the STOP is active or the PROTEN is disabled.
+     * |        |          |0 = I2C's stretch disabled and the I2C protocol function will go ahead.
+     * |        |          |1 = I2C's stretch active.
+     * |[8]     |SCLOUTEN  |SCL Output Enable Bit
+     * |        |          |This bit enables monitor pulling SCL to low
+     * |        |          |This monitor will pull SCL to low until it has had time to respond to an I2C interrupt.
+     * |        |          |0 = SCL output will be forced high due to open drain mechanism.
+     * |        |          |1 = I2C module may act as a slave peripheral just like in normal operation, the I2C holds the clock line low until it has had time to clear I2C interrupt.
+     * |[9]     |MONEN     |Monitor Mode Enable Bit
+     * |        |          |This bit enables monitor mode
+     * |        |          |In monitor mode the SDA output will be put in high impedance mode
+     * |        |          |This prevents the I2C module from outputting data of any kind (including ACK) onto the I2C data bus.
+     * |        |          |0 = The monitor mode is disabled.
+     * |        |          |1 = The monitor mode is enabled.
+     * |        |          |Note: Depending on the state of the SCLOUTEN bit, the SCL output may be also forced high, preventing the module from having control over the I2C clock line.
+     * |[25:16] |TOCNT     |Time-out Clock Cycle
+     * |        |          |This bit field indicates how many clock cycle selected by TMCNTSRC (UI2C_BRGEN [5]) when each interrupt flags are clear
+     * |        |          |The time-out is enable when TOCNT bigger than 0.
+     * |        |          |Note: The TMCNTSRC (UI2C_BRGEN [5]) must be set zero on I2C mode.
+     * |[31]    |PROTEN    |I2C Protocol Enable Bit
+     * |        |          |0 = I2C Protocol disable.
+     * |        |          |1 = I2C Protocol enable.
+     * @var UI2C_T::PROTIEN
+     * Offset: 0x60  USCI Protocol Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |TOIEN     |Time-out Interrupt Enable Control
+     * |        |          |In I2C protocol, this bit enables the interrupt generation in case of a time-out event.
+     * |        |          |0 = The time-out interrupt is disabled.
+     * |        |          |1 = The time-out interrupt is enabled.
+     * |[1]     |STARIEN   |Start Condition Received Interrupt Enable Control
+     * |        |          |This bit enables the generation of a protocol interrupt if a start condition is detected.
+     * |        |          |0 = The start condition interrupt is disabled.
+     * |        |          |1 = The start condition interrupt is enabled.
+     * |[2]     |STORIEN   |Stop Condition Received Interrupt Enable Control
+     * |        |          |This bit enables the generation of a protocol interrupt if a stop condition is detected.
+     * |        |          |0 = The stop condition interrupt is disabled.
+     * |        |          |1 = The stop condition interrupt is enabled.
+     * |[3]     |NACKIEN   |Non - Acknowledge Interrupt Enable Control
+     * |        |          |This bit enables the generation of a protocol interrupt if a non - acknowledge is detected by a master.
+     * |        |          |0 = The non - acknowledge interrupt is disabled.
+     * |        |          |1 = The non - acknowledge interrupt is enabled.
+     * |[4]     |ARBLOIEN  |Arbitration Lost Interrupt Enable Control
+     * |        |          |This bit enables the generation of a protocol interrupt if an arbitration lost event is detected.
+     * |        |          |0 = The arbitration lost interrupt is disabled.
+     * |        |          |1 = The arbitration lost interrupt is enabled.
+     * |[5]     |ERRIEN    |Error Interrupt Enable Control
+     * |        |          |This bit enables the generation of a protocol interrupt if an I2C error condition is detected (indicated by ERR (UI2C_PROTSTS [16])).
+     * |        |          |0 = The error interrupt is disabled.
+     * |        |          |1 = The error interrupt is enabled.
+     * |[6]     |ACKIEN    |Acknowledge Interrupt Enable Control
+     * |        |          |This bit enables the generation of a protocol interrupt if an acknowledge is detected by a master.
+     * |        |          |0 = The acknowledge interrupt is disabled.
+     * |        |          |1 = The acknowledge interrupt is enabled.
+     * @var UI2C_T::PROTSTS
+     * Offset: 0x64  USCI Protocol Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[5]     |TOIF      |Time-out Interrupt Flag
+     * |        |          |0 = A time-out interrupt status has not occurred.
+     * |        |          |1 = A time-out interrupt status has occurred.
+     * |        |          |Note: It is cleared by software writing one into this bit
+     * |[6]     |ONBUSY    |On Bus Busy
+     * |        |          |Indicates that a communication is in progress on the bus
+     * |        |          |It is set by hardware when a START condition is detected
+     * |        |          |It is cleared by hardware when a STOP condition is detected
+     * |        |          |0 = The bus is IDLE (both SCLK and SDA High).
+     * |        |          |1 = The bus is busy.
+     * |[8]     |STARIF    |Start Condition Received Interrupt Flag
+     * |        |          |This bit indicates that a start condition or repeated start condition has been detected on master mode
+     * |        |          |However, this bit also indicates that a repeated start condition has been detected on slave mode.
+     * |        |          |A protocol interrupt can be generated if UI2C_PROTCTL.STARIEN = 1.
+     * |        |          |0 = A start condition has not yet been detected.
+     * |        |          |1 = A start condition has been detected.
+     * |        |          |It is cleared by software writing one into this bit
+     * |[9]     |STORIF    |Stop Condition Received Interrupt Flag
+     * |        |          |This bit indicates that a stop condition has been detected on the I2C bus lines
+     * |        |          |A protocol interrupt can be generated if UI2C_PROTCTL.STORIEN = 1.
+     * |        |          |0 = A stop condition has not yet been detected.
+     * |        |          |1 = A stop condition has been detected.
+     * |        |          |It is cleared by software writing one into this bit
+     * |        |          |Note: This bit is set when slave RX mode.
+     * |[10]    |NACKIF    |Non - Acknowledge Received Interrupt Flag
+     * |        |          |This bit indicates that a non - acknowledge has been received in master mode
+     * |        |          |A protocol interrupt can be generated if UI2C_PROTCTL.NACKIEN = 1.
+     * |        |          |0 = A non - acknowledge has not been received.
+     * |        |          |1 = A non - acknowledge has been received.
+     * |        |          |It is cleared by software writing one into this bit
+     * |[11]    |ARBLOIF   |Arbitration Lost Interrupt Flag
+     * |        |          |This bit indicates that an arbitration has been lost
+     * |        |          |A protocol interrupt can be generated if UI2C_PROTCTL.ARBLOIEN = 1.
+     * |        |          |0 = An arbitration has not been lost.
+     * |        |          |1 = An arbitration has been lost.
+     * |        |          |It is cleared by software writing one into this bit
+     * |[12]    |ERRIF     |Error Interrupt Flag
+     * |        |          |This bit indicates that a Bus Error occurs when a START or STOP condition is present at an illegal position in the formation frame
+     * |        |          |Example of illegal position are during the serial transfer of an address byte, a data byte or an acknowledge bit
+     * |        |          |A protocol interrupt can be generated if UI2C_PROTCTL.ERRIEN = 1.
+     * |        |          |0 = An I2C error has not been detected.
+     * |        |          |1 = An I2C error has been detected.
+     * |        |          |It is cleared by software writing one into this bit
+     * |        |          |Note: This bit is set when slave mode, user must write one into STO register to the defined "not addressed" slave mode.
+     * |[13]    |ACKIF     |Acknowledge Received Interrupt Flag
+     * |        |          |This bit indicates that an acknowledge has been received in master mode
+     * |        |          |A protocol interrupt can be generated if UI2C_PROTCTL.ACKIEN = 1.
+     * |        |          |0 = An acknowledge has not been received.
+     * |        |          |1 = An acknowledge has been received.
+     * |        |          |It is cleared by software writing one into this bit
+     * |[14]    |SLASEL    |Slave Select Status
+     * |        |          |This bit indicates that this device has been selected as slave.
+     * |        |          |0 = The device is not selected as slave.
+     * |        |          |1 = The device is selected as slave.
+     * |        |          |Note: This bit has no interrupt signal, and it will be cleared automatically by hardware.
+     * |[15]    |SLAREAD   |Slave Read Request Status
+     * |        |          |This bit indicates that a slave read request has been detected.
+     * |        |          |0 = A slave R/W bit is 1 has not been detected.
+     * |        |          |1 = A slave R/W bit is 1 has been detected.
+     * |        |          |Note: This bit has no interrupt signal, and it will be cleared automatically by hardware.
+     * |[16]    |WKAKDONE  |Wakeup Address Frame Acknowledge Bit Done
+     * |        |          |0 = The ACK bit cycle of address match frame isn't done.
+     * |        |          |1 = The ACK bit cycle of address match frame is done in power-down.
+     * |        |          |Note: This bit can't release when WKUPIF is set.
+     * |[17]    |WRSTSWK   |Read/Write Status Bit in Address Wakeup Frame
+     * |        |          |0 = Write command be record on the address match wakeup frame.
+     * |        |          |1 = Read command be record on the address match wakeup frame.
+     * |[18]    |BUSHANG   |Bus Hang-up
+     * |        |          |This bit indicates bus hang-up status
+     * |        |          |There is 4-bit counter count when SCL hold high and refer fSAMP_CLK
+     * |        |          |The hang-up counter will count to overflow and set this bit when SDA is low
+     * |        |          |The counter will be reset by falling edge of SCL signal.
+     * |        |          |0 = The bus is normal status for transmission.
+     * |        |          |1 = The bus is hang-up status for transmission.
+     * |        |          |Note: This bit has no interrupt signal, and it will be cleared automatically by hardware when a START condition is present.
+     * |[19]    |ERRARBLO  |Error Arbitration Lost
+     * |        |          |This bit indicates bus arbitration lost due to bigger noise which is can't be filtered by input processor
+     * |        |          |The I2C can send start condition when ERRARBLO is set
+     * |        |          |Thus this bit doesn't be cared on slave mode.
+     * |        |          |0 = The bus is normal status for transmission.
+     * |        |          |1 = The bus is error arbitration lost status for transmission.
+     * |        |          |Note: This bit has no interrupt signal, and it will be cleared automatically by hardware when a START condition is present.
+     * @var UI2C_T::ADMAT
+     * Offset: 0x88  I2C Slave Match Address Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |ADMAT0    |USCI Address 0 Match Status Register
+     * |        |          |When address 0 is matched, hardware will inform which address used
+     * |        |          |This bit will set to 1, and software can write 1 to clear this bit.
+     * |[1]     |ADMAT1    |USCI Address 1 Match Status Register
+     * |        |          |When address 1 is matched, hardware will inform which address used
+     * |        |          |This bit will set to 1, and software can write 1 to clear this bit.
+     * @var UI2C_T::TMCTL
+     * Offset: 0x8C  I2C Timing Configure Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |STCTL     |Setup Time Configure Control Register
+     * |        |          |This field is used to generate a delay timing between SDA edge and SCL rising edge in transmission mode..
+     * |        |          |The delay setup time is numbers of peripheral clock = STCTL x fPCLK.
+     * |[24:16] |HTCTL     |Hold Time Configure Control Register
+     * |        |          |This field is used to generate the delay timing between SCL falling edge SDA edge in
+     * |        |          |transmission mode.
+     * |        |          |The delay hold time is numbers of peripheral clock = HTCTL x fPCLK.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] USCI Control Register                                            */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t BRGEN;                 /*!< [0x0008] USCI Baud Rate Generator Register                                */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[8];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t LINECTL;               /*!< [0x002c] USCI Line Control Register                                       */
+    __O  uint32_t TXDAT;                 /*!< [0x0030] USCI Transmit Data Register                                      */
+    __I  uint32_t RXDAT;                 /*!< [0x0034] USCI Receive Data Register                                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t DEVADDR0;              /*!< [0x0044] USCI Device Address Register 0                                   */
+    __IO uint32_t DEVADDR1;              /*!< [0x0048] USCI Device Address Register 1                                   */
+    __IO uint32_t ADDRMSK0;              /*!< [0x004c] USCI Device Address Mask Register 0                              */
+    __IO uint32_t ADDRMSK1;              /*!< [0x0050] USCI Device Address Mask Register 1                              */
+    __IO uint32_t WKCTL;                 /*!< [0x0054] USCI Wake-up Control Register                                    */
+    __IO uint32_t WKSTS;                 /*!< [0x0058] USCI Wake-up Status Register                                     */
+    __IO uint32_t PROTCTL;               /*!< [0x005c] USCI Protocol Control Register                                   */
+    __IO uint32_t PROTIEN;               /*!< [0x0060] USCI Protocol Interrupt Enable Register                          */
+    __IO uint32_t PROTSTS;               /*!< [0x0064] USCI Protocol Status Register                                    */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[8];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t ADMAT;                 /*!< [0x0088] I2C Slave Match Address Register                                 */
+    __IO uint32_t TMCTL;                 /*!< [0x008c] I2C Timing Configure Control Register                            */
+} UI2C_T;
+
+/**
+    @addtogroup UI2C_CONST UI2C Bit Field Definition
+    Constant Definitions for UI2C Controller
+@{ */
+
+#define UI2C_CTL_FUNMODE_Pos             (0)                                               /*!< UI2C_T::CTL: FUNMODE Position          */
+#define UI2C_CTL_FUNMODE_Msk             (0x7ul << UI2C_CTL_FUNMODE_Pos)                   /*!< UI2C_T::CTL: FUNMODE Mask              */
+
+#define UI2C_BRGEN_RCLKSEL_Pos           (0)                                               /*!< UI2C_T::BRGEN: RCLKSEL Position        */
+#define UI2C_BRGEN_RCLKSEL_Msk           (0x1ul << UI2C_BRGEN_RCLKSEL_Pos)                 /*!< UI2C_T::BRGEN: RCLKSEL Mask            */
+
+#define UI2C_BRGEN_PTCLKSEL_Pos          (1)                                               /*!< UI2C_T::BRGEN: PTCLKSEL Position       */
+#define UI2C_BRGEN_PTCLKSEL_Msk          (0x1ul << UI2C_BRGEN_PTCLKSEL_Pos)                /*!< UI2C_T::BRGEN: PTCLKSEL Mask           */
+
+#define UI2C_BRGEN_SPCLKSEL_Pos          (2)                                               /*!< UI2C_T::BRGEN: SPCLKSEL Position       */
+#define UI2C_BRGEN_SPCLKSEL_Msk          (0x3ul << UI2C_BRGEN_SPCLKSEL_Pos)                /*!< UI2C_T::BRGEN: SPCLKSEL Mask           */
+
+#define UI2C_BRGEN_TMCNTEN_Pos           (4)                                               /*!< UI2C_T::BRGEN: TMCNTEN Position        */
+#define UI2C_BRGEN_TMCNTEN_Msk           (0x1ul << UI2C_BRGEN_TMCNTEN_Pos)                 /*!< UI2C_T::BRGEN: TMCNTEN Mask            */
+
+#define UI2C_BRGEN_TMCNTSRC_Pos          (5)                                               /*!< UI2C_T::BRGEN: TMCNTSRC Position       */
+#define UI2C_BRGEN_TMCNTSRC_Msk          (0x1ul << UI2C_BRGEN_TMCNTSRC_Pos)                /*!< UI2C_T::BRGEN: TMCNTSRC Mask           */
+
+#define UI2C_BRGEN_PDSCNT_Pos            (8)                                               /*!< UI2C_T::BRGEN: PDSCNT Position         */
+#define UI2C_BRGEN_PDSCNT_Msk            (0x3ul << UI2C_BRGEN_PDSCNT_Pos)                  /*!< UI2C_T::BRGEN: PDSCNT Mask             */
+
+#define UI2C_BRGEN_DSCNT_Pos             (10)                                              /*!< UI2C_T::BRGEN: DSCNT Position          */
+#define UI2C_BRGEN_DSCNT_Msk             (0x1ful << UI2C_BRGEN_DSCNT_Pos)                  /*!< UI2C_T::BRGEN: DSCNT Mask              */
+
+#define UI2C_BRGEN_CLKDIV_Pos            (16)                                              /*!< UI2C_T::BRGEN: CLKDIV Position         */
+#define UI2C_BRGEN_CLKDIV_Msk            (0x3fful << UI2C_BRGEN_CLKDIV_Pos)                /*!< UI2C_T::BRGEN: CLKDIV Mask             */
+
+#define UI2C_LINECTL_LSB_Pos             (0)                                               /*!< UI2C_T::LINECTL: LSB Position          */
+#define UI2C_LINECTL_LSB_Msk             (0x1ul << UI2C_LINECTL_LSB_Pos)                   /*!< UI2C_T::LINECTL: LSB Mask              */
+
+#define UI2C_LINECTL_DWIDTH_Pos          (8)                                               /*!< UI2C_T::LINECTL: DWIDTH Position       */
+#define UI2C_LINECTL_DWIDTH_Msk          (0xful << UI2C_LINECTL_DWIDTH_Pos)                /*!< UI2C_T::LINECTL: DWIDTH Mask           */
+
+#define UI2C_TXDAT_TXDAT_Pos             (0)                                               /*!< UI2C_T::TXDAT: TXDAT Position          */
+#define UI2C_TXDAT_TXDAT_Msk             (0xfffful << UI2C_TXDAT_TXDAT_Pos)                /*!< UI2C_T::TXDAT: TXDAT Mask              */
+
+#define UI2C_RXDAT_RXDAT_Pos             (0)                                               /*!< UI2C_T::RXDAT: RXDAT Position          */
+#define UI2C_RXDAT_RXDAT_Msk             (0xfffful << UI2C_RXDAT_RXDAT_Pos)                /*!< UI2C_T::RXDAT: RXDAT Mask              */
+
+#define UI2C_DEVADDR0_DEVADDR_Pos        (0)                                               /*!< UI2C_T::DEVADDR0: DEVADDR Position     */
+#define UI2C_DEVADDR0_DEVADDR_Msk        (0x3fful << UI2C_DEVADDR0_DEVADDR_Pos)            /*!< UI2C_T::DEVADDR0: DEVADDR Mask         */
+
+#define UI2C_DEVADDR1_DEVADDR_Pos        (0)                                               /*!< UI2C_T::DEVADDR1: DEVADDR Position     */
+#define UI2C_DEVADDR1_DEVADDR_Msk        (0x3fful << UI2C_DEVADDR1_DEVADDR_Pos)            /*!< UI2C_T::DEVADDR1: DEVADDR Mask         */
+
+#define UI2C_ADDRMSK0_ADDRMSK_Pos        (0)                                               /*!< UI2C_T::ADDRMSK0: ADDRMSK Position     */
+#define UI2C_ADDRMSK0_ADDRMSK_Msk        (0x3fful << UI2C_ADDRMSK0_ADDRMSK_Pos)            /*!< UI2C_T::ADDRMSK0: ADDRMSK Mask         */
+
+#define UI2C_ADDRMSK1_ADDRMSK_Pos        (0)                                               /*!< UI2C_T::ADDRMSK1: ADDRMSK Position     */
+#define UI2C_ADDRMSK1_ADDRMSK_Msk        (0x3fful << UI2C_ADDRMSK1_ADDRMSK_Pos)            /*!< UI2C_T::ADDRMSK1: ADDRMSK Mask         */
+
+#define UI2C_WKCTL_WKEN_Pos              (0)                                               /*!< UI2C_T::WKCTL: WKEN Position           */
+#define UI2C_WKCTL_WKEN_Msk              (0x1ul << UI2C_WKCTL_WKEN_Pos)                    /*!< UI2C_T::WKCTL: WKEN Mask               */
+
+#define UI2C_WKCTL_WKADDREN_Pos          (1)                                               /*!< UI2C_T::WKCTL: WKADDREN Position       */
+#define UI2C_WKCTL_WKADDREN_Msk          (0x1ul << UI2C_WKCTL_WKADDREN_Pos)                /*!< UI2C_T::WKCTL: WKADDREN Mask           */
+
+#define UI2C_WKSTS_WKF_Pos               (0)                                               /*!< UI2C_T::WKSTS: WKF Position            */
+#define UI2C_WKSTS_WKF_Msk               (0x1ul << UI2C_WKSTS_WKF_Pos)                     /*!< UI2C_T::WKSTS: WKF Mask                */
+
+#define UI2C_PROTCTL_GCFUNC_Pos          (0)                                               /*!< UI2C_T::PROTCTL: GCFUNC Position       */
+#define UI2C_PROTCTL_GCFUNC_Msk          (0x1ul << UI2C_PROTCTL_GCFUNC_Pos)                /*!< UI2C_T::PROTCTL: GCFUNC Mask           */
+
+#define UI2C_PROTCTL_AA_Pos              (1)                                               /*!< UI2C_T::PROTCTL: AA Position           */
+#define UI2C_PROTCTL_AA_Msk              (0x1ul << UI2C_PROTCTL_AA_Pos)                    /*!< UI2C_T::PROTCTL: AA Mask               */
+
+#define UI2C_PROTCTL_STO_Pos             (2)                                               /*!< UI2C_T::PROTCTL: STO Position          */
+#define UI2C_PROTCTL_STO_Msk             (0x1ul << UI2C_PROTCTL_STO_Pos)                   /*!< UI2C_T::PROTCTL: STO Mask              */
+
+#define UI2C_PROTCTL_STA_Pos             (3)                                               /*!< UI2C_T::PROTCTL: STA Position          */
+#define UI2C_PROTCTL_STA_Msk             (0x1ul << UI2C_PROTCTL_STA_Pos)                   /*!< UI2C_T::PROTCTL: STA Mask              */
+
+#define UI2C_PROTCTL_ADDR10EN_Pos        (4)                                               /*!< UI2C_T::PROTCTL: ADDR10EN Position     */
+#define UI2C_PROTCTL_ADDR10EN_Msk        (0x1ul << UI2C_PROTCTL_ADDR10EN_Pos)              /*!< UI2C_T::PROTCTL: ADDR10EN Mask         */
+
+#define UI2C_PROTCTL_PTRG_Pos            (5)                                               /*!< UI2C_T::PROTCTL: PTRG Position         */
+#define UI2C_PROTCTL_PTRG_Msk            (0x1ul << UI2C_PROTCTL_PTRG_Pos)                  /*!< UI2C_T::PROTCTL: PTRG Mask             */
+
+#define UI2C_PROTCTL_SCLOUTEN_Pos        (8)                                               /*!< UI2C_T::PROTCTL: SCLOUTEN Position     */
+#define UI2C_PROTCTL_SCLOUTEN_Msk        (0x1ul << UI2C_PROTCTL_SCLOUTEN_Pos)              /*!< UI2C_T::PROTCTL: SCLOUTEN Mask         */
+
+#define UI2C_PROTCTL_MONEN_Pos           (9)                                               /*!< UI2C_T::PROTCTL: MONEN Position        */
+#define UI2C_PROTCTL_MONEN_Msk           (0x1ul << UI2C_PROTCTL_MONEN_Pos)                 /*!< UI2C_T::PROTCTL: MONEN Mask            */
+
+#define UI2C_PROTCTL_TOCNT_Pos           (16)                                              /*!< UI2C_T::PROTCTL: TOCNT Position        */
+#define UI2C_PROTCTL_TOCNT_Msk           (0x3fful << UI2C_PROTCTL_TOCNT_Pos)               /*!< UI2C_T::PROTCTL: TOCNT Mask            */
+
+#define UI2C_PROTCTL_PROTEN_Pos          (31)                                              /*!< UI2C_T::PROTCTL: PROTEN Position       */
+#define UI2C_PROTCTL_PROTEN_Msk          (0x1ul << UI2C_PROTCTL_PROTEN_Pos)                /*!< UI2C_T::PROTCTL: PROTEN Mask           */
+
+#define UI2C_PROTIEN_TOIEN_Pos           (0)                                               /*!< UI2C_T::PROTIEN: TOIEN Position        */
+#define UI2C_PROTIEN_TOIEN_Msk           (0x1ul << UI2C_PROTIEN_TOIEN_Pos)                 /*!< UI2C_T::PROTIEN: TOIEN Mask            */
+
+#define UI2C_PROTIEN_STARIEN_Pos         (1)                                               /*!< UI2C_T::PROTIEN: STARIEN Position      */
+#define UI2C_PROTIEN_STARIEN_Msk         (0x1ul << UI2C_PROTIEN_STARIEN_Pos)               /*!< UI2C_T::PROTIEN: STARIEN Mask          */
+
+#define UI2C_PROTIEN_STORIEN_Pos         (2)                                               /*!< UI2C_T::PROTIEN: STORIEN Position      */
+#define UI2C_PROTIEN_STORIEN_Msk         (0x1ul << UI2C_PROTIEN_STORIEN_Pos)               /*!< UI2C_T::PROTIEN: STORIEN Mask          */
+
+#define UI2C_PROTIEN_NACKIEN_Pos         (3)                                               /*!< UI2C_T::PROTIEN: NACKIEN Position      */
+#define UI2C_PROTIEN_NACKIEN_Msk         (0x1ul << UI2C_PROTIEN_NACKIEN_Pos)               /*!< UI2C_T::PROTIEN: NACKIEN Mask          */
+
+#define UI2C_PROTIEN_ARBLOIEN_Pos        (4)                                               /*!< UI2C_T::PROTIEN: ARBLOIEN Position     */
+#define UI2C_PROTIEN_ARBLOIEN_Msk        (0x1ul << UI2C_PROTIEN_ARBLOIEN_Pos)              /*!< UI2C_T::PROTIEN: ARBLOIEN Mask         */
+
+#define UI2C_PROTIEN_ERRIEN_Pos          (5)                                               /*!< UI2C_T::PROTIEN: ERRIEN Position       */
+#define UI2C_PROTIEN_ERRIEN_Msk          (0x1ul << UI2C_PROTIEN_ERRIEN_Pos)                /*!< UI2C_T::PROTIEN: ERRIEN Mask           */
+
+#define UI2C_PROTIEN_ACKIEN_Pos          (6)                                               /*!< UI2C_T::PROTIEN: ACKIEN Position       */
+#define UI2C_PROTIEN_ACKIEN_Msk          (0x1ul << UI2C_PROTIEN_ACKIEN_Pos)                /*!< UI2C_T::PROTIEN: ACKIEN Mask           */
+
+#define UI2C_PROTSTS_TOIF_Pos            (5)                                               /*!< UI2C_T::PROTSTS: TOIF Position         */
+#define UI2C_PROTSTS_TOIF_Msk            (0x1ul << UI2C_PROTSTS_TOIF_Pos)                  /*!< UI2C_T::PROTSTS: TOIF Mask             */
+
+#define UI2C_PROTSTS_ONBUSY_Pos          (6)                                               /*!< UI2C_T::PROTSTS: ONBUSY Position       */
+#define UI2C_PROTSTS_ONBUSY_Msk          (0x1ul << UI2C_PROTSTS_ONBUSY_Pos)                /*!< UI2C_T::PROTSTS: ONBUSY Mask           */
+
+#define UI2C_PROTSTS_STARIF_Pos          (8)                                               /*!< UI2C_T::PROTSTS: STARIF Position       */
+#define UI2C_PROTSTS_STARIF_Msk          (0x1ul << UI2C_PROTSTS_STARIF_Pos)                /*!< UI2C_T::PROTSTS: STARIF Mask           */
+
+#define UI2C_PROTSTS_STORIF_Pos          (9)                                               /*!< UI2C_T::PROTSTS: STORIF Position       */
+#define UI2C_PROTSTS_STORIF_Msk          (0x1ul << UI2C_PROTSTS_STORIF_Pos)                /*!< UI2C_T::PROTSTS: STORIF Mask           */
+
+#define UI2C_PROTSTS_NACKIF_Pos          (10)                                              /*!< UI2C_T::PROTSTS: NACKIF Position       */
+#define UI2C_PROTSTS_NACKIF_Msk          (0x1ul << UI2C_PROTSTS_NACKIF_Pos)                /*!< UI2C_T::PROTSTS: NACKIF Mask           */
+
+#define UI2C_PROTSTS_ARBLOIF_Pos         (11)                                              /*!< UI2C_T::PROTSTS: ARBLOIF Position      */
+#define UI2C_PROTSTS_ARBLOIF_Msk         (0x1ul << UI2C_PROTSTS_ARBLOIF_Pos)               /*!< UI2C_T::PROTSTS: ARBLOIF Mask          */
+
+#define UI2C_PROTSTS_ERRIF_Pos           (12)                                              /*!< UI2C_T::PROTSTS: ERRIF Position        */
+#define UI2C_PROTSTS_ERRIF_Msk           (0x1ul << UI2C_PROTSTS_ERRIF_Pos)                 /*!< UI2C_T::PROTSTS: ERRIF Mask            */
+
+#define UI2C_PROTSTS_ACKIF_Pos           (13)                                              /*!< UI2C_T::PROTSTS: ACKIF Position        */
+#define UI2C_PROTSTS_ACKIF_Msk           (0x1ul << UI2C_PROTSTS_ACKIF_Pos)                 /*!< UI2C_T::PROTSTS: ACKIF Mask            */
+
+#define UI2C_PROTSTS_SLASEL_Pos          (14)                                              /*!< UI2C_T::PROTSTS: SLASEL Position       */
+#define UI2C_PROTSTS_SLASEL_Msk          (0x1ul << UI2C_PROTSTS_SLASEL_Pos)                /*!< UI2C_T::PROTSTS: SLASEL Mask           */
+
+#define UI2C_PROTSTS_SLAREAD_Pos         (15)                                              /*!< UI2C_T::PROTSTS: SLAREAD Position      */
+#define UI2C_PROTSTS_SLAREAD_Msk         (0x1ul << UI2C_PROTSTS_SLAREAD_Pos)               /*!< UI2C_T::PROTSTS: SLAREAD Mask          */
+
+#define UI2C_PROTSTS_WKAKDONE_Pos        (16)                                              /*!< UI2C_T::PROTSTS: WKAKDONE Position     */
+#define UI2C_PROTSTS_WKAKDONE_Msk        (0x1ul << UI2C_PROTSTS_WKAKDONE_Pos)              /*!< UI2C_T::PROTSTS: WKAKDONE Mask         */
+
+#define UI2C_PROTSTS_WRSTSWK_Pos         (17)                                              /*!< UI2C_T::PROTSTS: WRSTSWK Position      */
+#define UI2C_PROTSTS_WRSTSWK_Msk         (0x1ul << UI2C_PROTSTS_WRSTSWK_Pos)               /*!< UI2C_T::PROTSTS: WRSTSWK Mask          */
+
+#define UI2C_PROTSTS_BUSHANG_Pos         (18)                                              /*!< UI2C_T::PROTSTS: BUSHANG Position      */
+#define UI2C_PROTSTS_BUSHANG_Msk         (0x1ul << UI2C_PROTSTS_BUSHANG_Pos)               /*!< UI2C_T::PROTSTS: BUSHANG Mask          */
+
+#define UI2C_PROTSTS_ERRARBLO_Pos        (19)                                              /*!< UI2C_T::PROTSTS: ERRARBLO Position     */
+#define UI2C_PROTSTS_ERRARBLO_Msk        (0x1ul << UI2C_PROTSTS_ERRARBLO_Pos)              /*!< UI2C_T::PROTSTS: ERRARBLO Mask         */
+
+#define UI2C_ADMAT_ADMAT0_Pos            (0)                                               /*!< UI2C_T::ADMAT: ADMAT0 Position         */
+#define UI2C_ADMAT_ADMAT0_Msk            (0x1ul << UI2C_ADMAT_ADMAT0_Pos)                  /*!< UI2C_T::ADMAT: ADMAT0 Mask             */
+
+#define UI2C_ADMAT_ADMAT1_Pos            (1)                                               /*!< UI2C_T::ADMAT: ADMAT1 Position         */
+#define UI2C_ADMAT_ADMAT1_Msk            (0x1ul << UI2C_ADMAT_ADMAT1_Pos)                  /*!< UI2C_T::ADMAT: ADMAT1 Mask             */
+
+#define UI2C_TMCTL_STCTL_Pos             (0)                                               /*!< UI2C_T::TMCTL: STCTL Position          */
+#define UI2C_TMCTL_STCTL_Msk             (0x1fful << UI2C_TMCTL_STCTL_Pos)                 /*!< UI2C_T::TMCTL: STCTL Mask              */
+
+#define UI2C_TMCTL_HTCTL_Pos             (16)                                              /*!< UI2C_T::TMCTL: HTCTL Position          */
+#define UI2C_TMCTL_HTCTL_Msk             (0x1fful << UI2C_TMCTL_HTCTL_Pos)                 /*!< UI2C_T::TMCTL: HTCTL Mask              */
+
+/** @} UI2C_CONST */
+/** @} end of UI2C register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __UI2C_REG_H__ */

--- a/hal/m258ke/nuvoton/usbd.c
+++ b/hal/m258ke/nuvoton/usbd.c
@@ -1,0 +1,794 @@
+/**************************************************************************//**
+ * @file     usbd.c
+ * @version  V0.10
+ * @brief    M251 series USBD driver source file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+*****************************************************************************/
+
+#include <string.h>
+#include "NuMicro.h"
+
+#if 0
+    #define DBG_PRINTF      printf
+#else
+    #define DBG_PRINTF(...)
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/** @addtogroup Standard_Driver Standard Driver
+  @{
+*/
+
+/** @addtogroup USBD_Driver USBD Driver
+  @{
+*/
+
+
+/** @addtogroup USBD_EXPORTED_FUNCTIONS USBD Exported Functions
+  @{
+*/
+
+/* Global variables for Control Pipe */
+uint8_t g_USBD_au8SetupPacket[8]           = {0u};    /*!< Setup packet buffer */
+volatile uint8_t g_USBD_u8RemoteWakeupEn  = 0u;     /*!< Remote wake up function enable flag */
+
+/**
+ * @cond HIDDEN_SYMBOLS
+ */
+static volatile uint8_t *s_USBD_pu8CtrlInPointer       = 0ul;
+static volatile uint8_t *s_USBD_pu8CtrlOutPointer      = 0ul;
+static volatile uint32_t s_USBD_u32CtrlInSize          = 0ul;
+static volatile uint32_t s_USBD_u32CtrlOutSize         = 0ul;
+static volatile uint32_t s_USBD_u32CtrlOutSizeLimit    = 0ul;
+static volatile uint32_t s_USBD_u32UsbAddr             = 0ul;
+static volatile uint32_t s_USBD_u32UsbConfig           = 0ul;
+static volatile uint32_t s_USBD_u32CtrlMaxPktSize      = 8ul;
+static volatile uint32_t s_USBD_u32UsbAltInterface     = 0ul;
+static volatile uint8_t  s_USBD_u8CtrlInZeroFlag       = 0ul;
+static volatile uint32_t s_USBD_u32CtrlOutToggle       = 0ul;
+/**
+ * @endcond
+ */
+
+const S_USBD_INFO_T *g_USBD_sINFO;                   /*!< A pointer for USB information structure */
+
+VENDOR_REQ g_USBD_pfnVendorRequest          = NULL;  /*!< USB Vendor Request Functional Pointer */
+CLASS_REQ g_USBD_pfnClassRequest            = NULL;  /*!< USB Class Request Functional Pointer */
+SET_INTERFACE_REQ g_USBD_pfnSetInterface    = NULL;  /*!< USB Set Interface Functional Pointer */
+SET_CONFIG_CB g_USBD_pfnSetConfigCallback   = NULL;  /*!< USB Set configuration callback function pointer */
+uint32_t g_USBD_u32EpStallLock              =  0ul;  /*!< Bit map flag to lock specified EP when SET_FEATURE */
+
+/**
+  * @brief      This function makes USBD module to be ready to use
+  *
+  * @param[in]  param           The structure of USBD information.
+  * @param[in]  pfnClassReq     USB Class request callback function.
+  * @param[in]  pfnSetInterface USB Set Interface request callback function.
+  *
+  *
+  * @details    This function will enable USB controller, USB PHY transceiver and pull-up resistor of USB_D+ pin. USB PHY will drive SE0 to bus.
+  */
+void USBD_Open(const S_USBD_INFO_T *param, CLASS_REQ pfnClassReq, SET_INTERFACE_REQ pfnSetInterface)
+{
+    g_USBD_sINFO            = param;
+    g_USBD_pfnClassRequest  = pfnClassReq;
+    g_USBD_pfnSetInterface  = pfnSetInterface;
+
+    /* get EP0 maximum packet size */
+    s_USBD_u32CtrlMaxPktSize = g_USBD_sINFO->gu8DevDesc[7];
+
+    /* Initial USB engine */
+#ifdef SUPPORT_LPM
+    USBD->ATTR = 0x7D0UL | USBD_LPMACK;
+#else
+    USBD->ATTR = 0x7D0UL;
+#endif
+    /* Force SE0 */
+    USBD_SET_SE0();
+}
+
+/**
+  * @brief    This function makes USB host to recognize the device
+  *
+  *
+  *
+  * @details  Enable WAKEUP, FLDET, USB and BUS interrupts. Disable software-disconnect function after 100ms delay with SysTick timer.
+  */
+void USBD_Start(void)
+{
+    /* Disable software-disconnect function */
+    USBD_CLR_SE0();
+
+    /* Clear USB-related interrupts before enable interrupt */
+    USBD_CLR_INT_FLAG(USBD_INT_BUS | USBD_INT_USB | USBD_INT_FLDET | USBD_INT_WAKEUP);
+
+    /* Enable USB-related interrupts. */
+    USBD_ENABLE_INT(USBD_INT_BUS | USBD_INT_USB | USBD_INT_FLDET | USBD_INT_WAKEUP);
+}
+
+/**
+  * @brief      Get the received SETUP packet
+  *
+  * @param[in]  buf A buffer pointer used to store 8-byte SETUP packet.
+  *
+  *
+  * @details    Store SETUP packet to a user-specified buffer.
+  *
+  */
+void USBD_GetSetupPacket(uint8_t *buf)
+{
+    USBD_MemCopy(buf, g_USBD_au8SetupPacket, 8ul);
+}
+
+/**
+  * @brief    Process SETUP packet
+  *
+  *
+  *
+  * @details  Parse SETUP packet and perform the corresponding action.
+  *
+  */
+void USBD_ProcessSetupPacket(void)
+{
+    s_USBD_u32CtrlOutToggle = 0;
+    /* Get SETUP packet from USB buffer */
+    USBD_MemCopy(g_USBD_au8SetupPacket, (uint8_t *)USBD_BUF_BASE, 8ul);
+
+    /* Check the request type */
+    switch (g_USBD_au8SetupPacket[0] & 0x60ul)
+    {
+        case REQ_STANDARD:   /* Standard */
+        {
+            USBD_StandardRequest();
+            break;
+        }
+
+        case REQ_CLASS:   /* Class */
+        {
+            if (g_USBD_pfnClassRequest != NULL)
+            {
+                g_USBD_pfnClassRequest();
+            }
+
+            break;
+        }
+
+        case REQ_VENDOR:   /* Vendor */
+        {
+            if (g_USBD_pfnVendorRequest != NULL)
+            {
+                g_USBD_pfnVendorRequest();
+            }
+
+            break;
+        }
+
+        default:   /* reserved */
+        {
+            /* Setup error, stall the device */
+            USBD_SET_EP_STALL(EP0);
+            USBD_SET_EP_STALL(EP1);
+            break;
+        }
+    }
+}
+
+/**
+  * @brief    Process GetDescriptor request
+  *
+  *
+  *
+  * @details  Parse GetDescriptor request and perform the corresponding action.
+  *
+  */
+void USBD_GetDescriptor(void)
+{
+    uint32_t u32Len;
+
+    s_USBD_u8CtrlInZeroFlag = (uint8_t)0ul;
+
+    u32Len   = 0ul;
+    u32Len   = g_USBD_au8SetupPacket[7];
+    u32Len <<= 8ul;
+    u32Len  += g_USBD_au8SetupPacket[6];
+
+    switch (g_USBD_au8SetupPacket[3])
+    {
+        /* Get Device Descriptor */
+        case DESC_DEVICE:
+        {
+            u32Len = USBD_Minimum(u32Len, LEN_DEVICE);
+            DBG_PRINTF("Get device desc, %d\n", u32Len);
+
+            USBD_PrepareCtrlIn((uint8_t *)g_USBD_sINFO->gu8DevDesc, u32Len);
+
+            break;
+        }
+
+        /* Get Configuration Descriptor */
+        case DESC_CONFIG:
+        {
+            uint32_t u32TotalLen;
+
+            DBG_PRINTF("Get config desc len %d, acture len %d\n", u32Len, u32TotalLen);
+            u32TotalLen = g_USBD_sINFO->gu8ConfigDesc[3];
+            u32TotalLen = g_USBD_sINFO->gu8ConfigDesc[2] + (u32TotalLen << 8U);
+
+            DBG_PRINTF("Get config desc len %d, acture len %d\n", u32Len, u32TotalLen);
+
+            if (u32Len > u32TotalLen)
+            {
+                u32Len = u32TotalLen;
+
+                if ((u32Len % s_USBD_u32CtrlMaxPktSize) == 0ul)
+                {
+                    s_USBD_u8CtrlInZeroFlag = (uint8_t)1ul;
+                }
+            }
+
+            DBG_PRINTF("Minimum len %d\n", u32Len);
+
+            USBD_PrepareCtrlIn((uint8_t *)g_USBD_sINFO->gu8ConfigDesc, u32Len);
+
+            break;
+        }
+
+
+        /* Get BOS Descriptor */
+        case DESC_BOS:
+        {
+            if (g_USBD_sINFO->gu8BosDesc)
+            {
+                u32Len = USBD_Minimum(u32Len, LEN_BOS + LEN_DEVCAP);
+                USBD_PrepareCtrlIn((uint8_t *)g_USBD_sINFO->gu8BosDesc, u32Len);
+            }
+            else
+            {
+                USBD_SET_EP_STALL(EP0);
+                USBD_SET_EP_STALL(EP1);
+            }
+
+            break;
+        }
+
+        /* Get HID Descriptor */
+        case DESC_HID:
+        {
+            /* CV3.0 HID Class Descriptor Test,
+               Need to indicate index of the HID Descriptor within gu8ConfigDescriptor, specifically HID Composite device. */
+            uint32_t u32ConfigDescOffset;   /* u32ConfigDescOffset is configuration descriptor offset (HID descriptor start index) */
+            u32Len = USBD_Minimum(u32Len, LEN_HID);
+            DBG_PRINTF("Get HID desc, %d\n", u32Len);
+
+            u32ConfigDescOffset = g_USBD_sINFO->gu32ConfigHidDescIdx[g_USBD_au8SetupPacket[4]];
+            USBD_PrepareCtrlIn((uint8_t *)&g_USBD_sINFO->gu8ConfigDesc[u32ConfigDescOffset], u32Len);
+
+            break;
+        }
+
+        /* Get Report Descriptor */
+        case DESC_HID_RPT:
+        {
+            DBG_PRINTF("Get HID report, %d\n", u32Len);
+
+            if (u32Len > g_USBD_sINFO->gu32HidReportSize[g_USBD_au8SetupPacket[4]])
+            {
+                u32Len = g_USBD_sINFO->gu32HidReportSize[g_USBD_au8SetupPacket[4]];
+
+                if ((u32Len % s_USBD_u32CtrlMaxPktSize) == 0ul)
+                {
+                    s_USBD_u8CtrlInZeroFlag = (uint8_t)1ul;
+                }
+            }
+
+            USBD_PrepareCtrlIn((uint8_t *)g_USBD_sINFO->gu8HidReportDesc[g_USBD_au8SetupPacket[4]], u32Len);
+            break;
+        }
+
+        /* Get String Descriptor */
+        case DESC_STRING:
+        {
+            /* Get String Descriptor */
+            if (g_USBD_au8SetupPacket[2] < 4ul)
+            {
+                if (u32Len > g_USBD_sINFO->gu8StringDesc[g_USBD_au8SetupPacket[2]][0])
+                {
+                    u32Len = g_USBD_sINFO->gu8StringDesc[g_USBD_au8SetupPacket[2]][0];
+
+                    if ((u32Len % s_USBD_u32CtrlMaxPktSize) == 0ul)
+                    {
+                        s_USBD_u8CtrlInZeroFlag = (uint8_t)1ul;
+                    }
+                }
+
+                DBG_PRINTF("Get string desc %d\n", u32Len);
+
+                USBD_PrepareCtrlIn((uint8_t *)g_USBD_sINFO->gu8StringDesc[g_USBD_au8SetupPacket[2]], u32Len);
+
+
+                break;
+            }
+            else
+            {
+                /* Not support. Reply STALL. */
+                USBD_SET_EP_STALL(EP0);
+                USBD_SET_EP_STALL(EP1);
+
+                DBG_PRINTF("Unsupported string desc (%d). Stall ctrl pipe.\n", g_USBD_au8SetupPacket[2]);
+
+                break;
+            }
+        }
+
+        default:
+            /* Not support. Reply STALL. */
+            USBD_SET_EP_STALL(EP0);
+            USBD_SET_EP_STALL(EP1);
+
+            DBG_PRINTF("Unsupported get desc type. stall ctrl pipe\n");
+
+            break;
+    }
+}
+
+/**
+  * @brief    Process standard request
+  *
+  *
+  *
+  * @details  Parse standard request and perform the corresponding action.
+  *
+  */
+void USBD_StandardRequest(void)
+{
+    DBG_PRINTF("USBD_StandardRequest\n");
+
+    /* clear global variables for new request */
+    s_USBD_pu8CtrlInPointer = 0ul;
+    s_USBD_u32CtrlInSize    = 0ul;
+
+    if (g_USBD_au8SetupPacket[0] & 0x80ul)   /* request data transfer direction */
+    {
+        /* Device to host */
+        switch (g_USBD_au8SetupPacket[1])
+        {
+            case GET_CONFIGURATION:
+            {
+                /* Return current configuration setting */
+                /* Data stage */
+                M8(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0)) = (uint8_t)s_USBD_u32UsbConfig;
+                USBD_SET_DATA1(EP0);
+                USBD_SET_PAYLOAD_LEN(EP0, 1ul);
+                /* Status stage */
+                USBD_PrepareCtrlOut(0, 0ul);
+
+                DBG_PRINTF("Get configuration\n");
+
+                break;
+            }
+
+            case GET_DESCRIPTOR:
+            {
+                USBD_GetDescriptor();
+                USBD_PrepareCtrlOut(0, 0ul); /* For status stage */
+                break;
+            }
+
+            case GET_INTERFACE:
+            {
+                /* Return current interface setting */
+                /* Data stage */
+                M8(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0)) = (uint8_t)s_USBD_u32UsbAltInterface;
+                USBD_SET_DATA1(EP0);
+                USBD_SET_PAYLOAD_LEN(EP0, 1ul);
+                /* Status stage */
+                USBD_PrepareCtrlOut(0, 0ul);
+
+                DBG_PRINTF("Get interface\n");
+
+                break;
+            }
+
+            case GET_STATUS:
+            {
+                /* Device */
+                if (g_USBD_au8SetupPacket[0] == 0x80ul)
+                {
+                    uint8_t u8Tmp;
+
+                    u8Tmp = (uint8_t)0ul;
+
+                    if (g_USBD_sINFO->gu8ConfigDesc[7] & 0x40ul) u8Tmp |= (uint8_t)1ul; /* Self-Powered/Bus-Powered. */
+
+                    if (g_USBD_sINFO->gu8ConfigDesc[7] & 0x20)   u8Tmp |= (uint8_t)(g_USBD_u8RemoteWakeupEn << 1ul); /* Remote wake up */
+
+                    M8(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0)) = u8Tmp;
+
+                }
+                /* Interface */
+                else if (g_USBD_au8SetupPacket[0] == 0x81ul)
+                    M8(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0)) = (uint8_t)0ul;
+                /* Endpoint */
+                else if (g_USBD_au8SetupPacket[0] == 0x82ul)
+                {
+                    uint8_t ep = (uint8_t)g_USBD_au8SetupPacket[4] & 0xFul;
+                    M8(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0)) = (uint8_t)(USBD_GetStall(ep) ? 1ul : 0ul);
+                }
+
+                M8(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0) + 1) = (uint8_t)0ul;
+                /* Data stage */
+                USBD_SET_DATA1(EP0);
+                USBD_SET_PAYLOAD_LEN(EP0, 2ul);
+                /* Status stage */
+                USBD_PrepareCtrlOut(0, 0ul);
+
+                DBG_PRINTF("Get status\n");
+
+                break;
+            }
+
+            default:
+            {
+                /* Setup error, stall the device */
+                USBD_SET_EP_STALL(EP0);
+                USBD_SET_EP_STALL(EP1);
+
+                DBG_PRINTF("Unknown request. stall ctrl pipe.\n");
+
+                break;
+            }
+        }
+    }
+    else
+    {
+        /* Host to device */
+        switch (g_USBD_au8SetupPacket[1])
+        {
+            case CLEAR_FEATURE:
+            {
+                if (g_USBD_au8SetupPacket[2] == FEATURE_ENDPOINT_HALT)
+                {
+                    uint32_t epNum, i;
+
+                    /* EP number stall is not allow to be clear in MSC class "Error Recovery Test".
+                       a flag: g_USBD_u32EpStallLock is added to support it */
+                    epNum = (uint8_t)(g_USBD_au8SetupPacket[4] & 0xFul);
+
+                    for (i = 0ul; i < USBD_MAX_EP; i++)
+                    {
+                        if (((USBD->EP[i].CFG & 0xFul) == epNum) && ((g_USBD_u32EpStallLock & (1ul << i)) == 0ul))
+                        {
+                            USBD->EP[i].CFGP &= ~USBD_CFGP_SSTALL_Msk;
+                            USBD->EP[i].CFG  &= ~USBD_CFG_DSQSYNC_Msk;
+                            DBG_PRINTF("Clr stall ep%d %x\n", i, USBD->EP[i].CFGP);
+                        }
+                    }
+                }
+                else if (g_USBD_au8SetupPacket[2] == FEATURE_DEVICE_REMOTE_WAKEUP)
+                    g_USBD_u8RemoteWakeupEn = (uint8_t)0;
+
+                /* Status stage */
+                USBD_SET_DATA1(EP0);
+                USBD_SET_PAYLOAD_LEN(EP0, 0ul);
+
+                DBG_PRINTF("Clear feature op %d\n", g_USBD_au8SetupPacket[2]);
+
+                break;
+            }
+
+            case SET_ADDRESS:
+            {
+                s_USBD_u32UsbAddr = g_USBD_au8SetupPacket[2];
+                DBG_PRINTF("Set addr to %d\n", s_USBD_u32UsbAddr);
+
+                /* DATA IN for end of setup */
+                /* Status Stage */
+                USBD_SET_DATA1(EP0);
+                USBD_SET_PAYLOAD_LEN(EP0, 0ul);
+
+                break;
+            }
+
+            case SET_CONFIGURATION:
+            {
+                s_USBD_u32UsbConfig = g_USBD_au8SetupPacket[2];
+
+                if (g_USBD_pfnSetConfigCallback)
+                    g_USBD_pfnSetConfigCallback();
+
+                /* Status stage */
+                USBD_SET_DATA1(EP0);
+                USBD_SET_PAYLOAD_LEN(EP0, 0ul);
+
+                DBG_PRINTF("Set config to %d\n", s_USBD_u32UsbConfig);
+
+                break;
+            }
+
+            case SET_FEATURE:
+            {
+                if (g_USBD_au8SetupPacket[2] == FEATURE_ENDPOINT_HALT)
+                {
+                    USBD_SetStall((uint8_t)(g_USBD_au8SetupPacket[4] & 0xFul));
+                    DBG_PRINTF("Set feature. stall ep %d\n", g_USBD_au8SetupPacket[4] & 0xFul);
+                }
+                else if (g_USBD_au8SetupPacket[2] == FEATURE_DEVICE_REMOTE_WAKEUP)
+                {
+                    g_USBD_u8RemoteWakeupEn = (uint8_t)1ul;
+                    DBG_PRINTF("Set feature. enable remote wakeup\n");
+                }
+
+                /* Status stage */
+                USBD_SET_DATA1(EP0);
+                USBD_SET_PAYLOAD_LEN(EP0, 0ul);
+
+                break;
+            }
+
+            case SET_INTERFACE:
+            {
+                s_USBD_u32UsbAltInterface = g_USBD_au8SetupPacket[2];
+
+                if (g_USBD_pfnSetInterface != NULL)
+                {
+                    g_USBD_pfnSetInterface(s_USBD_u32UsbAltInterface);
+                }
+
+                /* Status stage */
+                USBD_SET_DATA1(EP0);
+                USBD_SET_PAYLOAD_LEN(EP0, 0ul);
+
+                DBG_PRINTF("Set interface to %d\n", s_USBD_u32UsbAltInterface);
+
+                break;
+            }
+
+            default:
+            {
+
+                /* Setup error, stall the device */
+                USBD_SET_EP_STALL(EP0);
+                USBD_SET_EP_STALL(EP1);
+
+                DBG_PRINTF("Unsupported request. stall ctrl pipe.\n");
+
+                break;
+            }
+        }
+    }
+}
+
+/**
+  * @brief      Prepare the first Control IN pipe
+  *
+  * @param[in]  pu8Buf  The pointer of data sent to USB host.
+  * @param[in]  u32Size The IN transfer size.
+  *
+  *
+  * @details    Prepare data for Control IN transfer.
+  *
+  */
+void USBD_PrepareCtrlIn(uint8_t pu8Buf[], uint32_t u32Size)
+{
+    DBG_PRINTF("Prepare Ctrl In %d\n", u32Size);
+
+    if (u32Size > s_USBD_u32CtrlMaxPktSize)
+    {
+        // Data size > MXPLD
+        s_USBD_pu8CtrlInPointer = pu8Buf + s_USBD_u32CtrlMaxPktSize;
+        s_USBD_u32CtrlInSize = u32Size - s_USBD_u32CtrlMaxPktSize;
+        USBD_SET_DATA1(EP0);
+        USBD_MemCopy((uint8_t *)USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0), pu8Buf, s_USBD_u32CtrlMaxPktSize);
+        USBD_SET_PAYLOAD_LEN(EP0, s_USBD_u32CtrlMaxPktSize);
+    }
+    else
+    {
+        // Data size <= MXPLD
+        s_USBD_pu8CtrlInPointer = 0ul;
+        s_USBD_u32CtrlInSize = 0ul;
+
+        USBD_SET_DATA1(EP0);
+        USBD_MemCopy((uint8_t *)USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0), pu8Buf, u32Size);
+        USBD_SET_PAYLOAD_LEN(EP0, u32Size);
+    }
+}
+
+/**
+  * @brief    Repeat Control IN pipe
+  *
+  *
+  *
+  * @details  This function processes the remained data of Control IN transfer.
+  *
+  */
+void USBD_CtrlIn(void)
+{
+
+    DBG_PRINTF("Ctrl In Ack. residue %d\n", s_USBD_u32CtrlInSize);
+
+    if (s_USBD_u32CtrlInSize)
+    {
+        // Process remained data
+        if (s_USBD_u32CtrlInSize > s_USBD_u32CtrlMaxPktSize)
+        {
+            // Data size > MXPLD
+            USBD_MemCopy((uint8_t *)USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0), (uint8_t *)s_USBD_pu8CtrlInPointer, s_USBD_u32CtrlMaxPktSize);
+            USBD_SET_PAYLOAD_LEN(EP0, s_USBD_u32CtrlMaxPktSize);
+            s_USBD_pu8CtrlInPointer += s_USBD_u32CtrlMaxPktSize;
+            s_USBD_u32CtrlInSize -= s_USBD_u32CtrlMaxPktSize;
+        }
+        else
+        {
+            // Data size <= MXPLD
+            USBD_MemCopy((uint8_t *)USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0), (uint8_t *)s_USBD_pu8CtrlInPointer, s_USBD_u32CtrlInSize);
+            USBD_SET_PAYLOAD_LEN(EP0, s_USBD_u32CtrlInSize);
+
+            s_USBD_pu8CtrlInPointer = 0ul;
+            s_USBD_u32CtrlInSize    = 0ul;
+        }
+    }
+    else     // No more data for IN token
+    {
+        // In ACK for Set address
+        if ((g_USBD_au8SetupPacket[0] == REQ_STANDARD) && (g_USBD_au8SetupPacket[1] == SET_ADDRESS))
+        {
+            if ((USBD_GET_ADDR() != s_USBD_u32UsbAddr) && (USBD_GET_ADDR() == 0ul))
+            {
+                USBD_SET_ADDR(s_USBD_u32UsbAddr);
+            }
+        }
+
+        /* For the case of data size is integral times maximum packet size */
+        if (s_USBD_u8CtrlInZeroFlag)
+        {
+            USBD_SET_PAYLOAD_LEN(EP0, 0ul);
+            s_USBD_u8CtrlInZeroFlag  = (uint8_t)0ul;
+        }
+
+        DBG_PRINTF("Ctrl In done.\n");
+
+    }
+}
+
+/**
+  * @brief      Prepare the first Control OUT pipe
+  *
+  * @param[in]  pu8Buf  The pointer of data received from USB host.
+  * @param[in]  u32Size The OUT transfer size.
+  *
+  *
+  * @details    This function is used to prepare the first Control OUT transfer.
+  *
+  */
+void USBD_PrepareCtrlOut(uint8_t *pu8Buf, uint32_t u32Size)
+{
+    s_USBD_pu8CtrlOutPointer = pu8Buf;
+    s_USBD_u32CtrlOutSize = 0ul;
+    s_USBD_u32CtrlOutSizeLimit = u32Size;
+    USBD_SET_PAYLOAD_LEN(EP1, s_USBD_u32CtrlMaxPktSize);
+}
+
+/**
+  * @brief    Repeat Control OUT pipe
+  *
+  *
+  *
+  * @details  This function processes the successive Control OUT transfer.
+  *
+  */
+void USBD_CtrlOut(void)
+{
+    if (s_USBD_u32CtrlOutToggle != (USBD->EPSTS0 & 0xf0))
+    {
+        s_USBD_u32CtrlOutToggle = USBD->EPSTS0 & 0xf0; //keep H/W EP1 toggle status
+
+        if (s_USBD_u32CtrlOutSize < s_USBD_u32CtrlOutSizeLimit)
+        {
+            uint32_t u32Size;
+            uint32_t addr;
+
+            u32Size = USBD_GET_PAYLOAD_LEN(EP1);
+            addr = USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP1);
+            USBD_MemCopy((uint8_t *)s_USBD_pu8CtrlOutPointer, (uint8_t *)addr, u32Size);
+            s_USBD_pu8CtrlOutPointer += u32Size;
+            s_USBD_u32CtrlOutSize += u32Size;
+
+            if (s_USBD_u32CtrlOutSize < s_USBD_u32CtrlOutSizeLimit)
+            {
+                USBD_SET_PAYLOAD_LEN(EP1, s_USBD_u32CtrlMaxPktSize);
+            }
+        }
+    }
+    else
+    {
+        USBD_SET_PAYLOAD_LEN(EP1, s_USBD_u32CtrlMaxPktSize);
+    }
+}
+
+/**
+  * @brief    Reset software flags
+  *
+  *
+  *
+  * @details  This function resets all variables for protocol and resets USB device address to 0.
+  *
+  */
+void USBD_SwReset(void)
+{
+    uint32_t i;
+
+    // Reset all variables for protocol
+    s_USBD_pu8CtrlInPointer    = 0ul;
+    s_USBD_u32CtrlInSize       = 0ul;
+    s_USBD_pu8CtrlOutPointer   = 0ul;
+    s_USBD_u32CtrlOutSize      = 0ul;
+    s_USBD_u32CtrlOutSizeLimit = 0ul;
+    g_USBD_u32EpStallLock      = 0ul;
+    memset(g_USBD_au8SetupPacket, 0, 8ul);
+
+    /* Reset PID DATA0 */
+    for (i = 0ul; i < USBD_MAX_EP; i++)
+        USBD->EP[i].CFG &= ~USBD_CFG_DSQSYNC_Msk;
+
+    // Reset USB device address
+    USBD_SET_ADDR(0ul);
+}
+
+/**
+ * @brief       USBD Set Vendor Request
+ *
+ * @param[in]   pfnVendorReq    Vendor Request Callback Function
+ *
+ *
+ * @details     This function is used to set USBD vendor request callback function
+ */
+void USBD_SetVendorRequest(VENDOR_REQ pfnVendorReq)
+{
+    g_USBD_pfnVendorRequest = pfnVendorReq;
+}
+
+/**
+ * @brief       The callback function which called when get SET CONFIGURATION request
+ *
+ * @param[in]   pfnSetConfigCallback    Callback function pointer for SET CONFIGURATION request
+ *
+ *
+ * @details     This function is used to set the callback function which will be called at SET CONFIGURATION request.
+ */
+void USBD_SetConfigCallback(SET_CONFIG_CB pfnSetConfigCallback)
+{
+    g_USBD_pfnSetConfigCallback = pfnSetConfigCallback;
+}
+
+
+/**
+ * @brief       EP stall lock function to avoid stall clear by USB SET FEATURE request.
+ *
+ * @param[in]   u32EpBitmap    Use bitmap to select which endpoints will be locked
+ *
+ *
+ * @details     This function is used to lock relative endpoint to avoid stall clear by SET FEATURE request.
+ *              If ep stall locked, user needs to reset USB device or re-configure device to clear it.
+ */
+void USBD_LockEpStall(uint32_t u32EpBitmap)
+{
+    g_USBD_u32EpStallLock = u32EpBitmap;
+}
+
+/** @} end of group USBD_EXPORTED_FUNCTIONS */
+
+/** @} end of group USBD_Driver */
+
+/** @} end of group Standard_Driver */
+
+#ifdef __cplusplus
+}
+#endif
+
+/*** (C) COPYRIGHT 2019 Nuvoton Technology Corp. ***/

--- a/hal/m258ke/nuvoton/usbd.c
+++ b/hal/m258ke/nuvoton/usbd.c
@@ -108,6 +108,24 @@ void USBD_Start(void)
 }
 
 /**
+  * @brief      To support byte access between USB SRAM and system SRAM
+  *
+  * @param[in]  dest Destination pointer.
+  *
+  * @param[in]  src  Source pointer.
+  *
+  * @param[in]  size Byte count.
+  *
+  *
+  * @details    This function will copy the number of data specified by size and src parameters to the address specified by dest parameter.
+  *
+  */
+void USBD_MemCopy(uint8_t *dest, uint8_t *src, uint32_t size)
+{
+    while (size--) *dest++ = *src++;
+}
+
+/**
   * @brief      Get the received SETUP packet
   *
   * @param[in]  buf A buffer pointer used to store 8-byte SETUP packet.

--- a/hal/m258ke/nuvoton/usbd.c
+++ b/hal/m258ke/nuvoton/usbd.c
@@ -101,10 +101,10 @@ void USBD_Start(void)
     USBD_CLR_SE0();
 
     /* Clear USB-related interrupts before enable interrupt */
-    USBD_CLR_INT_FLAG(USBD_INT_BUS | USBD_INT_USB | USBD_INT_FLDET | USBD_INT_WAKEUP);
+    USBD_CLR_INT_FLAG(USBD_INT_BUS | USBD_INT_USB | USBD_INTEN_WKEN_Msk);
 
     /* Enable USB-related interrupts. */
-    USBD_ENABLE_INT(USBD_INT_BUS | USBD_INT_USB | USBD_INT_FLDET | USBD_INT_WAKEUP);
+    USBD_ENABLE_INT(USBD_INT_BUS | USBD_INT_USB | USBD_INTEN_WKEN_Msk);
 }
 
 /**

--- a/hal/m258ke/nuvoton/usbd.c
+++ b/hal/m258ke/nuvoton/usbd.c
@@ -9,6 +9,7 @@
 
 #include <string.h>
 #include "NuMicro.h"
+#include "usbd.h"
 
 #if 0
     #define DBG_PRINTF      printf

--- a/hal/m258ke/nuvoton/usbd.h
+++ b/hal/m258ke/nuvoton/usbd.h
@@ -1,0 +1,671 @@
+/******************************************************************************
+ * @file     usbd.h
+ * @version  V0.10
+ * @brief    M251 series USB driver header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ ******************************************************************************/
+
+#ifndef __USBD_H__
+#define __USBD_H__
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*!< Definition for enabling Link Power Management(LPM) function.
+    LPM related handler will raise after LPM event happen.
+    if bcdUSB >= 0x0201, USB version is equal or higher than 2.1,
+    OS(Windows) will issue "get BOS descriptor" request to check the support of LPM.
+
+    Notice:
+        If bcdUSB >= 0x0201, where USB version is equal or higher than 2.1,
+        WIN8 ~ WIN10 will fail to enumerate the device if device stalls the "get BOS descriptor" request.
+        WIN7 can still enumerate this device even though the "get BOS descriptor" request been stalled.
+
+*/
+//#define SUPPORT_LPM
+
+/** @addtogroup Standard_Driver Standard Driver
+  @{
+*/
+
+/** @addtogroup USBD_Driver USBD Driver
+  @{
+*/
+
+/** @addtogroup USBD_EXPORTED_STRUCTS USBD Exported Structs
+  @{
+*/
+typedef struct s_usbd_info
+{
+    uint8_t *gu8DevDesc;            /*!< Pointer for USB Device Descriptor          */
+    uint8_t *gu8ConfigDesc;         /*!< Pointer for USB Configuration Descriptor   */
+    uint8_t **gu8StringDesc;        /*!< Pointer for USB String Descriptor pointers */
+    uint8_t **gu8HidReportDesc;     /*!< Pointer for USB HID Report Descriptor      */
+    uint8_t *gu8BosDesc;            /*!< Pointer for USB BOS Descriptor             */
+    uint32_t *gu32HidReportSize;    /*!< Pointer for HID Report descriptor Size     */
+    uint32_t *gu32ConfigHidDescIdx; /*!< Pointer for HID Descriptor start index     */
+} S_USBD_INFO_T; /*!< Device description structure */
+
+extern const S_USBD_INFO_T gsInfo;
+
+/** @} end of group USBD_EXPORTED_STRUCTS */
+
+
+
+
+/** @addtogroup USBD_EXPORTED_CONSTANTS USBD Exported Constants
+  @{
+*/
+#define USBD_BUF_BASE   (USBD_BASE+0x100ul) /*!< USBD buffer base address \hideinitializer */
+#define USBD_MAX_EP     12ul                /*!< Total EP number \hideinitializer          */
+
+#define EP0     0ul       /*!< Endpoint  0 \hideinitializer */
+#define EP1     1ul       /*!< Endpoint  1 \hideinitializer */
+#define EP2     2ul       /*!< Endpoint  2 \hideinitializer */
+#define EP3     3ul       /*!< Endpoint  3 \hideinitializer */
+#define EP4     4ul       /*!< Endpoint  4 \hideinitializer */
+#define EP5     5ul       /*!< Endpoint  5 \hideinitializer */
+#define EP6     6ul       /*!< Endpoint  6 \hideinitializer */
+#define EP7     7ul       /*!< Endpoint  7 \hideinitializer */
+#define EP8     8ul       /*!< Endpoint  8 \hideinitializer */
+#define EP9     9ul       /*!< Endpoint  9 \hideinitializer */
+#define EP10    10ul      /*!< Endpoint 10 \hideinitializer */
+#define EP11    11ul      /*!< Endpoint 11 \hideinitializer */
+
+/*!<USB Request Type */
+#define REQ_STANDARD        0x00ul
+#define REQ_CLASS           0x20ul
+#define REQ_VENDOR          0x40ul
+
+/*!<USB Standard Request */
+#define GET_STATUS          0x00ul
+#define CLEAR_FEATURE       0x01ul
+#define SET_FEATURE         0x03ul
+#define SET_ADDRESS         0x05ul
+#define GET_DESCRIPTOR      0x06ul
+#define SET_DESCRIPTOR      0x07ul
+#define GET_CONFIGURATION   0x08ul
+#define SET_CONFIGURATION   0x09ul
+#define GET_INTERFACE       0x0Aul
+#define SET_INTERFACE       0x0Bul
+#define SYNC_FRAME          0x0Cul
+
+/*!<USB Descriptor Type */
+#define DESC_DEVICE         0x01ul
+#define DESC_CONFIG         0x02ul
+#define DESC_STRING         0x03ul
+#define DESC_INTERFACE      0x04ul
+#define DESC_ENDPOINT       0x05ul
+#define DESC_QUALIFIER      0x06ul
+#define DESC_OTHERSPEED     0x07ul
+#define DESC_IFPOWER        0x08ul
+#define DESC_OTG            0x09ul
+#define DESC_BOS            0x0Ful
+#define DESC_CAPABILITY     0x10ul
+
+/*!<USB Device Capability Type */
+#define CAP_WIRELESS        0x01ul
+#define CAP_USB20_EXT       0x02ul
+
+/*!<USB HID Descriptor Type */
+#define DESC_HID            0x21ul
+#define DESC_HID_RPT        0x22ul
+
+/*!<USB Descriptor Length */
+#define LEN_DEVICE          18ul
+#define LEN_QUALIFIER       10ul
+#define LEN_CONFIG          9ul
+#define LEN_INTERFACE       9ul
+#define LEN_ENDPOINT        7ul
+#define LEN_OTG             5ul
+#define LEN_BOS             5ul
+#define LEN_HID             9ul
+#define LEN_CCID            0x36ul
+#define LEN_DEVCAP          7ul
+
+/*!<USB Endpoint Type */
+#define EP_ISO              0x01ul
+#define EP_BULK             0x02ul
+#define EP_INT              0x03ul
+
+#define EP_INPUT            0x80ul
+#define EP_OUTPUT           0x00ul
+
+/*!<USB Feature Selector */
+#define FEATURE_DEVICE_REMOTE_WAKEUP    0x01ul
+#define FEATURE_ENDPOINT_HALT           0x00ul
+
+/******************************************************************************/
+/*                USB Specific Macros                                         */
+/******************************************************************************/
+#define USBD_WAKEUP_EN          USBD_INTEN_WKEN_Msk         /*!< USB Wake-up Enable */
+#define USBD_DRVSE0             USBD_SE0_SE0_Msk            /*!< Drive SE0          */
+
+#define USBD_DPPU_EN            USBD_ATTR_DPPUEN_Msk        /*!< USB D+ Pull-up Enable */
+#define USBD_PWRDN              USBD_ATTR_PWRDN_Msk         /*!< PHY Turn-On           */
+#define USBD_PHY_EN             USBD_ATTR_PHYEN_Msk         /*!< PHY Enable            */
+#define USBD_USB_EN             USBD_ATTR_USBEN_Msk         /*!< USB Enable            */
+#define USBD_RWAKEUP            USBD_ATTR_RWAKEUP_Msk       /*!< Remote Wake Up Enable */
+#define USBD_LPMACK             USBD_ATTR_LPMACK_Msk        /*!< LPM Enable            */
+#define USBD_BYTEM              USBD_ATTR_BYTEM_Msk         /*!< Byte Mode Enable      */
+
+#define USBD_INT_BUS            USBD_INTEN_BUSIEN_Msk       /*!< USB Bus Event Interrupt      */
+#define USBD_INT_USB            USBD_INTEN_USBIEN_Msk       /*!< USB Event Interrupt          */
+#define USBD_INT_FLDET          USBD_INTEN_VBDETIEN_Msk     /*!< USB VBUS Detection Interrupt */
+#define USBD_INT_WAKEUP         (USBD_INTEN_NEVWKIEN_Msk | USBD_INTEN_WKEN_Msk)  /*!< USB No-Event-Wake-Up Interrupt */
+
+#define USBD_INTSTS_WAKEUP      USBD_INTSTS_NEVWKIF_Msk     /*!< USB No-Event-Wake-Up Interrupt Status */
+#define USBD_INTSTS_FLDET       USBD_INTSTS_VBDETIF_Msk     /*!< USB Float Detect Interrupt Status */
+#define USBD_INTSTS_BUS         USBD_INTSTS_BUSIF_Msk       /*!< USB Bus Event Interrupt Status */
+#define USBD_INTSTS_USB         USBD_INTSTS_USBIF_Msk       /*!< USB Event Interrupt Status */
+#define USBD_INTSTS_SETUP       USBD_INTSTS_SETUP_Msk       /*!< USB Setup Event */
+#define USBD_INTSTS_EP0         USBD_INTSTS_EPEVT0_Msk      /*!< USB Endpoint 0 Event */
+#define USBD_INTSTS_EP1         USBD_INTSTS_EPEVT1_Msk      /*!< USB Endpoint 1 Event */
+#define USBD_INTSTS_EP2         USBD_INTSTS_EPEVT2_Msk      /*!< USB Endpoint 2 Event */
+#define USBD_INTSTS_EP3         USBD_INTSTS_EPEVT3_Msk      /*!< USB Endpoint 3 Event */
+#define USBD_INTSTS_EP4         USBD_INTSTS_EPEVT4_Msk      /*!< USB Endpoint 4 Event */
+#define USBD_INTSTS_EP5         USBD_INTSTS_EPEVT5_Msk      /*!< USB Endpoint 5 Event */
+#define USBD_INTSTS_EP6         USBD_INTSTS_EPEVT6_Msk      /*!< USB Endpoint 6 Event */
+#define USBD_INTSTS_EP7         USBD_INTSTS_EPEVT7_Msk      /*!< USB Endpoint 7 Event */
+#define USBD_INTSTS_EP8         USBD_INTSTS_EPEVT8_Msk      /*!< USB Endpoint 8 Event */
+#define USBD_INTSTS_EP9         USBD_INTSTS_EPEVT9_Msk      /*!< USB Endpoint 9 Event */
+#define USBD_INTSTS_EP10        USBD_INTSTS_EPEVT10_Msk     /*!< USB Endpoint 10 Event */
+#define USBD_INTSTS_EP11        USBD_INTSTS_EPEVT11_Msk     /*!< USB Endpoint 11 Event */
+
+#define USBD_STATE_USBRST       USBD_ATTR_USBRST_Msk        /*!< USB Bus Reset      */
+#define USBD_STATE_SUSPEND      USBD_ATTR_SUSPEND_Msk       /*!< USB Bus Suspend    */
+#define USBD_STATE_RESUME       USBD_ATTR_RESUME_Msk        /*!< USB Bus Resume     */
+#define USBD_STATE_TIMEOUT      USBD_ATTR_TOUT_Msk          /*!< USB Bus Timeout    */
+#define USBD_STATE_L1RESUME     USBD_ATTR_L1RESUME_Msk      /*!< USB Bus L1RESUME   */
+#define USBD_STATE_L1SUSPEND    USBD_ATTR_L1SUSPEND_Msk     /*!< USB BUS L1SUSPEND  */
+
+#define USBD_CFGP_SSTALL        USBD_CFGP_SSTALL_Msk        /*!< Set Stall */
+#define USBD_CFG_CSTALL         USBD_CFG_CSTALL_Msk         /*!< Clear Stall */
+
+#define USBD_CFG_EPMODE_DISABLE (0ul << USBD_CFG_STATE_Pos) /*!< Endpoint Disable */
+#define USBD_CFG_EPMODE_OUT     (1ul << USBD_CFG_STATE_Pos) /*!< Out Endpoint     */
+#define USBD_CFG_EPMODE_IN      (2ul << USBD_CFG_STATE_Pos) /*!< In Endpoint      */
+#define USBD_CFG_TYPE_ISO       (1ul << USBD_CFG_ISOCH_Pos) /*!< Isochronous      */
+
+/** @} end of group USBD_EXPORTED_CONSTANTS */
+
+
+/** @addtogroup USBD_EXPORTED_FUNCTIONS USBD Exported Functions
+  @{
+*/
+
+/**
+  * @brief      Compare two input numbers and return maximum one.
+  *
+  * @param[in]  a   First number to be compared.
+  * @param[in]  b   Second number to be compared.
+  *
+  * @return     Maximum value between a and b.
+  *
+  * @details    If a > b, then return a. Otherwise, return b.
+  */
+#define USBD_Maximum(a,b)        ((a)>(b) ? (a) : (b))
+
+
+/**
+  * @brief      Compare two input numbers and return minimum one
+  *
+  * @param[in]  a   First number to be compared
+  * @param[in]  b   Second number to be compared
+  *
+  * @return     Minimum value between a and b
+  *
+  * @details    If a < b, then return a. Otherwise, return b.
+  */
+#define USBD_Minimum(a,b)        ((a)<(b) ? (a) : (b))
+
+
+/**
+  * @brief    Enable USB
+  *
+  *
+  *
+  * @details  To set USB ATTR control register to enable USB and PHY.
+  *
+  */
+#define USBD_ENABLE_USB()           ((uint32_t)(USBD->ATTR |= 0x7D0))
+
+/**
+  * @brief    Disable USB
+  *
+  *
+  *
+  * @details  To set USB ATTR control register to disable USB.
+  *
+  */
+#define USBD_DISABLE_USB()          ((uint32_t)(USBD->ATTR &= ~USBD_USB_EN))
+
+/**
+  * @brief    Enable USB PHY
+  *
+  *
+  *
+  * @details  To set USB ATTR control register to enable USB PHY.
+  *
+  */
+#define USBD_ENABLE_PHY()           ((uint32_t)(USBD->ATTR |= USBD_PHY_EN))
+
+/**
+  * @brief    Disable USB PHY
+  *
+  *
+  *
+  * @details  To set USB ATTR control register to disable USB PHY.
+  *
+  */
+#define USBD_DISABLE_PHY()          ((uint32_t)(USBD->ATTR &= ~USBD_PHY_EN))
+
+/**
+  * @brief    Enable SE0. Force USB PHY transceiver to drive SE0.
+  *
+  *
+  *
+  * @details  Set DRVSE0 bit of USB_DRVSE0 register to enable software-disconnect function. Force USB PHY transceiver to drive SE0 to bus.
+  *
+  */
+#define USBD_SET_SE0()              ((uint32_t)(USBD->SE0 |= USBD_DRVSE0))
+
+/**
+  * @brief    Disable SE0
+  *
+  *
+  *
+  * @details  Clear DRVSE0 bit of USB_DRVSE0 register to disable software-disconnect function.
+  *
+  */
+#define USBD_CLR_SE0()              ((uint32_t)(USBD->SE0 &= ~USBD_DRVSE0))
+
+/**
+  * @brief       Set USB device address
+  *
+  * @param[in]   addr The USB device address.
+  *
+  *
+  * @details     Write USB device address to USB_FADDR register.
+  *
+  */
+#define USBD_SET_ADDR(addr)         (USBD->FADDR = (addr))
+
+/**
+  * @brief    Get USB device address
+  *
+  *
+  * @return   USB device address
+  *
+  * @details  Read USB_FADDR register to get USB device address.
+  *
+  */
+#define USBD_GET_ADDR()             ((uint32_t)(USBD->FADDR))
+
+/**
+  * @brief      Enable USB interrupt function
+  *
+  * @param[in]  intr The combination of the specified interrupt enable bits.
+  *             Each bit corresponds to a interrupt enable bit.
+  *             This parameter decides which interrupts will be enabled.
+  *             (USBD_INT_WAKEUP, USBD_INT_FLDET, USBD_INT_USB, USBD_INT_BUS)
+  *
+  *
+  * @details    Enable USB related interrupt functions specified by intr parameter.
+  *
+  */
+#define USBD_ENABLE_INT(intr)       (USBD->INTEN |= (intr))
+
+/**
+  * @brief    Get interrupt status
+  *
+  *
+  * @return   The value of USB_INTSTS register
+  *
+  * @details  Return all interrupt flags of USB_INTSTS register.
+  *
+  */
+#define USBD_GET_INT_FLAG()         ((uint32_t)(USBD->INTSTS))
+
+/**
+  * @brief      Clear USB interrupt flag
+  *
+  * @param[in]  flag The combination of the specified interrupt flags.
+  *             Each bit corresponds to a interrupt source.
+  *             This parameter decides which interrupt flags will be cleared.
+  *             (USBD_INTSTS_WAKEUP, USBD_INTSTS_FLDET, USBD_INTSTS_BUS, USBD_INTSTS_USB)
+  *
+  *
+  * @details    Clear USB related interrupt flags specified by flag parameter.
+  *
+  */
+#define USBD_CLR_INT_FLAG(flag)     (USBD->INTSTS = (flag))
+
+/**
+  * @brief    Get endpoint status
+  *
+  *
+  * @return   The value of USB_EPSTS register.
+  *
+  * @details  Return all endpoint status.
+  *
+  */
+#define USBD_GET_EP_FLAG()          ((uint32_t)(USBD->EPSTS))
+
+/**
+  * @brief    Get USB bus state
+  *
+  *
+  * @return   The value of USB_ATTR[3:0] and USB_ATTR[13:12].
+  *           Bit  0 indicates USB bus reset status.
+  *           Bit  1 indicates USB bus suspend status.
+  *           Bit  2 indicates USB bus resume status.
+  *           Bit  3 indicates USB bus time-out status.
+  *           Bit 12 indicates USB bus LPM L1 suspend status.
+  *           Bit 13 indicates USB bus LPM L1 resume status.
+  *
+  * @details  Return USB_ATTR[3:0] and USB_ATTR[13:12] for USB bus events.
+  *
+  * \hideinitializer
+  */
+#define USBD_GET_BUS_STATE()        ((uint32_t)(USBD->ATTR & 0x300f))
+
+
+/**
+  * @brief    Check cable connection state
+  *
+  *
+  * @retval   0 USB cable is not attached.
+  * @retval   1 USB cable is attached.
+  *
+  * @details  Check the connection state by FLDET bit of USB_FLDET register.
+  *
+  */
+#define USBD_IS_ATTACHED()          ((uint32_t)(USBD->VBUSDET & USBD_VBUSDET_VBUSDET_Msk))
+
+/**
+  * @brief      Stop USB transaction of the specified endpoint ID
+  *
+  * @param[in]  ep The USB endpoint ID. M251 series supports 12  hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  *
+  * @details    Write 1 to CLRRDY bit of USB_CFGPx register to stop USB transaction of the specified endpoint ID.
+  *
+  */
+#define USBD_STOP_TRANSACTION(ep)   (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].CFGP + (uint32_t)((ep) << 4))) |= USBD_CFGP_CLRRDY_Msk)
+
+/**
+  * @brief      Set USB DATA1 PID for the specified endpoint ID
+  *
+  * @param[in]  ep The USB endpoint ID. M251 series supports 12  hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  *
+  * @details    Set DSQ_SYNC bit of USB_CFGx register to specify the DATA1 PID for the following IN token transaction.
+  *             Base on this setting, hardware will toggle PID between DATA0 and DATA1 automatically for IN token transactions.
+  *
+  */
+#define USBD_SET_DATA1(ep)          (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].CFG + (uint32_t)((ep) << 4))) |= USBD_CFG_DSQSYNC_Msk)
+
+/**
+  * @brief      Set USB DATA0 PID for the specified endpoint ID
+  *
+  * @param[in]  ep The USB endpoint ID. M251 series supports 12  hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  *
+  * @details    Clear DSQ_SYNC bit of USB_CFGx register to specify the DATA0 PID for the following IN token transaction.
+  *             Base on this setting, hardware will toggle PID between DATA0 and DATA1 automatically for IN token transactions.
+  *
+  */
+#define USBD_SET_DATA0(ep)          (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].CFG + (uint32_t)((ep) << 4))) &= (~USBD_CFG_DSQSYNC_Msk))
+
+/**
+  * @brief      Set USB payload size (IN data)
+  *
+  * @param[in]  ep The USB endpoint ID. M251 series supports 12  hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  * @param[in]  size The transfer length.
+  *
+  *
+  * @details    This macro will write the transfer length to USB_MXPLDx register for IN data transaction.
+  *
+  */
+#define USBD_SET_PAYLOAD_LEN(ep, size)  (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].MXPLD + (uint32_t)((ep) << 4))) = (size))
+
+/**
+  * @brief      Get USB payload size (OUT data)
+  *
+  * @param[in]  ep The USB endpoint ID. M251 series supports 12 endpoint ID. This parameter could be 0 ~ 11.
+  *
+  * @return     The value of USB_MXPLDx register.
+  *
+  * @details    Get the data length of OUT data transaction by reading USB_MXPLDx register.
+  *
+  */
+#define USBD_GET_PAYLOAD_LEN(ep)        ((uint32_t)*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].MXPLD + (uint32_t)((ep) << 4))))
+
+/**
+  * @brief      Configure endpoint
+  *
+  * @param[in]  ep The USB endpoint ID. M251 series supports 12  hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  * @param[in]  config The USB configuration.
+  *
+  *
+  * @details    This macro will write config parameter to USB_CFGx register of specified endpoint ID.
+  *
+  */
+#define USBD_CONFIG_EP(ep, config)      (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].CFG + (uint32_t)((ep) << 4))) = (config))
+
+/**
+  * @brief      Set USB endpoint buffer
+  *
+  * @param[in]  ep The USB endpoint ID. M251 series supports 12  hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  * @param[in]  offset The SRAM offset.
+  *
+  *
+  * @details    This macro will set the SRAM offset for the specified endpoint ID.
+  *
+  */
+#define USBD_SET_EP_BUF_ADDR(ep, offset)    (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].BUFSEG + (uint32_t)((ep) << 4))) = (offset))
+
+/**
+  * @brief      Get the offset of the specified USB endpoint buffer
+  *
+  @param[in]  ep The USB endpoint ID. M251 series supports 12  hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  * @return     The offset of the specified endpoint buffer.
+  *
+  * @details    This macro will return the SRAM offset of the specified endpoint ID.
+  *
+  */
+#define USBD_GET_EP_BUF_ADDR(ep)        ((uint32_t)*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].BUFSEG + (uint32_t)((ep) << 4))))
+
+/**
+  * @brief       Set USB endpoint stall state
+  *
+  * @param[in]   ep  The USB endpoint ID. M251 series supports 12 hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  *
+  * @details     Set USB endpoint stall state for the specified endpoint ID. Endpoint will respond STALL token automatically.
+  *
+  */
+#define USBD_SET_EP_STALL(ep)        (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].CFGP + (uint32_t)((ep) << 4))) |= USBD_CFGP_SSTALL_Msk)
+
+/**
+  * @brief       Clear USB endpoint stall state
+  *
+  * @param[in]   ep  The USB endpoint ID. M251 series supports 12 hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  *
+  * @details     Clear USB endpoint stall state for the specified endpoint ID. Endpoint will respond ACK/NAK token.
+  */
+#define USBD_CLR_EP_STALL(ep)        (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].CFGP + (uint32_t)((ep) << 4))) &= ~USBD_CFGP_SSTALL_Msk)
+
+/**
+  * @brief       Get USB endpoint stall state
+  *
+  * @param[in]   ep  The USB endpoint ID. M251 series supports 12 hardware endpoint ID. This parameter could be 0 ~ 11.
+  *
+  * @retval      0      USB endpoint is not stalled.
+  * @retval      Others USB endpoint is stalled.
+  *
+  * @details     Get USB endpoint stall state of the specified endpoint ID.
+  *
+  */
+#define USBD_GET_EP_STALL(ep)        (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].CFGP + (uint32_t)((ep) << 4))) & USBD_CFGP_SSTALL_Msk)
+
+/**
+  * @brief      To support byte access between USB SRAM and system SRAM
+  *
+  * @param[in]  dest Destination pointer.
+  *
+  * @param[in]  src  Source pointer.
+  *
+  * @param[in]  size Byte count.
+  *
+  *
+  * @details    This function will copy the number of data specified by size and src parameters to the address specified by dest parameter.
+  *
+  */
+__STATIC_INLINE void USBD_MemCopy(uint8_t *dest, uint8_t *src, uint32_t size)
+{
+    while (size--) *dest++ = *src++;
+}
+
+
+/**
+  * @brief       Set USB endpoint stall state
+  *
+  * @param[in]   epnum  USB endpoint number
+  *
+  *
+  * @details     Set USB endpoint stall state. Endpoint will respond STALL token automatically.
+  *
+  */
+__STATIC_INLINE void USBD_SetStall(uint8_t epnum)
+{
+    uint32_t i;
+
+    for (i = 0ul; i < USBD_MAX_EP; i++)
+    {
+        uint32_t u32CfgAddr;
+        uint32_t u32Cfg;
+        u32CfgAddr = (uint32_t)(i << 4) + (uint32_t)&USBD->EP[0].CFG; /* USBD_CFG0 */
+        u32Cfg = *((__IO uint32_t *)(u32CfgAddr));
+
+        if ((u32Cfg & 0xful) == epnum)
+        {
+            u32CfgAddr = (uint32_t)(i << 4) + (uint32_t)&USBD->EP[0].CFGP; /* USBD_CFGP0 */
+            u32Cfg = *((__IO uint32_t *)(u32CfgAddr));
+
+            *((__IO uint32_t *)(u32CfgAddr)) = (u32Cfg | USBD_CFGP_SSTALL);
+            break;
+        }
+    }
+}
+
+/**
+  * @brief       Clear USB endpoint stall state
+  *
+  * @param[in]   epnum  USB endpoint number
+  *
+  *
+  * @details     Clear USB endpoint stall state. Endpoint will respond ACK/NAK token.
+  */
+__STATIC_INLINE void USBD_ClearStall(uint8_t epnum)
+{
+    uint32_t i;
+
+    for (i = 0ul; i < USBD_MAX_EP; i++)
+    {
+        uint32_t u32CfgAddr;
+        uint32_t u32Cfg;
+        u32CfgAddr = (uint32_t)(i << 4) + (uint32_t)&USBD->EP[0].CFG; /* USBD_CFG0 */
+        u32Cfg = *((__IO uint32_t *)(u32CfgAddr));
+
+        if ((u32Cfg & 0xful) == epnum)
+        {
+            u32CfgAddr = (uint32_t)(i << 4) + (uint32_t)&USBD->EP[0].CFGP; /* USBD_CFGP0 */
+            u32Cfg = *((__IO uint32_t *)(u32CfgAddr));
+
+            *((__IO uint32_t *)(u32CfgAddr)) = (u32Cfg & ~USBD_CFGP_SSTALL);
+            break;
+        }
+    }
+}
+
+/**
+  * @brief       Get USB endpoint stall state
+  *
+  * @param[in]   epnum  USB endpoint number
+  *
+  * @retval      0      USB endpoint is not stalled.
+  * @retval      Others USB endpoint is stalled.
+  *
+  * @details     Get USB endpoint stall state.
+  *
+  */
+__STATIC_INLINE uint32_t USBD_GetStall(uint8_t epnum)
+{
+    uint32_t u32CfgAddr;
+    uint32_t u32Cfg;
+    uint32_t i;
+
+    for (i = 0ul; i < USBD_MAX_EP; i++)
+    {
+        u32CfgAddr = (uint32_t)(i << 4ul) + (uint32_t)&USBD->EP[0].CFG; /* USBD_CFG0 */
+        u32Cfg = *((__IO uint32_t *)(u32CfgAddr));
+
+        if ((u32Cfg & 0xful) == epnum)
+        {
+            u32CfgAddr = (uint32_t)(i << 4ul) + (uint32_t)&USBD->EP[0].CFGP; /* USBD_CFGP0 */
+            break;
+        }
+    }
+
+    return ((*((__IO uint32_t *)(u32CfgAddr))) & USBD_CFGP_SSTALL);
+}
+
+
+extern volatile uint8_t g_USBD_u8RemoteWakeupEn;
+
+
+typedef void (*VENDOR_REQ)(void);                               /*!< Functional pointer type definition for Vendor class                                    */
+typedef void (*CLASS_REQ)(void);                                /*!< Functional pointer type declaration for USB class request callback handler             */
+typedef void (*SET_INTERFACE_REQ)(uint32_t u32AltInterface);    /*!< Functional pointer type declaration for USB set interface request callback handler     */
+typedef void (*SET_CONFIG_CB)(void);                            /*!< Functional pointer type declaration for USB set configuration request callback handler */
+
+
+/*--------------------------------------------------------------------*/
+void USBD_Open(const S_USBD_INFO_T *param, CLASS_REQ pfnClassReq, SET_INTERFACE_REQ pfnSetInterface);
+void USBD_Start(void);
+void USBD_GetSetupPacket(uint8_t *buf);
+void USBD_ProcessSetupPacket(void);
+void USBD_StandardRequest(void);
+void USBD_PrepareCtrlIn(uint8_t pu8Buf[], uint32_t u32Size);
+void USBD_CtrlIn(void);
+void USBD_PrepareCtrlOut(uint8_t *pu8Buf, uint32_t u32Size);
+void USBD_CtrlOut(void);
+void USBD_SwReset(void);
+void USBD_SetVendorRequest(VENDOR_REQ pfnVendorReq);
+void USBD_SetConfigCallback(SET_CONFIG_CB pfnSetConfigCallback);
+void USBD_LockEpStall(uint32_t u32EpBitmap);
+
+/** @} end of group USBD_EXPORTED_FUNCTIONS */
+
+/** @} end of group USBD_Driver */
+
+/** @} end of group Standard_Driver */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __USBD_H__ */
+
+/*** (C) COPYRIGHT 2020 Nuvoton Technology Corp. ***/

--- a/hal/m258ke/nuvoton/usbd.h
+++ b/hal/m258ke/nuvoton/usbd.h
@@ -41,9 +41,9 @@ extern "C"
 */
 typedef struct s_usbd_info
 {
-    uint8_t *gu8DevDesc;            /*!< Pointer for USB Device Descriptor          */
-    uint8_t *gu8ConfigDesc;         /*!< Pointer for USB Configuration Descriptor   */
-    uint8_t **gu8StringDesc;        /*!< Pointer for USB String Descriptor pointers */
+    uint8_t const *gu8DevDesc;            /*!< Pointer for USB Device Descriptor          */
+    uint8_t const *gu8ConfigDesc;         /*!< Pointer for USB Configuration Descriptor   */
+    uint8_t const * const *gu8StringDesc; /*!< Pointer for USB String Descriptor pointers */
 } S_USBD_INFO_T; /*!< Device description structure */
 
 extern const S_USBD_INFO_T gsInfo;

--- a/hal/m258ke/nuvoton/usbd.h
+++ b/hal/m258ke/nuvoton/usbd.h
@@ -515,24 +515,6 @@ extern const S_USBD_INFO_T gsInfo;
   */
 #define USBD_GET_EP_STALL(ep)        (*((__IO uint32_t *) ((uint32_t)&USBD->EP[0].CFGP + (uint32_t)((ep) << 4))) & USBD_CFGP_SSTALL_Msk)
 
-/**
-  * @brief      To support byte access between USB SRAM and system SRAM
-  *
-  * @param[in]  dest Destination pointer.
-  *
-  * @param[in]  src  Source pointer.
-  *
-  * @param[in]  size Byte count.
-  *
-  *
-  * @details    This function will copy the number of data specified by size and src parameters to the address specified by dest parameter.
-  *
-  */
-__STATIC_INLINE void USBD_MemCopy(uint8_t *dest, uint8_t *src, uint32_t size)
-{
-    while (size--) *dest++ = *src++;
-}
-
 
 /**
   * @brief       Set USB endpoint stall state
@@ -638,6 +620,7 @@ typedef void (*CLASS_REQ)(void);                                /*!< Functional 
 /*--------------------------------------------------------------------*/
 void USBD_Open(const S_USBD_INFO_T *param, CLASS_REQ pfnClassReq);
 void USBD_Start(void);
+void USBD_MemCopy(uint8_t *dest, uint8_t *src, uint32_t size);
 void USBD_GetSetupPacket(uint8_t *buf);
 void USBD_ProcessSetupPacket(void);
 void USBD_StandardRequest(void);

--- a/hal/m258ke/nuvoton/usbd.h
+++ b/hal/m258ke/nuvoton/usbd.h
@@ -44,10 +44,6 @@ typedef struct s_usbd_info
     uint8_t *gu8DevDesc;            /*!< Pointer for USB Device Descriptor          */
     uint8_t *gu8ConfigDesc;         /*!< Pointer for USB Configuration Descriptor   */
     uint8_t **gu8StringDesc;        /*!< Pointer for USB String Descriptor pointers */
-    uint8_t **gu8HidReportDesc;     /*!< Pointer for USB HID Report Descriptor      */
-    uint8_t *gu8BosDesc;            /*!< Pointer for USB BOS Descriptor             */
-    uint32_t *gu32HidReportSize;    /*!< Pointer for HID Report descriptor Size     */
-    uint32_t *gu32ConfigHidDescIdx; /*!< Pointer for HID Descriptor start index     */
 } S_USBD_INFO_T; /*!< Device description structure */
 
 extern const S_USBD_INFO_T gsInfo;
@@ -637,12 +633,10 @@ extern volatile uint8_t g_USBD_u8RemoteWakeupEn;
 
 typedef void (*VENDOR_REQ)(void);                               /*!< Functional pointer type definition for Vendor class                                    */
 typedef void (*CLASS_REQ)(void);                                /*!< Functional pointer type declaration for USB class request callback handler             */
-typedef void (*SET_INTERFACE_REQ)(uint32_t u32AltInterface);    /*!< Functional pointer type declaration for USB set interface request callback handler     */
-typedef void (*SET_CONFIG_CB)(void);                            /*!< Functional pointer type declaration for USB set configuration request callback handler */
 
 
 /*--------------------------------------------------------------------*/
-void USBD_Open(const S_USBD_INFO_T *param, CLASS_REQ pfnClassReq, SET_INTERFACE_REQ pfnSetInterface);
+void USBD_Open(const S_USBD_INFO_T *param, CLASS_REQ pfnClassReq);
 void USBD_Start(void);
 void USBD_GetSetupPacket(uint8_t *buf);
 void USBD_ProcessSetupPacket(void);
@@ -652,8 +646,6 @@ void USBD_CtrlIn(void);
 void USBD_PrepareCtrlOut(uint8_t *pu8Buf, uint32_t u32Size);
 void USBD_CtrlOut(void);
 void USBD_SwReset(void);
-void USBD_SetVendorRequest(VENDOR_REQ pfnVendorReq);
-void USBD_SetConfigCallback(SET_CONFIG_CB pfnSetConfigCallback);
 void USBD_LockEpStall(uint32_t u32EpBitmap);
 
 /** @} end of group USBD_EXPORTED_FUNCTIONS */

--- a/hal/m258ke/nuvoton/usbd_reg.h
+++ b/hal/m258ke/nuvoton/usbd_reg.h
@@ -1,0 +1,722 @@
+/**************************************************************************//**
+ * @file     usbd_reg.h
+ * @version  V1.00
+ * @brief    USBD register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2020 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __USBD_REG_H__
+#define __USBD_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup USBD USB Device Controller (USBD)
+    Memory Mapped Structure for USBD Controller
+    @{
+*/
+
+typedef struct
+{
+    /**
+     * @var USBD_EP_T::BUFSEG
+     * Offset: 0x000  Endpoint n Buffer Segmentation Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:3]   |BUFSEG    |Endpoint Buffer Segmentation
+     * |        |          |It is used to indicate the offset address for each endpoint with the USB SRAM starting address The effective starting address of the endpoint is
+     * |        |          |USBD_SRAM address + { BUFSEG, 3'b000}
+     * |        |          |Where the USBD_SRAM address = USBD_BA+0x100h.
+     * |        |          |Refer to the section 1.1.5.7 for the endpoint SRAM structure and its description.
+     * @var USBD_EP_T::MXPLD
+     * Offset: 0x004  Endpoint n Maximal Payload Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:0]   |MXPLD     |Maximal Payload
+     * |        |          |Define the data length which is transmitted to host (IN token) or the actual data length which is received from the host (OUT token)
+     * |        |          |It also used to indicate that the endpoint is ready to be transmitted in IN token or received in OUT token.
+     * |        |          |(1) When the register is written by CPU,
+     * |        |          |For IN token, the value of MXPLD is used to define the data length to be transmitted and indicate the data buffer is ready.
+     * |        |          |For OUT token, it means that the controller is ready to receive data from the host and the value of MXPLD is the maximal data length comes from host.
+     * |        |          |(2) When the register is read by CPU,
+     * |        |          |For IN token, the value of MXPLD is indicated by the data length be transmitted to host
+     * |        |          |For OUT token, the value of MXPLD is indicated the actual data length receiving from host.
+     * |        |          |Note: Once MXPLD is written, the data packets will be transmitted/received immediately after IN/OUT token arrived.
+     * @var USBD_EP_T::CFG
+     * Offset: 0x008  Endpoint n Configuration Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |EPNUM     |Endpoint Number
+     * |        |          |These bits are used to define the endpoint number of the current endpoint
+     * |[4]     |ISOCH     |Isochronous Endpoint
+     * |        |          |This bit is used to set the endpoint as Isochronous endpoint, no handshake.
+     * |        |          |0 = No Isochronous endpoint.
+     * |        |          |1 = Isochronous endpoint.
+     * |[6:5]   |STATE     |Endpoint STATE
+     * |        |          |00 = Endpoint is Disabled.
+     * |        |          |01 = Out endpoint.
+     * |        |          |10 = IN endpoint.
+     * |        |          |11 = Undefined.
+     * |[7]     |DSQSYNC   |Data Sequence Synchronization
+     * |        |          |0 = DATA0 PID.
+     * |        |          |1 = DATA1 PID.
+     * |        |          |Note: It is used to specify the DATA0 or DATA1 PID in the following IN token transaction
+     * |        |          |hardware will toggle automatically in IN token base on the bit.
+     * |[9]     |CSTALL    |Clear STALL Response
+     * |        |          |0 = Disable the device to clear the STALL handshake in setup stage.
+     * |        |          |1 = Clear the device to response STALL handshake in setup stage.
+     * @var USBD_EP_T::CFGP
+     * Offset: 0x00C  Endpoint n Set Stall and Clear In/Out Ready Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |CLRRDY    |Clear Ready
+     * |        |          |When the USBD_MXPLDx register is set by user, it means that the endpoint is ready to transmit or receive data
+     * |        |          |If the user wants to disable this transaction before the transaction start, users can set this bit to 1 to disable it and it is auto clear to 0.
+     * |        |          |For IN token, write '1' to clear the IN token had ready to transmit the data to USB.
+     * |        |          |For OUT token, write '1' to clear the OUT token had ready to receive the data from USB.
+     * |        |          |This bit is write 1 only and is always 0 when it is read back.
+     * |[1]     |SSTALL    |Set STALL
+     * |        |          |0 = Disable the device to response STALL.
+     * |        |          |1 = Set the device to respond STALL automatically.
+     */
+    __IO uint32_t BUFSEG;                /*!< [0x0000] Endpoint n Buffer Segmentation Register                            */
+    __IO uint32_t MXPLD;                 /*!< [0x0004] Endpoint n Maximal Payload Register                                */
+    __IO uint32_t CFG;                   /*!< [0x0008] Endpoint n Configuration Register                                  */
+    __IO uint32_t CFGP;                  /*!< [0x000c] Endpoint n Set Stall and Clear In/Out Ready Control Register       */
+
+} USBD_EP_T;
+
+typedef struct
+{
+
+
+    /**
+     * @var USBD_T::INTEN
+     * Offset: 0x00  USB Device Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BUSIEN    |Bus Event Interrupt Enable Bit
+     * |        |          |0 = BUS event interrupt Disabled.
+     * |        |          |1 = BUS event interrupt Enabled.
+     * |[1]     |USBIEN    |USB Event Interrupt Enable Bit
+     * |        |          |0 = USB event interrupt Disabled.
+     * |        |          |1 = USB event interrupt Enabled.
+     * |[2]     |VBDETIEN  |VBUS Detection Interrupt Enable Bit
+     * |        |          |0 = VBUS detection Interrupt Disabled.
+     * |        |          |1 = VBUS detection Interrupt Enabled.
+     * |[3]     |NEVWKIEN  |USB No-event-wake-up Interrupt Enable Bit
+     * |        |          |0 = No-event-wake-up Interrupt Disabled.
+     * |        |          |1 = No-event-wake-up Interrupt Enabled.
+     * |[4]     |SOFIEN    |Start of Frame Interrupt Enable Bit
+     * |        |          |0 = SOF Interrupt Disabled.
+     * |        |          |1 = SOF Interrupt Enabled.
+     * |[5]     |BCDIEN    |Battery Charge Detect Interrupt Enable Bit (Only for M258)
+     * |        |          |0 = BCD Interrupt Disabled.
+     * |        |          |1 = BCD Interrupt Enabled.
+     * |[8]     |WKEN      |Wake-up Function Enable Bit
+     * |        |          |0 = USB wake-up function Disabled.
+     * |        |          |1 = USB wake-up function Enabled.
+     * |[15]    |INNAKEN   |Active NAK Function and Its Status in IN Token
+     * |        |          |0 = When device responds NAK after receiving IN token, IN NAK status will not be updated to USBD_EPSTS0 and USBD_EPSTS1register, so that the USB interrupt event will not be asserted.
+     * |        |          |1 = IN NAK status will be updated to USBD_EPSTS0 and USBD_EPSTS1 register and the USB interrupt event will be asserted, when the device responds NAK after receiving IN token.
+     * @var USBD_T::INTSTS
+     * Offset: 0x04  USB Device Interrupt Event Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BUSIF     |BUS Interrupt Status
+     * |        |          |The BUS event means that there is one of the suspense or the resume function in the bus.
+     * |        |          |0 = No BUS event occurred.
+     * |        |          |1 = Bus event occurred; check USBD_ATTR[3:0] to know which kind of bus event was occurred, cleared by write 1 to USBD_INTSTS[0].
+     * |[1]     |USBIF     |USB Event Interrupt Status
+     * |        |          |The USB event includes the SETUP Token, IN Token, OUT ACK, ISO IN, or ISO OUT events in the bus.
+     * |        |          |0 = No USB event occurred.
+     * |        |          |1 = USB event occurred, check EPSTS0~11[3:0] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[1] or EPSTS0~11 and SETUP (USBD_INTSTS[31]).
+     * |[2]     |VBDETIF   |VBUS Detection Interrupt Status
+     * |        |          |0 = There is not attached/detached event in the USB.
+     * |        |          |1 = There is attached/detached event in the USB bus and it is cleared by write 1 to USBD_INTSTS[2].
+     * |[3]     |NEVWKIF   |No-event-wake-up Interrupt Status
+     * |        |          |0 = NEVWK event does not occur.
+     * |        |          |1 = No-event-wake-up event occurred, cleared by write 1 to USBD_INTSTS[3].
+     * |[4]     |SOFIF     |Start of Frame Interrupt Status
+     * |        |          |0 = SOF event does not occur.
+     * |        |          |1 = SOF event occurred, cleared by write 1 to USBD_INTSTS[4].
+     * |[5]     |BCDIF     |Battery Charge Detect Interrupt Status (Only for M258)
+     * |        |          |It support VBUSOK`DCD interrupt status
+     * |        |          |When USBD_BCDC[0] = 1 ,USBD_BCDC[3:1] = 001 ,VBUS detect
+     * |        |          |When USBD_BCDC[0] = 1 ,USBD_BCDC[3:1] = 010 ,DCD detect
+     * |        |          |0 = BCD event does not occur.
+     * |        |          |1 = BCD event occurred, cleared by write 1 to USBD_INTSTS[5].
+     * |[16]    |EPEVT0    |Endpoint 0's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 0.
+     * |        |          |1 = USB event occurred on Endpoint 0, check USBD_EPSTS0[3:0] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[16] or USBD_INTSTS[1].
+     * |[17]    |EPEVT1    |Endpoint 1's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 1.
+     * |        |          |1 = USB event occurred on Endpoint 1, check USBD_EPSTS0[7:4] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[17] or USBD_INTSTS[1].
+     * |[18]    |EPEVT2    |Endpoint 2's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 2.
+     * |        |          |1 = USB event occurred on Endpoint 2, check USBD_EPSTS0[11:8] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[18] or USBD_INTSTS[1].
+     * |[19]    |EPEVT3    |Endpoint 3's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 3.
+     * |        |          |1 = USB event occurred on Endpoint 3, check USBD_EPSTS0[15:12] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[19] or USBD_INTSTS[1].
+     * |[20]    |EPEVT4    |Endpoint 4's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 4.
+     * |        |          |1 = USB event occurred on Endpoint 4, check USBD_EPSTS0[19:16] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[20] or USBD_INTSTS[1].
+     * |[21]    |EPEVT5    |Endpoint 5's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 5.
+     * |        |          |1 = USB event occurred on Endpoint 5, check USBD_EPSTS0[23:20] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[21] or USBD_INTSTS[1].
+     * |[22]    |EPEVT6    |Endpoint 6's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 6.
+     * |        |          |1 = USB event occurred on Endpoint 6, check USBD_EPSTS0[27:24] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[22] or USBD_INTSTS[1].
+     * |[23]    |EPEVT7    |Endpoint 7's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 7.
+     * |        |          |1 = USB event occurred on Endpoint 7, check USBD_EPSTS0[31:28] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[23] or USBD_INTSTS[1].
+     * |[24]    |EPEVT8    |Endpoint 8's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 8.
+     * |        |          |1 = USB event occurred on Endpoint 8, check USBD_EPSTS1[3 :0] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[24] or USBD_INTSTS[1].
+     * |[25]    |EPEVT9    |Endpoint 9's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 9.
+     * |        |          |1 = USB event occurred on Endpoint 9, check USBD_EPSTS1[7 :4] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[25] or USBD_INTSTS[1].
+     * |[26]    |EPEVT10   |Endpoint 10's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 10.
+     * |        |          |1 = USB event occurred on Endpoint 10, check USBD_EPSTS1[11 :8] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[26] or USBD_INTSTS[1].
+     * |[27]    |EPEVT11   |Endpoint 11's USB Event Status
+     * |        |          |0 = No event occurred in endpoint 11.
+     * |        |          |1 = USB event occurred on Endpoint 11, check USBD_EPSTS1[15:12] to know which kind of USB event was occurred, cleared by write 1 to USBD_INTSTS[27] or USBD_INTSTS[1].
+     * |[31]    |SETUP     |Setup Event Status
+     * |        |          |0 = No Setup event.
+     * |        |          |1 = Setup event occurred, cleared by write 1 to USBD_INTSTS[31].
+     * @var USBD_T::FADDR
+     * Offset: 0x08  USB Device Function Address Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[6:0]   |FADDR     |USB Device Function Address
+     * @var USBD_T::EPSTS
+     * Offset: 0x0C  USB Device Endpoint Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7]     |OV        |Overrun
+     * |        |          |It indicates that the received data is over the maximum payload number or not.
+     * |        |          |0 = No overrun.
+     * |        |          |1 = Out Data is more than the Max Payload in MXPLD register or the Setup Data is more than 8 Bytes.
+     * @var USBD_T::ATTR
+     * Offset: 0x10  USB Device Bus Status and Attribution Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |USBRST    |USB Reset Status
+     * |        |          |0 = Bus no reset.
+     * |        |          |1 = Bus reset when SE0 (single-ended 0) more than 2.5us.
+     * |        |          |Note: This bit is read only.
+     * |[1]     |SUSPEND   |Suspend Status
+     * |        |          |0 = Bus no suspend.
+     * |        |          |1 = Bus idle more than 3ms, either cable is plugged off or host is sleeping.
+     * |        |          |Note: This bit is read only.
+     * |[2]     |RESUME    |Resume Status
+     * |        |          |0 = No bus resume.
+     * |        |          |1 = Resume from suspend.
+     * |        |          |Note: This bit is read only.
+     * |[3]     |TOUT      |Time-out Status
+     * |        |          |0 = No time-out.
+     * |        |          |1 = No Bus response more than 18 bits time (1 / 12MHz * 18 = 1.5 us).
+     * |        |          |Note: This bit is read only.
+     * |[4]     |PHYEN     |PHY Transceiver Function Enable Bit
+     * |        |          |0 = PHY transceiver function Disabled.
+     * |        |          |1 = PHY transceiver function Enabled.
+     * |[5]     |RWAKEUP   |Remote Wake-up
+     * |        |          |0 = Release the USB bus from K state.
+     * |        |          |1 = Force USB bus to K (USB_D+ low, USB_D-: high) state, used for remote wake-up.
+     * |[7]     |USBEN     |USB Controller Enable Bit
+     * |        |          |0 = USB Controller Disabled.
+     * |        |          |1 = USB Controller Enabled.
+     * |[8]     |DPPUEN    |Pull-up Resistor on USB_DP Enable Bit
+     * |        |          |0 = Pull-up resistor in USB_D+ bus Disabled.
+     * |        |          |1 = Pull-up resistor in USB_D+ bus Active.
+     * |[9]     |PWRDN     |Power-down PHY Transceiver, Low Active
+     * |        |          |0 = Power-down related circuit of PHY transceiver.
+     * |        |          |1 = Turn-on related circuit of PHY transceiver.
+     * |[10]    |BYTEM     |CPU Access USB SRAM Size Mode Selection
+     * |        |          |0 = Word mode: The size of the transfer from CPU to USB SRAM can be Word only.
+     * |        |          |1 = Byte mode: The size of the transfer from CPU to USB SRAM can be Byte only.
+     * |[11]    |LPMACK    |LPM Token Acknowledge Enable Bit
+     * |        |          |The NYET/ACK will be returned only on a successful LPM transaction if no errors in both the EXT token and the LPM token and a valid bLinkState = 0001 (L1) is received, else ERROR and STALL will be returned automatically, respectively.
+     * |        |          |0= the valid LPM Token will be NYET.
+     * |        |          |1= the valid LPM Token will be ACK.
+     * |[12]    |L1SUSPEND |LPM L1 Suspend
+     * |        |          |0 = Bus no L1 state suspend.
+     * |        |          |1 = This bit is set by the hardware when LPM command to enter the L1 state is successfully received and acknowledged.
+     * |        |          |Note: This bit is read only.
+     * |[13]    |L1RESUME  |LPM L1 Resume
+     * |        |          |0 = Bus no LPM L1 state resume.
+     * |        |          |1 = LPM L1 state Resume from LPM L1 state suspend.
+     * |        |          |Note: This bit is read only.
+     * @var USBD_T::VBUSDET
+     * Offset: 0x14  USB Device VBUS Detection Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |VBUSDET   |Device VBUS Detection
+     * |        |          |0 = Controller is not attached to the USB host.
+     * |        |          |1 = Controller is attached to the USB host.
+     * @var USBD_T::STBUFSEG
+     * Offset: 0x18  SETUP Token Buffer Segmentation Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[8:3]   |STBUFSEG  |SETUP Token Buffer Segmentation
+     * |        |          |It is used to indicate the offset address for the SETUP token with the USB Device SRAM starting address The effective starting address is
+     * |        |          |USBD_SRAM address + {STBUFSEG, 3'b000}
+     * |        |          |Where the USBD_SRAM address = USBD_BA+0x100h.
+     * |        |          |Note: It is used for SETUP token only.
+     * @var USBD_T::EPSTS0
+     * Offset: 0x20  USB Device Endpoint Status Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[03:00] |EPSTS0    |Endpoint 0 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[07:04] |EPSTS1    |Endpoint 1 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[11:08] |EPSTS2    |Endpoint 2 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[15:12] |EPSTS3    |Endpoint 3 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[19:16] |EPSTS4    |Endpoint 4 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[23:20] |EPSTS5    |Endpoint 5 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[27:24] |EPSTS6    |Endpoint 6 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[31:28] |EPSTS7    |Endpoint 7 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * @var USBD_T::EPSTS1
+     * Offset: 0x24  USB Device Endpoint Status Register 1
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |EPSTS8    |Endpoint 8 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[7:4]   |EPSTS9    |Endpoint 9 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[11:8]  |EPSTS10   |Endpoint 10 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * |[15:12] |EPSTS11   |Endpoint 11 Status
+     * |        |          |These bits are used to indicate the current status of this endpoint
+     * |        |          |0000 = In ACK.
+     * |        |          |0001 = In NAK.
+     * |        |          |0010 = Out Packet Data0 ACK.
+     * |        |          |0011 = Setup ACK.
+     * |        |          |0110 = Out Packet Data1 ACK.
+     * |        |          |0111 = Isochronous transfer end.
+     * @var USBD_T::LPMATTR
+     * Offset: 0x88  USB LPM Attribution Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[3:0]   |LPMLINKSTS|LPM Link State
+     * |        |          |These bits contain the bLinkState received with last ACK LPM Token
+     * |[7:4]   |LPMBESL   |LPM Best Effort Service Latency
+     * |        |          |These bits contain the BESL value received with last ACK LPM Token
+     * |[8]     |LPMRWAKUP |LPM Remote Wakeup
+     * |        |          |This bit contains the bRemoteWake value received with last ACK LPM Token
+     * @var USBD_T::FN
+     * Offset: 0x8C  USB Frame number Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[10:0]  |FN        |Frame Number
+     * |        |          |These bits contain the 11-bits frame number in the last received SOF packet.
+     * @var USBD_T::SE0
+     * Offset: 0x90  USB Device Drive SE0 Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SE0       |Drive Single Ended Zero in USB Bus
+     * |        |          |The Single Ended Zero (SE0) is when both lines (USB_D+ and USB_D-) are being pulled low.
+     * |        |          |0 = Normal operation.
+     * |        |          |1 = Force USB PHY transceiver to drive SE0.
+     * @var USBD_T::BCDC
+     * Offset: 0x94  USB Device Battery Charge Detect Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |BCDEN     |Battery Charge Detect Enable
+     * |        |          |Enable battery charge detect, user select DETMOD then observer DETSTS to decide contact
+     * |        |          |port PHY be used to BCD, can't be used to communication when BCDEN = 1
+     * |        |          |0 = Normal operation
+     * |        |          |1 = Battery charge detect operation
+     * |[3:1]   |DETMOD    |Detect Mode
+     * |        |          |When BCDEN = 1, select detect mode to perform
+     * |        |          |000 = Idle, nothing to detect
+     * |        |          |001 = VBUS detect, detect USB VBUS whether great than threshold voltage
+     * |        |          |010 = Data contact detect(DCD), detect data pin contact status
+     * |        |          |011 = Primary detect(PD), distinguish between (SDP or NUSP) and (CDP or DCP)
+     * |        |          |100 = Secondary detect(SD), distinguish between CDP and DCP
+     * |        |          |101~111 = Reserved
+     * |[4]     |DETSTS    |Detect Status (Read Only)
+     * |        |          |When DETMOD = 000(IDLE), DETSTS = 0
+     * |        |          |
+     * |        |          |When DETMOD = 001(VBUS detect)
+     * |        |          |000 = VBUS is less than threshold voltage
+     * |        |          |001 = VBUS is greater than threshold voltage
+     * |        |          |
+     * |        |          |When DETMOD = 010(DCD detect)
+     * |        |          |000 = Data pin not contacted
+     * |        |          |001 = Data pin contacted
+     * |        |          |
+     * |        |          |When DETMOD = 011(PD)
+     * |        |          |000 = SDP port or not USB support port. If it is not USB support, NUSP is 1
+     * |        |          |001 = DCP or CDP
+     * |        |          |
+     * |        |          |When DETMOD = 100(SD)
+     * |        |          |000 = CDP
+     * |        |          |001 = DCP
+     * |[5]     |NUSP      |Not USB Support Port (Read Only)
+     * |        |          |When DETMOD = 011(PD), detect DM be pulled logic high, it means contact port not USB support port
+     * |        |          |0 = USB support port
+     * |        |          |1 = Not USB support port
+     */
+
+    __IO uint32_t INTEN;                 /*!< [0x0000] USB Device Interrupt Enable Register                             */
+    __IO uint32_t INTSTS;                /*!< [0x0004] USB Device Interrupt Event Status Register                       */
+    __IO uint32_t FADDR;                 /*!< [0x0008] USB Device Function Address Register                             */
+    __I  uint32_t EPSTS;                 /*!< [0x000c] USB Device Endpoint Status Register                              */
+    __IO uint32_t ATTR;                  /*!< [0x0010] USB Device Bus Status and Attribution Register                   */
+    __I  uint32_t VBUSDET;               /*!< [0x0014] USB Device VBUS Detection Register                               */
+    __IO uint32_t STBUFSEG;              /*!< [0x0018] SETUP Token Buffer Segmentation Register                         */
+    /* @cond HIDDEN_SYMBOLS */
+    __I  uint32_t RESERVE0[1];
+    /* @endcond //HIDDEN_SYMBOLS */
+    __I  uint32_t EPSTS0;                /*!< [0x0020] USB Device Endpoint Status Register 0                            */
+    __I  uint32_t EPSTS1;                /*!< [0x0024] USB Device Endpoint Status Register 1                            */
+    /* @cond HIDDEN_SYMBOLS */
+    __I  uint32_t RESERVE1[24];
+    /* @endcond //HIDDEN_SYMBOLS */
+    __I  uint32_t LPMATTR;               /*!< [0x0088] USB LPM Attribution Register                                     */
+    __I  uint32_t FN;                    /*!< [0x008c] USB Frame number Register                                        */
+    __IO uint32_t SE0;                   /*!< [0x0090] USB Device Drive SE0 Control Register                            */
+    __IO uint32_t BCDC;                  /*!< [0x0094] USB Device Battery Charge Detect Control Register                */
+    /* @cond HIDDEN_SYMBOLS */
+    __I  uint32_t RESERVE2[282];
+    /* @endcond //HIDDEN_SYMBOLS */
+    USBD_EP_T EP[12];                    /*!< [0x0500~0x60C] USB Device Endpoints(0~16)                                 */
+} USBD_T;
+
+/**
+    @addtogroup USBD_CONST USBD Bit Field Definition
+    Constant Definitions for USBD Controller
+@{ */
+
+#define USBD_INTEN_BUSIEN_Pos            (0)                                               /*!< USBD_T::INTEN: BUSIEN Position         */
+#define USBD_INTEN_BUSIEN_Msk            (0x1ul << USBD_INTEN_BUSIEN_Pos)                  /*!< USBD_T::INTEN: BUSIEN Mask             */
+
+#define USBD_INTEN_USBIEN_Pos            (1)                                               /*!< USBD_T::INTEN: USBIEN Position         */
+#define USBD_INTEN_USBIEN_Msk            (0x1ul << USBD_INTEN_USBIEN_Pos)                  /*!< USBD_T::INTEN: USBIEN Mask             */
+
+#define USBD_INTEN_VBDETIEN_Pos          (2)                                               /*!< USBD_T::INTEN: VBDETIEN Position       */
+#define USBD_INTEN_VBDETIEN_Msk          (0x1ul << USBD_INTEN_VBDETIEN_Pos)                /*!< USBD_T::INTEN: VBDETIEN Mask           */
+
+#define USBD_INTEN_NEVWKIEN_Pos          (3)                                               /*!< USBD_T::INTEN: NEVWKIEN Position       */
+#define USBD_INTEN_NEVWKIEN_Msk          (0x1ul << USBD_INTEN_NEVWKIEN_Pos)                /*!< USBD_T::INTEN: NEVWKIEN Mask           */
+
+#define USBD_INTEN_SOFIEN_Pos            (4)                                               /*!< USBD_T::INTEN: SOFIEN Position         */
+#define USBD_INTEN_SOFIEN_Msk            (0x1ul << USBD_INTEN_SOFIEN_Pos)                  /*!< USBD_T::INTEN: SOFIEN Mask             */
+
+#define USBD_INTEN_BCDIEN_Pos            (5)                                               /*!< USBD_T::INTEN: BCDIEN Position         */
+#define USBD_INTEN_BCDIEN_Msk            (0x1ul << USBD_INTEN_BCDIEN_Pos)                  /*!< USBD_T::INTEN: BCDIEN Mask             */
+
+#define USBD_INTEN_WKEN_Pos              (8)                                               /*!< USBD_T::INTEN: WKEN Position           */
+#define USBD_INTEN_WKEN_Msk              (0x1ul << USBD_INTEN_WKEN_Pos)                    /*!< USBD_T::INTEN: WKEN Mask               */
+
+#define USBD_INTEN_INNAKEN_Pos           (15)                                              /*!< USBD_T::INTEN: INNAKEN Position        */
+#define USBD_INTEN_INNAKEN_Msk           (0x1ul << USBD_INTEN_INNAKEN_Pos)                 /*!< USBD_T::INTEN: INNAKEN Mask            */
+
+#define USBD_INTSTS_BUSIF_Pos            (0)                                               /*!< USBD_T::INTSTS: BUSIF Position         */
+#define USBD_INTSTS_BUSIF_Msk            (0x1ul << USBD_INTSTS_BUSIF_Pos)                  /*!< USBD_T::INTSTS: BUSIF Mask             */
+
+#define USBD_INTSTS_USBIF_Pos            (1)                                               /*!< USBD_T::INTSTS: USBIF Position         */
+#define USBD_INTSTS_USBIF_Msk            (0x1ul << USBD_INTSTS_USBIF_Pos)                  /*!< USBD_T::INTSTS: USBIF Mask             */
+
+#define USBD_INTSTS_VBDETIF_Pos          (2)                                               /*!< USBD_T::INTSTS: VBDETIF Position       */
+#define USBD_INTSTS_VBDETIF_Msk          (0x1ul << USBD_INTSTS_VBDETIF_Pos)                /*!< USBD_T::INTSTS: VBDETIF Mask           */
+
+#define USBD_INTSTS_NEVWKIF_Pos          (3)                                               /*!< USBD_T::INTSTS: NEVWKIF Position       */
+#define USBD_INTSTS_NEVWKIF_Msk          (0x1ul << USBD_INTSTS_NEVWKIF_Pos)                /*!< USBD_T::INTSTS: NEVWKIF Mask           */
+
+#define USBD_INTSTS_SOFIF_Pos            (4)                                               /*!< USBD_T::INTSTS: SOFIF Position         */
+#define USBD_INTSTS_SOFIF_Msk            (0x1ul << USBD_INTSTS_SOFIF_Pos)                  /*!< USBD_T::INTSTS: SOFIF Mask             */
+
+#define USBD_INTSTS_BCDIF_Pos            (5)                                               /*!< USBD_T::INTSTS: BCDIF Position         */
+#define USBD_INTSTS_BCDIF_Msk            (0x1ul << USBD_INTSTS_BCDIF_Pos)                  /*!< USBD_T::INTSTS: BCDIF Mask             */
+
+#define USBD_INTSTS_EPEVT0_Pos           (16)                                              /*!< USBD_T::INTSTS: EPEVT0 Position        */
+#define USBD_INTSTS_EPEVT0_Msk           (0x1ul << USBD_INTSTS_EPEVT0_Pos)                 /*!< USBD_T::INTSTS: EPEVT0 Mask            */
+
+#define USBD_INTSTS_EPEVT1_Pos           (17)                                              /*!< USBD_T::INTSTS: EPEVT1 Position        */
+#define USBD_INTSTS_EPEVT1_Msk           (0x1ul << USBD_INTSTS_EPEVT1_Pos)                 /*!< USBD_T::INTSTS: EPEVT1 Mask            */
+
+#define USBD_INTSTS_EPEVT2_Pos           (18)                                              /*!< USBD_T::INTSTS: EPEVT2 Position        */
+#define USBD_INTSTS_EPEVT2_Msk           (0x1ul << USBD_INTSTS_EPEVT2_Pos)                 /*!< USBD_T::INTSTS: EPEVT2 Mask            */
+
+#define USBD_INTSTS_EPEVT3_Pos           (19)                                              /*!< USBD_T::INTSTS: EPEVT3 Position        */
+#define USBD_INTSTS_EPEVT3_Msk           (0x1ul << USBD_INTSTS_EPEVT3_Pos)                 /*!< USBD_T::INTSTS: EPEVT3 Mask            */
+
+#define USBD_INTSTS_EPEVT4_Pos           (20)                                              /*!< USBD_T::INTSTS: EPEVT4 Position        */
+#define USBD_INTSTS_EPEVT4_Msk           (0x1ul << USBD_INTSTS_EPEVT4_Pos)                 /*!< USBD_T::INTSTS: EPEVT4 Mask            */
+
+#define USBD_INTSTS_EPEVT5_Pos           (21)                                              /*!< USBD_T::INTSTS: EPEVT5 Position        */
+#define USBD_INTSTS_EPEVT5_Msk           (0x1ul << USBD_INTSTS_EPEVT5_Pos)                 /*!< USBD_T::INTSTS: EPEVT5 Mask            */
+
+#define USBD_INTSTS_EPEVT6_Pos           (22)                                              /*!< USBD_T::INTSTS: EPEVT6 Position        */
+#define USBD_INTSTS_EPEVT6_Msk           (0x1ul << USBD_INTSTS_EPEVT6_Pos)                 /*!< USBD_T::INTSTS: EPEVT6 Mask            */
+
+#define USBD_INTSTS_EPEVT7_Pos           (23)                                              /*!< USBD_T::INTSTS: EPEVT7 Position        */
+#define USBD_INTSTS_EPEVT7_Msk           (0x1ul << USBD_INTSTS_EPEVT7_Pos)                 /*!< USBD_T::INTSTS: EPEVT7 Mask            */
+
+#define USBD_INTSTS_EPEVT8_Pos           (24)                                              /*!< USBD_T::INTSTS: EPEVT8 Position        */
+#define USBD_INTSTS_EPEVT8_Msk           (0x1ul << USBD_INTSTS_EPEVT8_Pos)                 /*!< USBD_T::INTSTS: EPEVT8 Mask            */
+
+#define USBD_INTSTS_EPEVT9_Pos           (25)                                              /*!< USBD_T::INTSTS: EPEVT9 Position        */
+#define USBD_INTSTS_EPEVT9_Msk           (0x1ul << USBD_INTSTS_EPEVT9_Pos)                 /*!< USBD_T::INTSTS: EPEVT9 Mask            */
+
+#define USBD_INTSTS_EPEVT10_Pos          (26)                                              /*!< USBD_T::INTSTS: EPEVT10 Position       */
+#define USBD_INTSTS_EPEVT10_Msk          (0x1ul << USBD_INTSTS_EPEVT10_Pos)                /*!< USBD_T::INTSTS: EPEVT10 Mask           */
+
+#define USBD_INTSTS_EPEVT11_Pos          (27)                                              /*!< USBD_T::INTSTS: EPEVT11 Position       */
+#define USBD_INTSTS_EPEVT11_Msk          (0x1ul << USBD_INTSTS_EPEVT11_Pos)                /*!< USBD_T::INTSTS: EPEVT11 Mask           */
+
+#define USBD_INTSTS_SETUP_Pos            (31)                                              /*!< USBD_T::INTSTS: SETUP Position         */
+#define USBD_INTSTS_SETUP_Msk            (0x1ul << USBD_INTSTS_SETUP_Pos)                  /*!< USBD_T::INTSTS: SETUP Mask             */
+
+#define USBD_FADDR_FADDR_Pos             (0)                                               /*!< USBD_T::FADDR: FADDR Position          */
+#define USBD_FADDR_FADDR_Msk             (0x7ful << USBD_FADDR_FADDR_Pos)                  /*!< USBD_T::FADDR: FADDR Mask              */
+
+#define USBD_EPSTS_OV_Pos                (7)                                               /*!< USBD_T::EPSTS: OV Position             */
+#define USBD_EPSTS_OV_Msk                (0x1ul << USBD_EPSTS_OV_Pos)                      /*!< USBD_T::EPSTS: OV Mask                 */
+
+#define USBD_ATTR_USBRST_Pos             (0)                                               /*!< USBD_T::ATTR: USBRST Position          */
+#define USBD_ATTR_USBRST_Msk             (0x1ul << USBD_ATTR_USBRST_Pos)                   /*!< USBD_T::ATTR: USBRST Mask              */
+
+#define USBD_ATTR_SUSPEND_Pos            (1)                                               /*!< USBD_T::ATTR: SUSPEND Position         */
+#define USBD_ATTR_SUSPEND_Msk            (0x1ul << USBD_ATTR_SUSPEND_Pos)                  /*!< USBD_T::ATTR: SUSPEND Mask             */
+
+#define USBD_ATTR_RESUME_Pos             (2)                                               /*!< USBD_T::ATTR: RESUME Position          */
+#define USBD_ATTR_RESUME_Msk             (0x1ul << USBD_ATTR_RESUME_Pos)                   /*!< USBD_T::ATTR: RESUME Mask              */
+
+#define USBD_ATTR_TOUT_Pos               (3)                                               /*!< USBD_T::ATTR: TOUT Position            */
+#define USBD_ATTR_TOUT_Msk               (0x1ul << USBD_ATTR_TOUT_Pos)                     /*!< USBD_T::ATTR: TOUT Mask                */
+
+#define USBD_ATTR_PHYEN_Pos              (4)                                               /*!< USBD_T::ATTR: PHYEN Position           */
+#define USBD_ATTR_PHYEN_Msk              (0x1ul << USBD_ATTR_PHYEN_Pos)                    /*!< USBD_T::ATTR: PHYEN Mask               */
+
+#define USBD_ATTR_RWAKEUP_Pos            (5)                                               /*!< USBD_T::ATTR: RWAKEUP Position         */
+#define USBD_ATTR_RWAKEUP_Msk            (0x1ul << USBD_ATTR_RWAKEUP_Pos)                  /*!< USBD_T::ATTR: RWAKEUP Mask             */
+
+#define USBD_ATTR_USBEN_Pos              (7)                                               /*!< USBD_T::ATTR: USBEN Position           */
+#define USBD_ATTR_USBEN_Msk              (0x1ul << USBD_ATTR_USBEN_Pos)                    /*!< USBD_T::ATTR: USBEN Mask               */
+
+#define USBD_ATTR_DPPUEN_Pos             (8)                                               /*!< USBD_T::ATTR: DPPUEN Position          */
+#define USBD_ATTR_DPPUEN_Msk             (0x1ul << USBD_ATTR_DPPUEN_Pos)                   /*!< USBD_T::ATTR: DPPUEN Mask              */
+
+#define USBD_ATTR_PWRDN_Pos              (9)                                               /*!< USBD_T::ATTR: PWRDN Position          */
+#define USBD_ATTR_PWRDN_Msk              (0x1ul << USBD_ATTR_PWRDN_Pos)                    /*!< USBD_T::ATTR: PWRDN Mask              */
+
+#define USBD_ATTR_BYTEM_Pos              (10)                                              /*!< USBD_T::ATTR: BYTEM Position           */
+#define USBD_ATTR_BYTEM_Msk              (0x1ul << USBD_ATTR_BYTEM_Pos)                    /*!< USBD_T::ATTR: BYTEM Mask               */
+
+#define USBD_ATTR_LPMACK_Pos             (11)                                              /*!< USBD_T::ATTR: LPMACK Position          */
+#define USBD_ATTR_LPMACK_Msk             (0x1ul << USBD_ATTR_LPMACK_Pos)                   /*!< USBD_T::ATTR: LPMACK Mask              */
+
+#define USBD_ATTR_L1SUSPEND_Pos          (12)                                              /*!< USBD_T::ATTR: L1SUSPEND Position       */
+#define USBD_ATTR_L1SUSPEND_Msk          (0x1ul << USBD_ATTR_L1SUSPEND_Pos)                /*!< USBD_T::ATTR: L1SUSPEND Mask           */
+
+#define USBD_ATTR_L1RESUME_Pos           (13)                                              /*!< USBD_T::ATTR: L1RESUME Position        */
+#define USBD_ATTR_L1RESUME_Msk           (0x1ul << USBD_ATTR_L1RESUME_Pos)                 /*!< USBD_T::ATTR: L1RESUME Mask            */
+
+#define USBD_VBUSDET_VBUSDET_Pos         (0)                                               /*!< USBD_T::VBUSDET: VBUSDET Position      */
+#define USBD_VBUSDET_VBUSDET_Msk         (0x1ul << USBD_VBUSDET_VBUSDET_Pos)               /*!< USBD_T::VBUSDET: VBUSDET Mask          */
+
+#define USBD_STBUFSEG_STBUFSEG_Pos       (3)                                               /*!< USBD_T::STBUFSEG: STBUFSEG Position    */
+#define USBD_STBUFSEG_STBUFSEG_Msk       (0x3ful << USBD_STBUFSEG_STBUFSEG_Pos)            /*!< USBD_T::STBUFSEG: STBUFSEG Mask        */
+
+#define USBD_EPSTS0_EPSTS0_Pos           (0)                                              /*!< USBD_T::EPSTS0: EPSTS0 Position        */
+#define USBD_EPSTS0_EPSTS0_Msk           (0xful << USBD_EPSTS0_EPSTS0_Pos)                 /*!< USBD_T::EPSTS0: EPSTS0 Mask            */
+
+#define USBD_EPSTS0_EPSTS1_Pos           (4)                                              /*!< USBD_T::EPSTS0: EPSTS1 Position        */
+#define USBD_EPSTS0_EPSTS1_Msk           (0xful << USBD_EPSTS0_EPSTS1_Pos)                 /*!< USBD_T::EPSTS0: EPSTS1 Mask            */
+
+#define USBD_EPSTS0_EPSTS2_Pos           (8)                                              /*!< USBD_T::EPSTS0: EPSTS2 Position        */
+#define USBD_EPSTS0_EPSTS2_Msk           (0xful << USBD_EPSTS0_EPSTS2_Pos)                 /*!< USBD_T::EPSTS0: EPSTS2 Mask            */
+
+#define USBD_EPSTS0_EPSTS3_Pos           (12)                                              /*!< USBD_T::EPSTS0: EPSTS3 Position        */
+#define USBD_EPSTS0_EPSTS3_Msk           (0xful << USBD_EPSTS0_EPSTS3_Pos)                 /*!< USBD_T::EPSTS0: EPSTS3 Mask            */
+
+#define USBD_EPSTS0_EPSTS4_Pos           (16)                                              /*!< USBD_T::EPSTS0: EPSTS4 Position        */
+#define USBD_EPSTS0_EPSTS4_Msk           (0xful << USBD_EPSTS0_EPSTS4_Pos)                 /*!< USBD_T::EPSTS0: EPSTS4 Mask            */
+
+#define USBD_EPSTS0_EPSTS5_Pos           (20)                                              /*!< USBD_T::EPSTS0: EPSTS5 Position        */
+#define USBD_EPSTS0_EPSTS5_Msk           (0xful << USBD_EPSTS0_EPSTS5_Pos)                 /*!< USBD_T::EPSTS0: EPSTS5 Mask            */
+
+#define USBD_EPSTS0_EPSTS6_Pos           (24)                                              /*!< USBD_T::EPSTS0: EPSTS6 Position        */
+#define USBD_EPSTS0_EPSTS6_Msk           (0xful << USBD_EPSTS0_EPSTS6_Pos)                 /*!< USBD_T::EPSTS0: EPSTS6 Mask            */
+
+#define USBD_EPSTS0_EPSTS7_Pos           (28)                                              /*!< USBD_T::EPSTS0: EPSTS7 Position        */
+#define USBD_EPSTS0_EPSTS7_Msk           (0xful << USBD_EPSTS0_EPSTS7_Pos)                 /*!< USBD_T::EPSTS0: EPSTS7 Mask            */
+
+#define USBD_EPSTS1_EPSTS8_Pos           (0)                                               /*!< USBD_T::EPSTS1: EPSTS8 Position        */
+#define USBD_EPSTS1_EPSTS8_Msk           (0xful << USBD_EPSTS1_EPSTS8_Pos)                 /*!< USBD_T::EPSTS1: EPSTS8 Mask            */
+
+#define USBD_EPSTS1_EPSTS9_Pos           (4)                                               /*!< USBD_T::EPSTS1: EPSTS9 Position        */
+#define USBD_EPSTS1_EPSTS9_Msk           (0xful << USBD_EPSTS1_EPSTS9_Pos)                 /*!< USBD_T::EPSTS1: EPSTS9 Mask            */
+
+#define USBD_EPSTS1_EPSTS10_Pos          (8)                                               /*!< USBD_T::EPSTS1: EPSTS10 Position       */
+#define USBD_EPSTS1_EPSTS10_Msk          (0xful << USBD_EPSTS1_EPSTS10_Pos)                /*!< USBD_T::EPSTS1: EPSTS10 Mask           */
+
+#define USBD_EPSTS1_EPSTS11_Pos          (12)                                              /*!< USBD_T::EPSTS1: EPSTS11 Position       */
+#define USBD_EPSTS1_EPSTS11_Msk          (0xful << USBD_EPSTS1_EPSTS11_Pos)                /*!< USBD_T::EPSTS1: EPSTS11 Mask           */
+
+#define USBD_LPMATTR_LPMLINKSTS_Pos      (0)                                               /*!< USBD_T::LPMATTR: LPMLINKSTS Position   */
+#define USBD_LPMATTR_LPMLINKSTS_Msk      (0xful << USBD_LPMATTR_LPMLINKSTS_Pos)            /*!< USBD_T::LPMATTR: LPMLINKSTS Mask       */
+
+#define USBD_LPMATTR_LPMBESL_Pos         (4)                                               /*!< USBD_T::LPMATTR: LPMBESL Position      */
+#define USBD_LPMATTR_LPMBESL_Msk         (0xful << USBD_LPMATTR_LPMBESL_Pos)               /*!< USBD_T::LPMATTR: LPMBESL Mask          */
+
+#define USBD_LPMATTR_LPMRWAKUP_Pos       (8)                                               /*!< USBD_T::LPMATTR: LPMRWAKUP Position    */
+#define USBD_LPMATTR_LPMRWAKUP_Msk       (0x1ul << USBD_LPMATTR_LPMRWAKUP_Pos)             /*!< USBD_T::LPMATTR: LPMRWAKUP Mask        */
+
+#define USBD_FN_FN_Pos                   (0)                                               /*!< USBD_T::FN: FN Position                */
+#define USBD_FN_FN_Msk                   (0x7fful << USBD_FN_FN_Pos)                       /*!< USBD_T::FN: FN Mask                    */
+
+#define USBD_SE0_SE0_Pos                 (0)                                               /*!< USBD_T::SE0: SE0 Position              */
+#define USBD_SE0_SE0_Msk                 (0x1ul << USBD_SE0_SE0_Pos)                       /*!< USBD_T::SE0: SE0 Mask                  */
+
+#define USBD_BCDC_BCDEN_Pos              (0)                                               /*!< USBD_T::BCDEN: BCDEN Position          */
+#define USBD_BCDC_BCDEN_Msk              (0x1ul << USBD_BCDC_BCDEN_Pos)                    /*!< USBD_T::BCDEN: BCDEN Mask              */
+
+#define USBD_BCDC_DETMOD_Pos             (1)                                               /*!< USBD_T::DETMOD: DETMOD Position        */
+#define USBD_BCDC_DETMOD_Msk             (0x7ul << USBD_BCDC_DETMOD_Pos)                   /*!< USBD_T::DETMOD: DETMOD Mask            */
+
+#define USBD_BCDC_DETSTS_Pos             (4)                                               /*!< USBD_T::DETSTS: DETSTS Position        */
+#define USBD_BCDC_DETSTS_Msk             (0x1ul << USBD_BCDC_DETSTS_Pos)                   /*!< USBD_T::DETSTS: DETSTS Mask            */
+
+#define USBD_BCDC_NUSP_Pos               (5)                                               /*!< USBD_T::NUSP: NUSP Position            */
+#define USBD_BCDC_NUSP_Msk               (0x1ul << USBD_BCDC_NUSP_Pos)                     /*!< USBD_T::NUSP: NUSP Mask                */
+
+#define USBD_BUFSEG_BUFSEG_Pos           (3)                                               /*!< USBD_EP_T::BUFSEG: BUFSEG Position     */
+#define USBD_BUFSEG_BUFSEG_Msk           (0x3ful << USBD_BUFSEG_BUFSEG_Pos)                /*!< USBD_EP_T::BUFSEG: BUFSEG Mask         */
+
+#define USBD_MXPLD_MXPLD_Pos             (0)                                               /*!< USBD_EP_T::MXPLD: MXPLD Position       */
+#define USBD_MXPLD_MXPLD_Msk             (0x1fful << USBD_MXPLD_MXPLD_Pos)                 /*!< USBD_EP_T::MXPLD: MXPLD Mask           */
+
+#define USBD_CFG_EPNUM_Pos               (0)                                               /*!< USBD_EP_T::CFG: EPNUM Position         */
+#define USBD_CFG_EPNUM_Msk               (0xful << USBD_CFG_EPNUM_Pos)                     /*!< USBD_EP_T::CFG: EPNUM Mask             */
+
+#define USBD_CFG_ISOCH_Pos               (4)                                               /*!< USBD_EP_T::CFG: ISOCH Position         */
+#define USBD_CFG_ISOCH_Msk               (0x1ul << USBD_CFG_ISOCH_Pos)                     /*!< USBD_EP_T::CFG: ISOCH Mask             */
+
+#define USBD_CFG_STATE_Pos               (5)                                               /*!< USBD_EP_T::CFG: STATE Position         */
+#define USBD_CFG_STATE_Msk               (0x3ul << USBD_CFG_STATE_Pos)                     /*!< USBD_EP_T::CFG: STATE Mask             */
+
+#define USBD_CFG_DSQSYNC_Pos             (7)                                               /*!< USBD_EP_T::CFG: DSQSYNC Position       */
+#define USBD_CFG_DSQSYNC_Msk             (0x1ul << USBD_CFG_DSQSYNC_Pos)                   /*!< USBD_EP_T::CFG: DSQSYNC Mask           */
+
+#define USBD_CFG_CSTALL_Pos              (9)                                               /*!< USBD_EP_T::CFG: CSTALL Position        */
+#define USBD_CFG_CSTALL_Msk              (0x1ul << USBD_CFG_CSTALL_Pos)                    /*!< USBD_EP_T::CFG: CSTALL Mask            */
+
+#define USBD_CFGP_CLRRDY_Pos             (0)                                               /*!< USBD_EP_T::CFGP: CLRRDY Position       */
+#define USBD_CFGP_CLRRDY_Msk             (0x1ul << USBD_CFGP_CLRRDY_Pos)                   /*!< USBD_EP_T::CFGP: CLRRDY Mask           */
+
+#define USBD_CFGP_SSTALL_Pos             (1)                                               /*!< USBD_EP_T::CFGP: SSTALL Position       */
+#define USBD_CFGP_SSTALL_Msk             (0x1ul << USBD_CFGP_SSTALL_Pos)                   /*!< USBD_EP_T::CFGP: SSTALL Mask           */
+
+/** @} USBD_CONST */
+/** @} end of USBD register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __USBD_REG_H__ */

--- a/hal/m258ke/nuvoton/uspi_reg.h
+++ b/hal/m258ke/nuvoton/uspi_reg.h
@@ -1,0 +1,683 @@
+/**************************************************************************//**
+ * @file     uspi_reg.h
+ * @version  V1.00
+ * @brief    USPI register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __USPI_REG_H__
+#define __USPI_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup USPI SPI Mode of USCI Controller (USPI)
+    Memory Mapped Structure for USPI Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var USPI_T::CTL
+     * Offset: 0x00  USCI Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |FUNMODE   |Function Mode
+     * |        |          |This bit field selects the protocol for this USCI controller
+     * |        |          |Selecting a protocol that is not available or a reserved combination disables the USCI
+     * |        |          |When switching between two protocols, the USCI has to be disabled before selecting a new protocol
+     * |        |          |Simultaneously, the USCI will be reset when user write 000 to FUNMODE.
+     * |        |          |000 = The USCI is disabled. All protocol related state machines are set to idle state.
+     * |        |          |001 = The SPI protocol is selected.
+     * |        |          |010 = The UART protocol is selected.
+     * |        |          |100 = The I2C protocol is selected.
+     * |        |          |Note: Other bit combinations are reserved.
+     * @var USPI_T::INTEN
+     * Offset: 0x04  USCI Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |TXSTIEN   |Transmit Start Interrupt Enable Bit
+     * |        |          |This bit enables the interrupt generation in case of a transmit start event.
+     * |        |          |0 = The transmit start interrupt is disabled.
+     * |        |          |1 = The transmit start interrupt is enabled.
+     * |[2]     |TXENDIEN  |Transmit End Interrupt Enable Bit
+     * |        |          |This bit enables the interrupt generation in case of a transmit finish event.
+     * |        |          |0 = The transmit finish interrupt is disabled.
+     * |        |          |1 = The transmit finish interrupt is enabled.
+     * |[3]     |RXSTIEN   |Receive Start Interrupt Enable Bit
+     * |        |          |This bit enables the interrupt generation in case of a receive start event.
+     * |        |          |0 = The receive start interrupt is disabled.
+     * |        |          |1 = The receive start interrupt is enabled.
+     * |[4]     |RXENDIEN  |Receive End Interrupt Enable Bit
+     * |        |          |This bit enables the interrupt generation in case of a receive finish event.
+     * |        |          |0 = The receive end interrupt is disabled.
+     * |        |          |1 = The receive end interrupt is enabled.
+     * @var USPI_T::BRGEN
+     * Offset: 0x08  USCI Baud Rate Generator Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RCLKSEL   |Reference Clock Source Selection
+     * |        |          |This bit selects the source of reference clock (fREF_CLK).
+     * |        |          |0 = Peripheral device clock fPCLK.
+     * |        |          |1 = Reserved.
+     * |[1]     |PTCLKSEL  |Protocol Clock Source Selection
+     * |        |          |This bit selects the source of protocol clock (fPROT_CLK).
+     * |        |          |0 = Reference clock fREF_CLK.
+     * |        |          |1 = fREF_CLK2 (its frequency is half of fREF_CLK).
+     * |[3:2]   |SPCLKSEL  |Sample Clock Source Selection
+     * |        |          |This bit field used for the clock source selection of sample clock (fSAMP_CLK) for the protocol processor.
+     * |        |          |00 = fDIV_CLK.
+     * |        |          |01 = fPROT_CLK.
+     * |        |          |10 = fSCLK.
+     * |        |          |11 = fREF_CLK.
+     * |[4]     |TMCNTEN   |Time Measurement Counter Enable Bit
+     * |        |          |This bit enables the 10-bit timing measurement counter.
+     * |        |          |0 = Time measurement counter is Disabled.
+     * |        |          |1 = Time measurement counter is Enabled.
+     * |[5]     |TMCNTSRC  |Time Measurement Counter Clock Source Selection
+     * |        |          |0 = Time measurement counter with fPROT_CLK.
+     * |        |          |1 = Time measurement counter with fDIV_CLK.
+     * |[25:16] |CLKDIV    |Clock Divider
+     * |        |          |This bit field defines the ratio between the protocol clock frequency fPROT_CLK and the clock divider frequency fDIV_CLK (fDIV_CLK = fPROT_CLK / (CLKDIV+1) ).
+     * |        |          |Note: In UART function, it can be updated by hardware in the 4th falling edge of the input data 0x55 when the auto baud rate function (ABREN(USPI_PROTCTL[6])) is enabled
+     * |        |          |The revised value is the average bit time between bit 5 and bit 6
+     * |        |          |The user can use revised CLKDIV and new BRDETITV (USPI_PROTCTL[24:16]) to calculate the precise baud rate.
+     * @var USPI_T::DATIN0
+     * Offset: 0x10  USCI Input Data Signal Configuration Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SYNCSEL   |Input   Signal Synchronization Selection
+     * |        |          |This bit   selects if the un-synchronized input signal (with optionally inverted) or the   synchronized (and optionally filtered) signal can be used as input for the   data shift unit.
+     * |        |          |0 = The   un-synchronized signal can be taken as input for the data shift unit.
+     * |        |          |1 = The   synchronized signal can be taken as input for the data shift unit.
+     * |        |          |Note: In SPI protocol, we suggest this bit   should be set as 0.
+     * |[2]     |ININV     |Input   Signal Inverse Selection
+     * |        |          |This bit   defines the inverter enable of the input asynchronous signal.
+     * |        |          |0 = The   un-synchronized input signal will not be inverted.
+     * |        |          |1 = The   un-synchronized input signal will be inverted.
+     * |        |          |Note: In SPI protocol, we suggest this bit   should be set as 0.
+     * @var USPI_T::CTLIN0
+     * Offset: 0x20  USCI Input Control Signal Configuration Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SYNCSEL   |Input   Synchronization Signal Selection
+     * |        |          |This bit   selects if the un-synchronized input signal (with optionally inverted) or the   synchronized (and optionally filtered) signal can be used as input for the   data shift unit.
+     * |        |          |0 = The   un-synchronized signal can be taken as input for the data shift unit.
+     * |        |          |1 = The   synchronized signal can be taken as input for the data shift unit.
+     * |        |          |Note: In SPI protocol, we suggest this bit   should be set as 0.
+     * |[2]     |ININV     |Input   Signal Inverse Selection
+     * |        |          |This bit   defines the inverter enable of the input asynchronous signal.
+     * |        |          |0 = The   un-synchronized input signal will not be inverted.
+     * |        |          |1 = The   un-synchronized input signal will be inverted.
+     * @var USPI_T::CLKIN
+     * Offset: 0x28  USCI Input Clock Signal Configuration Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SYNCSEL   |Input   Synchronization Signal Selection
+     * |        |          |This bit   selects if the un-synchronized input signal or the synchronized (and   optionally filtered) signal can be used as input for the data shift unit.
+     * |        |          |0 = The un-synchronized   signal can be taken as input for the data shift unit.
+     * |        |          |1 = The   synchronized signal can be taken as input for the data shift unit.
+     * |        |          |Note: In SPI protocol, we suggest this bit   should be set as 0.
+     * @var USPI_T::LINECTL
+     * Offset: 0x2C  USCI Line Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |LSB       |LSB First Transmission Selection
+     * |        |          |0 = The MSB, which bit of transmit/receive data buffer depends on the setting of DWIDTH, is transmitted/received first.
+     * |        |          |1 = The LSB, the bit 0 of data buffer, will be transmitted/received first.
+     * |[5]     |DATOINV   |Data Output Inverse Selection
+     * |        |          |This bit defines the relation between the internal shift data value and the output data signal of USCIx_DAT0/1 pin.
+     * |        |          |0 = Data output level is not inverted.
+     * |        |          |1 = Data output level is inverted.
+     * |[7]     |CTLOINV   |Control Signal Output Inverse Selection
+     * |        |          |This bit defines the relation between the internal control signal and the output control signal.
+     * |        |          |0 = No effect.
+     * |        |          |1 = The control signal will be inverted before its output.
+     * |        |          |Note: The control signal has different definitions in different protocol
+     * |        |          |In SPI protocol, the control signal means slave select signal
+     * |        |          |In UART protocol, the control signal means RTS signal.
+     * |[11:8]  |DWIDTH    |Word Length of Transmission
+     * |        |          |This bit field defines the data word length (amount of bits) for reception and transmission
+     * |        |          |The data word is always right-aligned in the data buffer
+     * |        |          |USCI support word length from 4 to 16 bits.
+     * |        |          |0x0: The data word contains 16 bits located at bit positions [15:0].
+     * |        |          |0x1: Reserved.
+     * |        |          |0x2: Reserved.
+     * |        |          |0x3: Reserved.
+     * |        |          |0x4: The data word contains 4 bits located at bit positions [3:0].
+     * |        |          |0x5: The data word contains 5 bits located at bit positions [4:0].
+     * |        |          |...
+     * |        |          |0xF: The data word contains 15 bits located at bit positions [14:0].
+     * |        |          |Note: In UART protocol, the length can be configured as 6~13 bits.
+     * @var USPI_T::TXDAT
+     * Offset: 0x30  USCI Transmit Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |TXDAT     |Transmit Data
+     * |        |          |Software can use this bit field to write 16-bit transmit data for transmission
+     * |        |          |In order to avoid overwriting the transmit data, user have to check TXEMPTY (USPI_BUFSTS[8]) status before writing transmit data into this bit field.
+     * |[16]    |PORTDIR   |Port Direction Control
+     * |        |          |This bit field is only available while USCI operates in SPI protocol (FUNMODE = 0x1) with half-duplex transfer
+     * |        |          |It is used to define the direction of the data port pin
+     * |        |          |When software writes USPI_TXDAT register, the transmit data and its port direction are settled simultaneously.
+     * |        |          |0 = The data pin is configured as output mode.
+     * |        |          |1 = The data pin is configured as input mode.
+     * @var USPI_T::RXDAT
+     * Offset: 0x34  USCI Receive Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |RXDAT     |Received Data
+     * |        |          |This bit field monitors the received data which stored in receive data buffer.
+     * @var USPI_T::BUFCTL
+     * Offset: 0x38  USCI Transmit/Receive Buffer Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[6]     |TXUDRIEN  |Slave Transmit Under Run Interrupt Enable Bit
+     * |        |          |0 = Transmit under-run interrupt Disabled.
+     * |        |          |1 = Transmit under-run interrupt Enabled.
+     * |[7]     |TXCLR     |Clear Transmit Buffer
+     * |        |          |0 = No effect.
+     * |        |          |1 = The transmit buffer is cleared
+     * |        |          |Should only be used while the buffer is not taking part in data traffic.
+     * |        |          |Note: It is cleared automatically after one PCLK cycle.
+     * |[14]    |RXOVIEN   |Receive Buffer Overrun Interrupt Enable Bit
+     * |        |          |0 = Receive overrun interrupt Disabled.
+     * |        |          |1 = Receive overrun interrupt Enabled.
+     * |[15]    |RXCLR     |Clear Receive Buffer
+     * |        |          |0 = No effect.
+     * |        |          |1 = The receive buffer is cleared
+     * |        |          |Should only be used while the buffer is not taking part in data traffic.
+     * |        |          |Note: It is cleared automatically after one PCLK cycle.
+     * |[16]    |TXRST     |Transmit Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the transmit-related counters, state machine, and the content of transmit shift register and data buffer.
+     * |        |          |Note1: It is cleared automatically after one PCLK cycle.
+     * |        |          |Note2: Write 1 to this bit will set the output data pin to zero if USPI_BUFCTL[5]=0.
+     * |[17]    |RXRST     |Receive Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the receive-related counters, state machine, and the content of receive shift register and data buffer.
+     * |        |          |Note: It is cleared automatically after one PCLK cycle.
+     * @var USPI_T::BUFSTS
+     * Offset: 0x3C  USCI Transmit/Receive Buffer Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RXEMPTY   |Receive Buffer Empty Indicator
+     * |        |          |0 = Receive buffer is not empty.
+     * |        |          |1 = Receive buffer is empty.
+     * |[1]     |RXFULL    |Receive Buffer Full Indicator
+     * |        |          |0 = Receive buffer is not full.
+     * |        |          |1 = Receive buffer is full.
+     * |[3]     |RXOVIF    |Receive Buffer Over-run Interrupt Status
+     * |        |          |This bit indicates that a receive buffer overrun event has been detected
+     * |        |          |If RXOVIEN (USPI_BUFCTL[14]) is enabled, the corresponding interrupt request is activated
+     * |        |          |It is cleared by software writes 1 to this bit.
+     * |        |          |0 = A receive buffer overrun event has not been detected.
+     * |        |          |1 = A receive buffer overrun event has been detected.
+     * |[8]     |TXEMPTY   |Transmit Buffer Empty Indicator
+     * |        |          |0 = Transmit buffer is not empty.
+     * |        |          |1 = Transmit buffer is empty and available for the next transmission datum.
+     * |[9]     |TXFULL    |Transmit Buffer Full Indicator
+     * |        |          |0 = Transmit buffer is not full.
+     * |        |          |1 = Transmit buffer is full.
+     * |[11]    |TXUDRIF   |Transmit Buffer Under-run Interrupt Status
+     * |        |          |This bit indicates that a transmit buffer under-run event has been detected
+     * |        |          |If enabled by TXUDRIEN (USPI_BUFCTL[6]), the corresponding interrupt request is activated
+     * |        |          |It is cleared by software writes 1 to this bit
+     * |        |          |0 = A transmit buffer under-run event has not been detected.
+     * |        |          |1 = A transmit buffer under-run event has been detected.
+     * @var USPI_T::PDMACTL
+     * Offset: 0x40  USCI PDMA Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PDMARST   |PDMA Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the USCI's PDMA control logic. This bit will be cleared to 0 automatically.
+     * |[1]     |TXPDMAEN  |PDMA Transmit Channel Available
+     * |        |          |0 = Transmit PDMA function Disabled.
+     * |        |          |1 = Transmit PDMA function Enabled.
+     * |[2]     |RXPDMAEN  |PDMA Receive Channel Available
+     * |        |          |0 = Receive PDMA function Disabled.
+     * |        |          |1 = Receive PDMA function Enabled.
+     * |[3]     |PDMAEN    |PDMA Mode Enable Bit
+     * |        |          |0 = PDMA function Disabled.
+     * |        |          |1 = PDMA function Enabled.
+     * |        |          |Notice: The I2C is not supporting PDMA function.
+     * @var USPI_T::WKCTL
+     * Offset: 0x54  USCI Wake-up Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKEN      |Wake-up Enable Bit
+     * |        |          |0 = Wake-up function Disabled.
+     * |        |          |1 = Wake-up function Enabled.
+     * |[1]     |WKADDREN  |Wake-up Address Match Enable Bit
+     * |        |          |0 = The chip is woken up according data toggle.
+     * |        |          |1 = The chip is woken up according address match.
+     * |[2]     |PDBOPT    |Power Down Blocking Option
+     * |        |          |0 = If user attempts to enter Power-down mode by executing WFI while the protocol is in transferring, MCU will stop the transfer and enter Power-down mode immediately.
+     * |        |          |1 = If user attempts to enter Power-down mode by executing WFI while the protocol is in transferring, the on-going transfer will not be stopped and MCU will enter idle mode immediately.
+     * @var USPI_T::WKSTS
+     * Offset: 0x58  USCI Wake-up Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKF       |Wake-up Flag
+     * |        |          |When chip is woken up from Power-down mode, this bit is set to 1
+     * |        |          |Software can write 1 to clear this bit.
+     * @var USPI_T::PROTCTL
+     * Offset: 0x5C  USCI Protocol Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SLAVE     |Slave Mode Selection
+     * |        |          |0 = Master mode.
+     * |        |          |1 = Slave mode.
+     * |[1]     |SLV3WIRE  |Slave 3-wire Mode Selection (Slave Only)
+     * |        |          |The SPI protocol can work with 3-wire interface (without slave select signal) in Slave mode.
+     * |        |          |0 = 4-wire bi-direction interface.
+     * |        |          |1 = 3-wire bi-direction interface.
+     * |[2]     |SS        |Slave Select Control (Master Only)
+     * |        |          |If AUTOSS bit is cleared, setting this bit to 1 will set the slave select signal to active state, and setting this bit to 0 will set the slave select back to inactive state.
+     * |        |          |If the AUTOSS function is enabled (AUTOSS = 1), the setting value of this bit will not affect the current state of slave select signal.
+     * |        |          |Note: In SPI protocol, the internal slave select signal is active high.
+     * |[3]     |AUTOSS    |Automatic Slave Select Function Enable (Master Only)
+     * |        |          |0 = Slave select signal will be controlled by the setting value of SS (USPI_PROTCTL[2]) bit.
+     * |        |          |1 = Slave select signal will be generated automatically
+     * |        |          |The slave select signal will be asserted by the SPI controller when transmit/receive is started, and will be de-asserted after each transmit/receive is finished.
+     * |[7:6]   |SCLKMODE  |Serial Bus Clock Mode
+     * |        |          |This bit field defines the SCLK idle status, data transmit, and data receive edge.
+     * |        |          |MODE0 = The idle state of SPI clock is low level
+     * |        |          |Data is transmitted with falling edge and received with rising edge.
+     * |        |          |MODE1 = The idle state of SPI clock is low level
+     * |        |          |Data is transmitted with rising edge and received with falling edge.
+     * |        |          |MODE2 = The idle state of SPI clock is high level
+     * |        |          |Data is transmitted with rising edge and received with falling edge.
+     * |        |          |MODE3 = The idle state of SPI clock is high level
+     * |        |          |Data is transmitted with falling edge and received with rising edge.
+     * |[11:8]  |SUSPITV   |Suspend Interval (Master Only)
+     * |        |          |This bit field provides the configurable suspend interval between two successive transmit/receive transaction in a transfer
+     * |        |          |The definition of the suspend interval is the interval between the last clock edge of the preceding transaction word and the first clock edge of the following transaction word
+     * |        |          |The default value is 0x3
+     * |        |          |The period of the suspend interval is obtained according to the following equation.
+     * |        |          |(SUSPITV[3:0] + 0.5) * period of SPI_CLK clock cycle
+     * |        |          |Example:
+     * |        |          |SUSPITV = 0x0 u2026 0.5 SPI_CLK clock cycle.
+     * |        |          |SUSPITV = 0x1 u2026 1.5 SPI_CLK clock cycle.
+     * |        |          |u2026u2026
+     * |        |          |SUSPITV = 0xE u2026 14.5 SPI_CLK clock cycle.
+     * |        |          |SUSPITV = 0xF u2026 15.5 SPI_CLK clock cycle.
+     * |[14:12] |TSMSEL    |Transmit Data Mode Selection
+     * |        |          |This bit field describes how receive and transmit data is shifted in and out.
+     * |        |          |TSMSEL = 000b: Full-duplex SPI.
+     * |        |          |TSMSEL = 100b: Half-duplex SPI.
+     * |        |          |Other values are reserved.
+     * |        |          |Note: Changing the value of this bit field will produce the TXRST and RXRST to clear the TX/RX data buffer automatically.
+     * |[25:16] |SLVTOCNT  |Slave Mode Time-out Period (Slave Only)
+     * |        |          |In Slave mode, this bit field is used for Slave time-out period
+     * |        |          |This bit field indicates how many clock periods (selected by TMCNTSRC, USPI_BRGEN[5]) between the two edges of input SCLK will assert the Slave time-out event
+     * |        |          |Writing 0x0 into this bit field will disable the Slave time-out function.
+     * |        |          |Example: Assume SLVTOCNT is 0x0A and TMCNTSRC (USPI_BRGEN[5]) is 1, it means the time-out event will occur if the state of SPI bus clock pin is not changed more than (10+1) periods of fDIV_CLK.
+     * |[28]    |TXUDRPOL  |Transmit Under-run Data Polarity (for Slave)
+     * |        |          |This bit defines the transmitting data level when no data is available for transferring.
+     * |        |          |0 = The output data level is 0 if TX under run event occurs.
+     * |        |          |1 = The output data level is 1 if TX under run event occurs.
+     * |[31]    |PROTEN    |SPI Protocol Enable Bit
+     * |        |          |0 = SPI Protocol Disabled.
+     * |        |          |1 = SPI Protocol Enabled.
+     * @var USPI_T::PROTIEN
+     * Offset: 0x60  USCI Protocol Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SSINAIEN  |Slave Select Inactive Interrupt Enable Control
+     * |        |          |This bit enables/disables the generation of a slave select interrupt if the slave select changes to inactive.
+     * |        |          |0 = Slave select inactive interrupt generation Disabled.
+     * |        |          |1 = Slave select inactive interrupt generation Enabled.
+     * |[1]     |SSACTIEN  |Slave Select Active Interrupt Enable Control
+     * |        |          |This bit enables/disables the generation of a slave select interrupt if the slave select changes to active.
+     * |        |          |0 = Slave select active interrupt generation Disabled.
+     * |        |          |1 = Slave select active interrupt generation Enabled.
+     * |[2]     |SLVTOIEN  |Slave Time-out Interrupt Enable Control
+     * |        |          |In SPI protocol, this bit enables the interrupt generation in case of a Slave time-out event.
+     * |        |          |0 = The Slave time-out interrupt Disabled.
+     * |        |          |1 = The Slave time-out interrupt Enabled.
+     * |[3]     |SLVBEIEN  |Slave Mode Bit Count Error Interrupt Enable Control
+     * |        |          |If data transfer is terminated by slave time-out or slave select inactive event in Slave mode, so that the transmit/receive data bit count does not match the setting of DWIDTH (USPI_LINECTL[11:8])
+     * |        |          |Bit count error event occurs.
+     * |        |          |0 = The Slave mode bit count error interrupt Disabled.
+     * |        |          |1 = The Slave mode bit count error interrupt Enabled.
+     * @var USPI_T::PROTSTS
+     * Offset: 0x64  USCI Protocol Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |TXSTIF    |Transmit Start Interrupt Flag
+     * |        |          |0 = Transmit start event does not occur.
+     * |        |          |1 = Transmit start event occurs.
+     * |        |          |Note: It is cleared by software writes 1 to this bit
+     * |[2]     |TXENDIF   |Transmit End Interrupt Flag
+     * |        |          |0 = Transmit end event does not occur.
+     * |        |          |1 = Transmit end event occurs.
+     * |        |          |Note: It is cleared by software writes 1 to this bit
+     * |[3]     |RXSTIF    |Receive Start Interrupt Flag
+     * |        |          |0 = Receive start event does not occur.
+     * |        |          |1 = Receive start event occurs.
+     * |        |          |Note: It is cleared by software writes 1 to this bit
+     * |[4]     |RXENDIF   |Receive End Interrupt Flag
+     * |        |          |0 = Receive end event does not occur.
+     * |        |          |1 = Receive end event occurs.
+     * |        |          |Note: It is cleared by software writes 1 to this bit
+     * |[5]     |SLVTOIF   |Slave Time-out Interrupt Flag (for Slave Only)
+     * |        |          |0 = Slave time-out event does not occur.
+     * |        |          |1 = Slave time-out event occurs.
+     * |        |          |Note: It is cleared by software writes 1 to this bit
+     * |[6]     |SLVBEIF   |Slave Bit Count Error Interrupt Flag (for Slave Only)
+     * |        |          |0 = Slave bit count error event does not occur.
+     * |        |          |1 = Slave bit count error event occurs.
+     * |        |          |Note: It is cleared by software writes 1 to this bit.
+     * |[8]     |SSINAIF   |Slave Select Inactive Interrupt Flag (for Slave Only)
+     * |        |          |This bit indicates that the internal slave select signal has changed to inactive
+     * |        |          |It is cleared by software writes 1 to this bit
+     * |        |          |0 = The slave select signal has not changed to inactive.
+     * |        |          |1 = The slave select signal has changed to inactive.
+     * |        |          |Note: The internal slave select signal is active high.
+     * |[9]     |SSACTIF   |Slave Select Active Interrupt Flag (for Slave Only)
+     * |        |          |This bit indicates that the internal slave select signal has changed to active
+     * |        |          |It is cleared by software writes one to this bit
+     * |        |          |0 = The slave select signal has not changed to active.
+     * |        |          |1 = The slave select signal has changed to active.
+     * |        |          |Note: The internal slave select signal is active high.
+     * |[16]    |SSLINE    |Slave Select Line Bus Status (Read Only)
+     * |        |          |This bit is only available in Slave mode
+     * |        |          |It used to monitor the current status of the input slave select signal on the bus.
+     * |        |          |0 = The slave select line status is 0.
+     * |        |          |1 = The slave select line status is 1.
+     * |[17]    |BUSY      |Busy Status (Read Only)
+     * |        |          |0 = SPI is in idle state.
+     * |        |          |1 = SPI is in busy state.
+     * |        |          |The following listing are the bus busy conditions:
+     * |        |          |a. USPI_PROTCTL[31] = 1 and the TXEMPTY = 0.
+     * |        |          |b. For SPI Master mode, the TXEMPTY = 1 but the current transaction is not finished yet.
+     * |        |          |c
+     * |        |          |For SPI Slave mode, the USPI_PROTCTL[31] = 1 and there is serial clock input into the SPI core logic when slave select is active.
+     * |        |          |d
+     * |        |          |For SPI Slave mode, the USPI_PROTCTL[31] = 1 and the transmit buffer or transmit shift register is not empty even if the slave select is inactive.
+     * |[18]    |SLVUDR    |Slave Mode Transmit Under-run Status (Read Only)
+     * |        |          |In Slave mode, if there is no available transmit data in buffer while transmit data shift out caused by input serial bus clock, this status flag will be set to 1
+     * |        |          |This bit indicates whether the current shift-out data of word transmission is switched to TXUDRPOL (USPI_PROTCTL[28]) or not.
+     * |        |          |0 = Slave transmit under run event does not occur.
+     * |        |          |1 = Slave transmit under run event occurs.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] USCI Control Register                                            */
+    __IO uint32_t INTEN;                 /*!< [0x0004] USCI Interrupt Enable Register                                   */
+    __IO uint32_t BRGEN;                 /*!< [0x0008] USCI Baud Rate Generator Register                                */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t DATIN0;                /*!< [0x0010] USCI Input Data Signal Configuration Register 0                  */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CTLIN0;                /*!< [0x0020] USCI Input Control Signal Configuration Register 0               */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CLKIN;                 /*!< [0x0028] USCI Input Clock Signal Configuration Register                   */
+    __IO uint32_t LINECTL;               /*!< [0x002c] USCI Line Control Register                                       */
+    __O  uint32_t TXDAT;                 /*!< [0x0030] USCI Transmit Data Register                                      */
+    __I  uint32_t RXDAT;                 /*!< [0x0034] USCI Receive Data Register                                       */
+    __IO uint32_t BUFCTL;                /*!< [0x0038] USCI Transmit/Receive Buffer Control Register                    */
+    __IO uint32_t BUFSTS;                /*!< [0x003c] USCI Transmit/Receive Buffer Status Register                     */
+    __IO uint32_t PDMACTL;               /*!< [0x0040] USCI PDMA Control Register                                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[4];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t WKCTL;                 /*!< [0x0054] USCI Wake-up Control Register                                    */
+    __IO uint32_t WKSTS;                 /*!< [0x0058] USCI Wake-up Status Register                                     */
+    __IO uint32_t PROTCTL;               /*!< [0x005c] USCI Protocol Control Register                                   */
+    __IO uint32_t PROTIEN;               /*!< [0x0060] USCI Protocol Interrupt Enable Register                          */
+    __IO uint32_t PROTSTS;               /*!< [0x0064] USCI Protocol Status Register                                    */
+} USPI_T;
+
+/**
+    @addtogroup USPI_CONST USPI Bit Field Definition
+    Constant Definitions for USPI Controller
+@{ */
+
+#define USPI_CTL_FUNMODE_Pos             (0)                                               /*!< USPI_T::CTL: FUNMODE Position          */
+#define USPI_CTL_FUNMODE_Msk             (0x7ul << USPI_CTL_FUNMODE_Pos)                   /*!< USPI_T::CTL: FUNMODE Mask              */
+
+#define USPI_INTEN_TXSTIEN_Pos           (1)                                               /*!< USPI_T::INTEN: TXSTIEN Position        */
+#define USPI_INTEN_TXSTIEN_Msk           (0x1ul << USPI_INTEN_TXSTIEN_Pos)                 /*!< USPI_T::INTEN: TXSTIEN Mask            */
+
+#define USPI_INTEN_TXENDIEN_Pos          (2)                                               /*!< USPI_T::INTEN: TXENDIEN Position       */
+#define USPI_INTEN_TXENDIEN_Msk          (0x1ul << USPI_INTEN_TXENDIEN_Pos)                /*!< USPI_T::INTEN: TXENDIEN Mask           */
+
+#define USPI_INTEN_RXSTIEN_Pos           (3)                                               /*!< USPI_T::INTEN: RXSTIEN Position        */
+#define USPI_INTEN_RXSTIEN_Msk           (0x1ul << USPI_INTEN_RXSTIEN_Pos)                 /*!< USPI_T::INTEN: RXSTIEN Mask            */
+
+#define USPI_INTEN_RXENDIEN_Pos          (4)                                               /*!< USPI_T::INTEN: RXENDIEN Position       */
+#define USPI_INTEN_RXENDIEN_Msk          (0x1ul << USPI_INTEN_RXENDIEN_Pos)                /*!< USPI_T::INTEN: RXENDIEN Mask           */
+
+#define USPI_BRGEN_RCLKSEL_Pos           (0)                                               /*!< USPI_T::BRGEN: RCLKSEL Position        */
+#define USPI_BRGEN_RCLKSEL_Msk           (0x1ul << USPI_BRGEN_RCLKSEL_Pos)                 /*!< USPI_T::BRGEN: RCLKSEL Mask            */
+
+#define USPI_BRGEN_PTCLKSEL_Pos          (1)                                               /*!< USPI_T::BRGEN: PTCLKSEL Position       */
+#define USPI_BRGEN_PTCLKSEL_Msk          (0x1ul << USPI_BRGEN_PTCLKSEL_Pos)                /*!< USPI_T::BRGEN: PTCLKSEL Mask           */
+
+#define USPI_BRGEN_SPCLKSEL_Pos          (2)                                               /*!< USPI_T::BRGEN: SPCLKSEL Position       */
+#define USPI_BRGEN_SPCLKSEL_Msk          (0x3ul << USPI_BRGEN_SPCLKSEL_Pos)                /*!< USPI_T::BRGEN: SPCLKSEL Mask           */
+
+#define USPI_BRGEN_TMCNTEN_Pos           (4)                                               /*!< USPI_T::BRGEN: TMCNTEN Position        */
+#define USPI_BRGEN_TMCNTEN_Msk           (0x1ul << USPI_BRGEN_TMCNTEN_Pos)                 /*!< USPI_T::BRGEN: TMCNTEN Mask            */
+
+#define USPI_BRGEN_TMCNTSRC_Pos          (5)                                               /*!< USPI_T::BRGEN: TMCNTSRC Position       */
+#define USPI_BRGEN_TMCNTSRC_Msk          (0x1ul << USPI_BRGEN_TMCNTSRC_Pos)                /*!< USPI_T::BRGEN: TMCNTSRC Mask           */
+
+#define USPI_BRGEN_CLKDIV_Pos            (16)                                              /*!< USPI_T::BRGEN: CLKDIV Position         */
+#define USPI_BRGEN_CLKDIV_Msk            (0x3fful << USPI_BRGEN_CLKDIV_Pos)                /*!< USPI_T::BRGEN: CLKDIV Mask             */
+
+#define USPI_DATIN0_SYNCSEL_Pos          (0)                                               /*!< USPI_T::DATIN0: SYNCSEL Position       */
+#define USPI_DATIN0_SYNCSEL_Msk          (0x1ul << USPI_DATIN0_SYNCSEL_Pos)                /*!< USPI_T::DATIN0: SYNCSEL Mask           */
+
+#define USPI_DATIN0_ININV_Pos            (2)                                               /*!< USPI_T::DATIN0: ININV Position         */
+#define USPI_DATIN0_ININV_Msk            (0x1ul << USPI_DATIN0_ININV_Pos)                  /*!< USPI_T::DATIN0: ININV Mask             */
+
+#define USPI_CTLIN0_SYNCSEL_Pos          (0)                                               /*!< USPI_T::CTLIN0: SYNCSEL Position       */
+#define USPI_CTLIN0_SYNCSEL_Msk          (0x1ul << USPI_CTLIN0_SYNCSEL_Pos)                /*!< USPI_T::CTLIN0: SYNCSEL Mask           */
+
+#define USPI_CTLIN0_ININV_Pos            (2)                                               /*!< USPI_T::CTLIN0: ININV Position         */
+#define USPI_CTLIN0_ININV_Msk            (0x1ul << USPI_CTLIN0_ININV_Pos)                  /*!< USPI_T::CTLIN0: ININV Mask             */
+
+#define USPI_CLKIN_SYNCSEL_Pos           (0)                                               /*!< USPI_T::CLKIN: SYNCSEL Position        */
+#define USPI_CLKIN_SYNCSEL_Msk           (0x1ul << USPI_CLKIN_SYNCSEL_Pos)                 /*!< USPI_T::CLKIN: SYNCSEL Mask            */
+
+#define USPI_LINECTL_LSB_Pos             (0)                                               /*!< USPI_T::LINECTL: LSB Position          */
+#define USPI_LINECTL_LSB_Msk             (0x1ul << USPI_LINECTL_LSB_Pos)                   /*!< USPI_T::LINECTL: LSB Mask              */
+
+#define USPI_LINECTL_DATOINV_Pos         (5)                                               /*!< USPI_T::LINECTL: DATOINV Position      */
+#define USPI_LINECTL_DATOINV_Msk         (0x1ul << USPI_LINECTL_DATOINV_Pos)               /*!< USPI_T::LINECTL: DATOINV Mask          */
+
+#define USPI_LINECTL_CTLOINV_Pos         (7)                                               /*!< USPI_T::LINECTL: CTLOINV Position      */
+#define USPI_LINECTL_CTLOINV_Msk         (0x1ul << USPI_LINECTL_CTLOINV_Pos)               /*!< USPI_T::LINECTL: CTLOINV Mask          */
+
+#define USPI_LINECTL_DWIDTH_Pos          (8)                                               /*!< USPI_T::LINECTL: DWIDTH Position       */
+#define USPI_LINECTL_DWIDTH_Msk          (0xful << USPI_LINECTL_DWIDTH_Pos)                /*!< USPI_T::LINECTL: DWIDTH Mask           */
+
+#define USPI_TXDAT_TXDAT_Pos             (0)                                               /*!< USPI_T::TXDAT: TXDAT Position          */
+#define USPI_TXDAT_TXDAT_Msk             (0xfffful << USPI_TXDAT_TXDAT_Pos)                /*!< USPI_T::TXDAT: TXDAT Mask              */
+
+#define USPI_TXDAT_PORTDIR_Pos           (16)                                              /*!< USPI_T::TXDAT: PORTDIR Position        */
+#define USPI_TXDAT_PORTDIR_Msk           (0x1ul << USPI_TXDAT_PORTDIR_Pos)                 /*!< USPI_T::TXDAT: PORTDIR Mask            */
+
+#define USPI_RXDAT_RXDAT_Pos             (0)                                               /*!< USPI_T::RXDAT: RXDAT Position          */
+#define USPI_RXDAT_RXDAT_Msk             (0xfffful << USPI_RXDAT_RXDAT_Pos)                /*!< USPI_T::RXDAT: RXDAT Mask              */
+
+#define USPI_BUFCTL_TXUDRIEN_Pos         (6)                                               /*!< USPI_T::BUFCTL: TXUDRIEN Position      */
+#define USPI_BUFCTL_TXUDRIEN_Msk         (0x1ul << USPI_BUFCTL_TXUDRIEN_Pos)               /*!< USPI_T::BUFCTL: TXUDRIEN Mask          */
+
+#define USPI_BUFCTL_TXCLR_Pos            (7)                                               /*!< USPI_T::BUFCTL: TXCLR Position         */
+#define USPI_BUFCTL_TXCLR_Msk            (0x1ul << USPI_BUFCTL_TXCLR_Pos)                  /*!< USPI_T::BUFCTL: TXCLR Mask             */
+
+#define USPI_BUFCTL_RXOVIEN_Pos          (14)                                              /*!< USPI_T::BUFCTL: RXOVIEN Position       */
+#define USPI_BUFCTL_RXOVIEN_Msk          (0x1ul << USPI_BUFCTL_RXOVIEN_Pos)                /*!< USPI_T::BUFCTL: RXOVIEN Mask           */
+
+#define USPI_BUFCTL_RXCLR_Pos            (15)                                              /*!< USPI_T::BUFCTL: RXCLR Position         */
+#define USPI_BUFCTL_RXCLR_Msk            (0x1ul << USPI_BUFCTL_RXCLR_Pos)                  /*!< USPI_T::BUFCTL: RXCLR Mask             */
+
+#define USPI_BUFCTL_TXRST_Pos            (16)                                              /*!< USPI_T::BUFCTL: TXRST Position         */
+#define USPI_BUFCTL_TXRST_Msk            (0x1ul << USPI_BUFCTL_TXRST_Pos)                  /*!< USPI_T::BUFCTL: TXRST Mask             */
+
+#define USPI_BUFCTL_RXRST_Pos            (17)                                              /*!< USPI_T::BUFCTL: RXRST Position         */
+#define USPI_BUFCTL_RXRST_Msk            (0x1ul << USPI_BUFCTL_RXRST_Pos)                  /*!< USPI_T::BUFCTL: RXRST Mask             */
+
+#define USPI_BUFSTS_RXEMPTY_Pos          (0)                                               /*!< USPI_T::BUFSTS: RXEMPTY Position       */
+#define USPI_BUFSTS_RXEMPTY_Msk          (0x1ul << USPI_BUFSTS_RXEMPTY_Pos)                /*!< USPI_T::BUFSTS: RXEMPTY Mask           */
+
+#define USPI_BUFSTS_RXFULL_Pos           (1)                                               /*!< USPI_T::BUFSTS: RXFULL Position        */
+#define USPI_BUFSTS_RXFULL_Msk           (0x1ul << USPI_BUFSTS_RXFULL_Pos)                 /*!< USPI_T::BUFSTS: RXFULL Mask            */
+
+#define USPI_BUFSTS_RXOVIF_Pos           (3)                                               /*!< USPI_T::BUFSTS: RXOVIF Position        */
+#define USPI_BUFSTS_RXOVIF_Msk           (0x1ul << USPI_BUFSTS_RXOVIF_Pos)                 /*!< USPI_T::BUFSTS: RXOVIF Mask            */
+
+#define USPI_BUFSTS_TXEMPTY_Pos          (8)                                               /*!< USPI_T::BUFSTS: TXEMPTY Position       */
+#define USPI_BUFSTS_TXEMPTY_Msk          (0x1ul << USPI_BUFSTS_TXEMPTY_Pos)                /*!< USPI_T::BUFSTS: TXEMPTY Mask           */
+
+#define USPI_BUFSTS_TXFULL_Pos           (9)                                               /*!< USPI_T::BUFSTS: TXFULL Position        */
+#define USPI_BUFSTS_TXFULL_Msk           (0x1ul << USPI_BUFSTS_TXFULL_Pos)                 /*!< USPI_T::BUFSTS: TXFULL Mask            */
+
+#define USPI_BUFSTS_TXUDRIF_Pos          (11)                                              /*!< USPI_T::BUFSTS: TXUDRIF Position       */
+#define USPI_BUFSTS_TXUDRIF_Msk          (0x1ul << USPI_BUFSTS_TXUDRIF_Pos)                /*!< USPI_T::BUFSTS: TXUDRIF Mask           */
+
+#define USPI_PDMACTL_PDMARST_Pos         (0)                                               /*!< USPI_T::PDMACTL: PDMARST Position      */
+#define USPI_PDMACTL_PDMARST_Msk         (0x1ul << USPI_PDMACTL_PDMARST_Pos)               /*!< USPI_T::PDMACTL: PDMARST Mask          */
+
+#define USPI_PDMACTL_TXPDMAEN_Pos        (1)                                               /*!< USPI_T::PDMACTL: TXPDMAEN Position     */
+#define USPI_PDMACTL_TXPDMAEN_Msk        (0x1ul << USPI_PDMACTL_TXPDMAEN_Pos)              /*!< USPI_T::PDMACTL: TXPDMAEN Mask         */
+
+#define USPI_PDMACTL_RXPDMAEN_Pos        (2)                                               /*!< USPI_T::PDMACTL: RXPDMAEN Position     */
+#define USPI_PDMACTL_RXPDMAEN_Msk        (0x1ul << USPI_PDMACTL_RXPDMAEN_Pos)              /*!< USPI_T::PDMACTL: RXPDMAEN Mask         */
+
+#define USPI_PDMACTL_PDMAEN_Pos          (3)                                               /*!< USPI_T::PDMACTL: PDMAEN Position       */
+#define USPI_PDMACTL_PDMAEN_Msk          (0x1ul << USPI_PDMACTL_PDMAEN_Pos)                /*!< USPI_T::PDMACTL: PDMAEN Mask           */
+
+#define USPI_WKCTL_WKEN_Pos              (0)                                               /*!< USPI_T::WKCTL: WKEN Position           */
+#define USPI_WKCTL_WKEN_Msk              (0x1ul << USPI_WKCTL_WKEN_Pos)                    /*!< USPI_T::WKCTL: WKEN Mask               */
+
+#define USPI_WKCTL_WKADDREN_Pos          (1)                                               /*!< USPI_T::WKCTL: WKADDREN Position       */
+#define USPI_WKCTL_WKADDREN_Msk          (0x1ul << USPI_WKCTL_WKADDREN_Pos)                /*!< USPI_T::WKCTL: WKADDREN Mask           */
+
+#define USPI_WKCTL_PDBOPT_Pos            (2)                                               /*!< USPI_T::WKCTL: PDBOPT Position         */
+#define USPI_WKCTL_PDBOPT_Msk            (0x1ul << USPI_WKCTL_PDBOPT_Pos)                  /*!< USPI_T::WKCTL: PDBOPT Mask             */
+
+#define USPI_WKSTS_WKF_Pos               (0)                                               /*!< USPI_T::WKSTS: WKF Position            */
+#define USPI_WKSTS_WKF_Msk               (0x1ul << USPI_WKSTS_WKF_Pos)                     /*!< USPI_T::WKSTS: WKF Mask                */
+
+#define USPI_PROTCTL_SLAVE_Pos           (0)                                               /*!< USPI_T::PROTCTL: SLAVE Position        */
+#define USPI_PROTCTL_SLAVE_Msk           (0x1ul << USPI_PROTCTL_SLAVE_Pos)                 /*!< USPI_T::PROTCTL: SLAVE Mask            */
+
+#define USPI_PROTCTL_SLV3WIRE_Pos        (1)                                               /*!< USPI_T::PROTCTL: SLV3WIRE Position     */
+#define USPI_PROTCTL_SLV3WIRE_Msk        (0x1ul << USPI_PROTCTL_SLV3WIRE_Pos)              /*!< USPI_T::PROTCTL: SLV3WIRE Mask         */
+
+#define USPI_PROTCTL_SS_Pos              (2)                                               /*!< USPI_T::PROTCTL: SS Position           */
+#define USPI_PROTCTL_SS_Msk              (0x1ul << USPI_PROTCTL_SS_Pos)                    /*!< USPI_T::PROTCTL: SS Mask               */
+
+#define USPI_PROTCTL_AUTOSS_Pos          (3)                                               /*!< USPI_T::PROTCTL: AUTOSS Position       */
+#define USPI_PROTCTL_AUTOSS_Msk          (0x1ul << USPI_PROTCTL_AUTOSS_Pos)                /*!< USPI_T::PROTCTL: AUTOSS Mask           */
+
+#define USPI_PROTCTL_SCLKMODE_Pos        (6)                                               /*!< USPI_T::PROTCTL: SCLKMODE Position     */
+#define USPI_PROTCTL_SCLKMODE_Msk        (0x3ul << USPI_PROTCTL_SCLKMODE_Pos)              /*!< USPI_T::PROTCTL: SCLKMODE Mask         */
+
+#define USPI_PROTCTL_SUSPITV_Pos         (8)                                               /*!< USPI_T::PROTCTL: SUSPITV Position      */
+#define USPI_PROTCTL_SUSPITV_Msk         (0xful << USPI_PROTCTL_SUSPITV_Pos)               /*!< USPI_T::PROTCTL: SUSPITV Mask          */
+
+#define USPI_PROTCTL_TSMSEL_Pos          (12)                                              /*!< USPI_T::PROTCTL: TSMSEL Position       */
+#define USPI_PROTCTL_TSMSEL_Msk          (0x7ul << USPI_PROTCTL_TSMSEL_Pos)                /*!< USPI_T::PROTCTL: TSMSEL Mask           */
+
+#define USPI_PROTCTL_SLVTOCNT_Pos        (16)                                              /*!< USPI_T::PROTCTL: SLVTOCNT Position     */
+#define USPI_PROTCTL_SLVTOCNT_Msk        (0x3fful << USPI_PROTCTL_SLVTOCNT_Pos)            /*!< USPI_T::PROTCTL: SLVTOCNT Mask         */
+
+#define USPI_PROTCTL_TXUDRPOL_Pos        (28)                                              /*!< USPI_T::PROTCTL: TXUDRPOL Position     */
+#define USPI_PROTCTL_TXUDRPOL_Msk        (0x1ul << USPI_PROTCTL_TXUDRPOL_Pos)              /*!< USPI_T::PROTCTL: TXUDRPOL Mask         */
+
+#define USPI_PROTCTL_PROTEN_Pos          (31)                                              /*!< USPI_T::PROTCTL: PROTEN Position       */
+#define USPI_PROTCTL_PROTEN_Msk          (0x1ul << USPI_PROTCTL_PROTEN_Pos)                /*!< USPI_T::PROTCTL: PROTEN Mask           */
+
+#define USPI_PROTIEN_SSINAIEN_Pos        (0)                                               /*!< USPI_T::PROTIEN: SSINAIEN Position     */
+#define USPI_PROTIEN_SSINAIEN_Msk        (0x1ul << USPI_PROTIEN_SSINAIEN_Pos)              /*!< USPI_T::PROTIEN: SSINAIEN Mask         */
+
+#define USPI_PROTIEN_SSACTIEN_Pos        (1)                                               /*!< USPI_T::PROTIEN: SSACTIEN Position     */
+#define USPI_PROTIEN_SSACTIEN_Msk        (0x1ul << USPI_PROTIEN_SSACTIEN_Pos)              /*!< USPI_T::PROTIEN: SSACTIEN Mask         */
+
+#define USPI_PROTIEN_SLVTOIEN_Pos        (2)                                               /*!< USPI_T::PROTIEN: SLVTOIEN Position     */
+#define USPI_PROTIEN_SLVTOIEN_Msk        (0x1ul << USPI_PROTIEN_SLVTOIEN_Pos)              /*!< USPI_T::PROTIEN: SLVTOIEN Mask         */
+
+#define USPI_PROTIEN_SLVBEIEN_Pos        (3)                                               /*!< USPI_T::PROTIEN: SLVBEIEN Position     */
+#define USPI_PROTIEN_SLVBEIEN_Msk        (0x1ul << USPI_PROTIEN_SLVBEIEN_Pos)              /*!< USPI_T::PROTIEN: SLVBEIEN Mask         */
+
+#define USPI_PROTSTS_TXSTIF_Pos          (1)                                               /*!< USPI_T::PROTSTS: TXSTIF Position       */
+#define USPI_PROTSTS_TXSTIF_Msk          (0x1ul << USPI_PROTSTS_TXSTIF_Pos)                /*!< USPI_T::PROTSTS: TXSTIF Mask           */
+
+#define USPI_PROTSTS_TXENDIF_Pos         (2)                                               /*!< USPI_T::PROTSTS: TXENDIF Position      */
+#define USPI_PROTSTS_TXENDIF_Msk         (0x1ul << USPI_PROTSTS_TXENDIF_Pos)               /*!< USPI_T::PROTSTS: TXENDIF Mask          */
+
+#define USPI_PROTSTS_RXSTIF_Pos          (3)                                               /*!< USPI_T::PROTSTS: RXSTIF Position       */
+#define USPI_PROTSTS_RXSTIF_Msk          (0x1ul << USPI_PROTSTS_RXSTIF_Pos)                /*!< USPI_T::PROTSTS: RXSTIF Mask           */
+
+#define USPI_PROTSTS_RXENDIF_Pos         (4)                                               /*!< USPI_T::PROTSTS: RXENDIF Position      */
+#define USPI_PROTSTS_RXENDIF_Msk         (0x1ul << USPI_PROTSTS_RXENDIF_Pos)               /*!< USPI_T::PROTSTS: RXENDIF Mask          */
+
+#define USPI_PROTSTS_SLVTOIF_Pos         (5)                                               /*!< USPI_T::PROTSTS: SLVTOIF Position      */
+#define USPI_PROTSTS_SLVTOIF_Msk         (0x1ul << USPI_PROTSTS_SLVTOIF_Pos)               /*!< USPI_T::PROTSTS: SLVTOIF Mask          */
+
+#define USPI_PROTSTS_SLVBEIF_Pos         (6)                                               /*!< USPI_T::PROTSTS: SLVBEIF Position      */
+#define USPI_PROTSTS_SLVBEIF_Msk         (0x1ul << USPI_PROTSTS_SLVBEIF_Pos)               /*!< USPI_T::PROTSTS: SLVBEIF Mask          */
+
+#define USPI_PROTSTS_SSINAIF_Pos         (8)                                               /*!< USPI_T::PROTSTS: SSINAIF Position      */
+#define USPI_PROTSTS_SSINAIF_Msk         (0x1ul << USPI_PROTSTS_SSINAIF_Pos)               /*!< USPI_T::PROTSTS: SSINAIF Mask          */
+
+#define USPI_PROTSTS_SSACTIF_Pos         (9)                                               /*!< USPI_T::PROTSTS: SSACTIF Position      */
+#define USPI_PROTSTS_SSACTIF_Msk         (0x1ul << USPI_PROTSTS_SSACTIF_Pos)               /*!< USPI_T::PROTSTS: SSACTIF Mask          */
+
+#define USPI_PROTSTS_SSLINE_Pos          (16)                                              /*!< USPI_T::PROTSTS: SSLINE Position       */
+#define USPI_PROTSTS_SSLINE_Msk          (0x1ul << USPI_PROTSTS_SSLINE_Pos)                /*!< USPI_T::PROTSTS: SSLINE Mask           */
+
+#define USPI_PROTSTS_BUSY_Pos            (17)                                              /*!< USPI_T::PROTSTS: BUSY Position         */
+#define USPI_PROTSTS_BUSY_Msk            (0x1ul << USPI_PROTSTS_BUSY_Pos)                  /*!< USPI_T::PROTSTS: BUSY Mask             */
+
+#define USPI_PROTSTS_SLVUDR_Pos          (18)                                              /*!< USPI_T::PROTSTS: SLVUDR Position       */
+#define USPI_PROTSTS_SLVUDR_Msk          (0x1ul << USPI_PROTSTS_SLVUDR_Pos)                /*!< USPI_T::PROTSTS: SLVUDR Mask           */
+
+/** @} USPI_CONST */
+/** @} end of USPI register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __USPI_REG_H__ */

--- a/hal/m258ke/nuvoton/uuart_reg.h
+++ b/hal/m258ke/nuvoton/uuart_reg.h
@@ -1,0 +1,690 @@
+/**************************************************************************//**
+ * @file     uuart_reg.h
+ * @version  V1.00
+ * @brief    UUART register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __UUART_REG_H__
+#define __UUART_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup UUART UART Mode of USCI Controller (UUART)
+    Memory Mapped Structure for UUART Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var UUART_T::CTL
+     * Offset: 0x00  USCI Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[2:0]   |FUNMODE   |Function Mode
+     * |        |          |This bit field selects the protocol for this USCI controller
+     * |        |          |Selecting a protocol that is not available or a reserved combination disables the USCI
+     * |        |          |When switching between two protocols, the USCI has to be disabled before selecting a new protocol
+     * |        |          |Simultaneously, the USCI will be reset when user write 000 to FUNMODE.
+     * |        |          |000 = The USCI is disabled. All protocol related state machines are set to idle state.
+     * |        |          |001 = The SPI protocol is selected.
+     * |        |          |010 = The UART protocol is selected.
+     * |        |          |100 = The I2C protocol is selected.
+     * |        |          |Note: Other bit combinations are reserved.
+     * @var UUART_T::INTEN
+     * Offset: 0x04  USCI Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |TXSTIEN   |Transmit Start Interrupt Enable Bit
+     * |        |          |This bit enables the interrupt generation in case of a transmit start event.
+     * |        |          |0 = The transmit start interrupt is disabled.
+     * |        |          |1 = The transmit start interrupt is enabled.
+     * |[2]     |TXENDIEN  |Transmit End Interrupt Enable Bit
+     * |        |          |This bit enables the interrupt generation in case of a transmit finish event.
+     * |        |          |0 = The transmit finish interrupt is disabled.
+     * |        |          |1 = The transmit finish interrupt is enabled.
+     * |[3]     |RXSTIEN   |Receive Start Interrupt Enable BIt
+     * |        |          |This bit enables the interrupt generation in case of a receive start event.
+     * |        |          |0 = The receive start interrupt is disabled.
+     * |        |          |1 = The receive start interrupt is enabled.
+     * |[4]     |RXENDIEN  |Receive End Interrupt Enable Bit
+     * |        |          |This bit enables the interrupt generation in case of a receive finish event.
+     * |        |          |0 = The receive end interrupt is disabled.
+     * |        |          |1 = The receive end interrupt is enabled.
+     * @var UUART_T::BRGEN
+     * Offset: 0x08  USCI Baud Rate Generator Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RCLKSEL   |Reference Clock Source Selection
+     * |        |          |This bit selects the source signal of reference clock (fREF_CLK).
+     * |        |          |0 = Peripheral device clock fPCLK.
+     * |        |          |1 = Reserved.
+     * |[1]     |PTCLKSEL  |Protocol Clock Source Selection
+     * |        |          |This bit selects the source signal of protocol clock (fPROT_CLK).
+     * |        |          |0 = Reference clock fREF_CLK.
+     * |        |          |1 = fREF_CLK2 (its frequency is half of fREF_CLK).
+     * |[3:2]   |SPCLKSEL  |Sample Clock Source Selection
+     * |        |          |This bit field used for the clock source selection of a sample clock (fSAMP_CLK) for the protocol processor.
+     * |        |          |00 = fSAMP_CLK = fDIV_CLK.
+     * |        |          |01 = fSAMP_CLK = fPROT_CLK.
+     * |        |          |10 = fSAMP_CLK = fSCLK.
+     * |        |          |11 = fSAMP_CLK = fREF_CLK.
+     * |[4]     |TMCNTEN   |Timing Measurement Counter Enable Bit
+     * |        |          |This bit enables the 10-bit timing measurement counter.
+     * |        |          |0 = Timing measurement counter is Disabled.
+     * |        |          |1 = Timing measurement counter is Enabled.
+     * |[5]     |TMCNTSRC  |Timing Measurement Counter Clock Source Selection
+     * |        |          |0 = Timing measurement counter with fPROT_CLK.
+     * |        |          |1 = Timing measurement counter with fDIV_CLK.
+     * |[9:8]   |PDSCNT    |Pre-divider for Sample Counter
+     * |        |          |This bit field defines the divide ratio of the clock division from sample clock fSAMP_CLK
+     * |        |          |The divided frequency fPDS_CNT = fSAMP_CLK / (PDSCNT+1).
+     * |[14:10] |DSCNT     |Denominator for Sample Counter
+     * |        |          |This bit field defines the divide ratio of the sample clock fSAMP_CLK.
+     * |        |          |The divided frequency fDS_CNT = fPDS_CNT / (DSCNT+1).
+     * |        |          |Note: The maximum value of DSCNT is 0xF on UART mode and suggest to set over 4 to confirm the receiver data is sampled in right value
+     * |[25:16] |CLKDIV    |Clock Divider
+     * |        |          |This bit field defines the ratio between the protocol clock frequency fPROT_CLK and the clock divider frequency fDIV_CLK (fDIV_CLK = fPROT_CLK / (CLKDIV+1) ).
+     * |        |          |Note: In UART function, it can be updated by hardware in the 4th falling edge of the input data 0x55 when the auto baud rate function (ABREN(UUART_PROTCTL[6])) is enabled
+     * |        |          |The revised value is the average bit time between bit 5 and bit 6
+     * |        |          |The user can use revised CLKDIV and new BRDETITV (UUART_PROTCTL[24:16]) to calculate the precise baud rate.
+     * @var UUART_T::DATIN0
+     * Offset: 0x10  USCI Input Data Signal Configuration Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SYNCSEL   |Input Signal   Synchronization Selection
+     * |        |          |This bit   selects if the un-synchronized input signal (with optionally inverted) or the   synchronized (and optionally filtered) signal can be used as input for the   data shift unit.
+     * |        |          |0 = The   un-synchronized signal can be taken as input for the data shift unit.
+     * |        |          |1 = The   synchronized signal can be taken as input for the data shift unit.
+     * |[2]     |ININV     |Input   Signal Inverse Selection
+     * |        |          |This bit   defines the inverter enable of the input asynchronous signal.
+     * |        |          |0 = The   un-synchronized input signal will not be inverted.
+     * |        |          |1 = The   un-synchronized input signal will be inverted.
+     * |[4:3]   |EDGEDET   |Input Signal   Edge Detection Mode
+     * |        |          |This bit   field selects which edge actives the trigger event of input data signal.
+     * |        |          |00 = The   trigger event activation is disabled.
+     * |        |          |01 = A rising   edge activates the trigger event of input data signal.
+     * |        |          |10 = A   falling edge activates the trigger event of input data signal.
+     * |        |          |11 = Both   edges activate the trigger event of input data signal.
+     * |        |          |Note: In UART function mode, it is suggested to   set this bit field as 10.
+     * @var UUART_T::CTLIN0
+     * Offset: 0x20  USCI Input Control Signal Configuration Register 0
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SYNCSEL   |Input   Synchronization Signal Selection
+     * |        |          |This bit   selects if the un-synchronized input signal (with optionally inverted) or the   synchronized (and optionally filtered) signal can be used as input for the   data shift unit.
+     * |        |          |0 = The   un-synchronized signal can be taken as input for the data shift unit.
+     * |        |          |1 = The   synchronized signal can be taken as input for the data shift unit.
+     * |[2]     |ININV     |Input   Signal Inverse Selection
+     * |        |          |This bit   defines the inverter enable of the input asynchronous signal.
+     * |        |          |0 = The   un-synchronized input signal will not be inverted.
+     * |        |          |1 = The   un-synchronized input signal will be inverted.
+     * @var UUART_T::CLKIN
+     * Offset: 0x28  USCI Input Clock Signal Configuration Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |SYNCSEL   |Input   Synchronization Signal Selection
+     * |        |          |This bit   selects if the un-synchronized input signal or the synchronized (and   optionally filtered) signal can be used as input for the data shift unit.
+     * |        |          |0 = The   un-synchronized signal can be taken as input for the data shift unit.
+     * |        |          |1 = The   synchronized signal can be taken as input for the data shift unit.
+     * @var UUART_T::LINECTL
+     * Offset: 0x2C  USCI Line Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |LSB       |LSB First Transmission Selection
+     * |        |          |0 = The MSB, which bit of transmit/receive data buffer depends on the setting of DWIDTH, is transmitted/received first.
+     * |        |          |1 = The LSB, the bit 0 of data buffer, will be transmitted/received first.
+     * |[5]     |DATOINV   |Data Output Inverse Selection
+     * |        |          |This bit defines the relation between the internal shift data value and the output data signal of USCIx_DAT1 pin.
+     * |        |          |0 = The value of USCIx_DAT1 is equal to the data shift register.
+     * |        |          |1 = The value of USCIx_DAT1 is the inversion of data shift register.
+     * |[7]     |CTLOINV   |Control Signal Output Inverse Selection
+     * |        |          |This bit defines the relation between the internal control signal and the output control signal.
+     * |        |          |0 = No effect.
+     * |        |          |1 = The control signal will be inverted before its output.
+     * |        |          |Note: In UART protocol, the control signal means nRTS signal.
+     * |[11:8]  |DWIDTH    |Word Length of Transmission
+     * |        |          |This bit field defines the data word length (amount of bits) for reception and transmission
+     * |        |          |The data word is always right-aligned in the data buffer
+     * |        |          |USCI support word length from 4 to 16 bits.
+     * |        |          |0x0: The data word contains 16 bits located at bit positions [15:0].
+     * |        |          |0x1: Reserved.
+     * |        |          |0x2: Reserved.
+     * |        |          |0x3: Reserved.
+     * |        |          |0x4: The data word contains 4 bits located at bit positions [3:0].
+     * |        |          |0x5: The data word contains 5 bits located at bit positions [4:0].
+     * |        |          |...
+     * |        |          |0xF: The data word contains 15 bits located at bit positions [14:0].
+     * |        |          |Note: In UART protocol, the length can be configured as 6~13 bits.
+     * @var UUART_T::TXDAT
+     * Offset: 0x30  USCI Transmit Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |TXDAT     |Transmit Data
+     * |        |          |Software can use this bit field to write 16-bit transmit data for transmission.
+     * @var UUART_T::RXDAT
+     * Offset: 0x34  USCI Receive Data Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[15:0]  |RXDAT     |Received Data
+     * |        |          |This bit field monitors the received data which stored in receive data buffer.
+     * |        |          |Note: RXDAT[15:13] indicate the same frame status of BREAK, FRMERR and PARITYERR (UUART_PROTSTS[7:5]).
+     * @var UUART_T::BUFCTL
+     * Offset: 0x38  USCI Transmit/Receive Buffer Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[7]     |TXCLR     |Clear Transmit Buffer
+     * |        |          |0 = No effect.
+     * |        |          |1 = The transmit buffer is cleared (filling level is cleared and output pointer is set to input pointer value)
+     * |        |          |Should only be used while the buffer is not taking part in data traffic.
+     * |        |          |Note: It is cleared automatically after one PCLK cycle.
+     * |[14]    |RXOVIEN   |Receive Buffer Overrun Error Interrupt Enable Control
+     * |        |          |0 = Receive overrun interrupt Disabled.
+     * |        |          |1 = Receive overrun interrupt Enabled.
+     * |[15]    |RXCLR     |Clear Receive Buffer
+     * |        |          |0 = No effect.
+     * |        |          |1 = The receive buffer is cleared (filling level is cleared and output pointer is set to input pointer value)
+     * |        |          |Should only be used while the buffer is not taking part in data traffic.
+     * |        |          |Note: It is cleared automatically after one PCLK cycle.
+     * |[16]    |TXRST     |Transmit Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the transmit-related counters, state machine, and the content of transmit shift register and data buffer.
+     * |        |          |Note: It is cleared automatically after one PCLK cycle.
+     * |[17]    |RXRST     |Receive Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the receive-related counters, state machine, and the content of receive shift register and data buffer.
+     * |        |          |Note1: It is cleared automatically after one PCLK cycle.
+     * |        |          |Note2: It is suggest to check the RXBUSY (UUART_PROTSTS[10]) before this bit will be set to 1.
+     * @var UUART_T::BUFSTS
+     * Offset: 0x3C  USCI Transmit/Receive Buffer Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |RXEMPTY   |Receive Buffer Empty Indicator
+     * |        |          |0 = Receive buffer is not empty.
+     * |        |          |1 = Receive buffer is empty.
+     * |[1]     |RXFULL    |Receive Buffer Full Indicator
+     * |        |          |0 = Receive buffer is not full.
+     * |        |          |1 = Receive buffer is full.
+     * |[3]     |RXOVIF    |Receive Buffer Over-run Error Interrupt Status
+     * |        |          |This bit indicates that a receive buffer overrun error event has been detected
+     * |        |          |If RXOVIEN (UUART_BUFCTL[14]) is enabled, the corresponding interrupt request is activated
+     * |        |          |It is cleared by software writes 1 to this bit.
+     * |        |          |0 = A receive buffer overrun error event has not been detected.
+     * |        |          |1 = A receive buffer overrun error event has been detected.
+     * |[8]     |TXEMPTY   |Transmit Buffer Empty Indicator
+     * |        |          |0 = Transmit buffer is not empty.
+     * |        |          |1 = Transmit buffer is empty.
+     * |[9]     |TXFULL    |Transmit Buffer Full Indicator
+     * |        |          |0 = Transmit buffer is not full.
+     * |        |          |1 = Transmit buffer is full.
+     * |[11]    |TXUDRIF   |Transmit Buffer Under-run Error Interrupt Status
+     * |        |          |This bit indicates that a transmit buffer under-run error event has been detected
+     * |        |          |If enabled by TXUDRIEN (UUART_BUFCTL[6]), the corresponding interrupt request is activated
+     * |        |          |It is cleared by software writes 1 to this bit
+     * |        |          |0 = A transmit buffer under-run error event has not been detected.
+     * |        |          |1 = A transmit buffer under-run error event has been detected.
+     * @var UUART_T::PDMACTL
+     * Offset: 0x40  USCI PDMA Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |PDMARST   |PDMA Reset
+     * |        |          |0 = No effect.
+     * |        |          |1 = Reset the USCI's PDMA control logic. This bit will be cleared to 0 automatically.
+     * |[1]     |TXPDMAEN  |PDMA Transmit Channel Available
+     * |        |          |0 = Transmit PDMA function Disabled.
+     * |        |          |1 = Transmit PDMA function Enabled.
+     * |[2]     |RXPDMAEN  |PDMA Receive Channel Available
+     * |        |          |0 = Receive PDMA function Disabled.
+     * |        |          |1 = Receive PDMA function Enabled.
+     * |[3]     |PDMAEN    |PDMA Mode Enable Bit
+     * |        |          |0 = PDMA function Disabled.
+     * |        |          |1 = PDMA function Enabled.
+     * @var UUART_T::WKCTL
+     * Offset: 0x54  USCI Wake-up Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKEN      |Wake-up Enable Bit
+     * |        |          |0 = Wake-up function Disabled.
+     * |        |          |1 = Wake-up function Enabled.
+     * |[2]     |PDBOPT    |Power Down Blocking Option
+     * |        |          |0 = If user attempts to enter Power-down mode by executing WFI while the protocol is in transferring, MCU will stop the transfer and enter Power-down mode immediately.
+     * |        |          |1 = If user attempts to enter Power-down mode by executing WFI while the protocol is in transferring, the on-going transfer will not be stopped and MCU will enter idle mode immediately.
+     * @var UUART_T::WKSTS
+     * Offset: 0x58  USCI Wake-up Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WKF       |Wake-up Flag
+     * |        |          |When chip is woken up from Power-down mode, this bit is set to 1
+     * |        |          |Software can write 1 to clear this bit.
+     * @var UUART_T::PROTCTL
+     * Offset: 0x5C  USCI Protocol Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |STOPB     |Stop Bits
+     * |        |          |This bit defines the number of stop bits in an UART frame.
+     * |        |          |0 = The number of stop bits is 1.
+     * |        |          |1 = The number of stop bits is 2.
+     * |[1]     |PARITYEN  |Parity Enable Bit
+     * |        |          |This bit defines the parity bit is enabled in an UART frame.
+     * |        |          |0 = The parity bit Disabled.
+     * |        |          |1 = The parity bit Enabled.
+     * |[2]     |EVENPARITY|Even Parity Enable Bit
+     * |        |          |0 = Odd number of logic 1 is transmitted and checked in each word.
+     * |        |          |1 = Even number of logic 1 is transmitted and checked in each word.
+     * |        |          |Note: This bit has effect only when PARITYEN is set.
+     * |[3]     |RTSAUTOEN |nRTS Auto-flow Control Enable Bit
+     * |        |          |When nRTS auto-flow is enabled, if the receiver buffer is full (RXFULL (UUART_BUFSTS[1] =1), the UART will de-assert nRTS signal.
+     * |        |          |0 = nRTS auto-flow control Disabled.
+     * |        |          |1 = nRTS auto-flow control Enabled.
+     * |        |          |Note: This bit has effect only when the RTSAUDIREN is not set.
+     * |[4]     |CTSAUTOEN |nCTS Auto-flow Control Enable Bit
+     * |        |          |When nCTS auto-flow is enabled, the UART will send data to external device when nCTS input assert (UART will not send data to device if nCTS input is dis-asserted).
+     * |        |          |0 = nCTS auto-flow control Disabled.
+     * |        |          |1 = nCTS auto-flow control Enabled.
+     * |[5]     |RTSAUDIREN|nRTS Auto Direction Enable Bit
+     * |        |          |When nRTS auto direction is enabled, if the transmitted bytes in the TX buffer is empty, the UART asserted nRTS signal automatically.
+     * |        |          |0 = nRTS auto direction control Disabled.
+     * |        |          |1 = nRTS auto direction control Enabled.
+     * |        |          |Note 1: This bit is used for nRTS auto direction control for RS485.
+     * |        |          |Note 2: This bit has effect only when the RTSAUTOEN is not set.
+     * |[6]     |ABREN     |Auto-baud Rate Detect Enable Bit
+     * |        |          |0 = Auto-baud rate detect function Disabled.
+     * |        |          |1 = Auto-baud rate detect function Enabled.
+     * |        |          |Note: When the auto - baud rate detect operation finishes, hardware will clear this bit
+     * |        |          |The associated interrupt ABRDETIF (UUART_PROTST[9]) will be generated (If ARBIEN (UUART_PROTIEN [1]) is enabled).
+     * |[9]     |DATWKEN   |Data Wake-up Mode Enable Bit
+     * |        |          |0 = Data wake-up mode Disabled.
+     * |        |          |1 = Data wake-up mode Enabled.
+     * |[10]    |CTSWKEN   |nCTS Wake-up Mode Enable Bit
+     * |        |          |0 = nCTS wake-up mode Disabled.
+     * |        |          |1 = nCTS wake-up mode Enabled.
+     * |[14:11] |WAKECNT   |Wake-up Counter
+     * |        |          |These bits field indicate how many clock cycle selected by fPDS_CNT do the slave can get the 1st bit (start bit) when the device is wake-up from Power-down mode.
+     * |[24:16] |BRDETITV  |Baud Rate Detection Interval
+     * |        |          |This bit fields indicate how many clock cycle selected by TMCNTSRC (UUART_BRGEN [5]) does the slave calculates the baud rate in one bits
+     * |        |          |The order of the bus shall be 1 and 0 step by step (e.g
+     * |        |          |the input data pattern shall be 0x55)
+     * |        |          |The user can read the value to know the current input baud rate of the bus whenever the ABRDETIF (UUART_PROTCTL[9]) is set.
+     * |        |          |Note: This bit can be cleared to 0 by software writing 1 to the BRDETITV.
+     * |[26]    |STICKEN   |Stick Parity Enable Bit
+     * |        |          |0 = Stick parity Disabled.
+     * |        |          |1 = Stick parity Enabled.
+     * |        |          |Note: Refer to RS-485 Support section for detail information.
+     * |[29]    |BCEN      |Transmit Break Control Enable Bit
+     * |        |          |0 = Transmit Break Control Disabled.
+     * |        |          |1 = Transmit Break Control Enabled.
+     * |        |          |Note: When this bit is set to logic 1, the serial data output (TX) is forced to the Spacing State (logic 0)
+     * |        |          |This bit acts only on TX line and has no effect on the transmitter logic.
+     * |[30]    |DEG       |Deglitch Enable Bit
+     * |        |          |0 = Deglitch Disabled.
+     * |        |          |1 = Deglitch Enabled.
+     * |        |          |Note: When this bit is set to logic 1, any pulse width less than about 300 ns will be considered a glitch and will be removed in the serial
+     * |        |          |data input(RX).This bit acts only on RX line and has no effect on the transmitter logic.
+     * |[31]    |PROTEN    |UART Protocol Enable Bit
+     * |        |          |0 = UART Protocol Disabled.
+     * |        |          |1 = UART Protocol Enabled.
+     * @var UUART_T::PROTIEN
+     * Offset: 0x60  USCI Protocol Interrupt Enable Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |ABRIEN    |Auto-baud Rate Interrupt Enable Bit
+     * |        |          |0 = Auto-baud rate interrupt Disabled.
+     * |        |          |1 = Auto-baud rate interrupt Enabled.
+     * |[2]     |RLSIEN    |Receive Line Status Interrupt Enable Bit
+     * |        |          |0 = Receive line status interrupt Disabled.
+     * |        |          |1 = Receive line status interrupt Enabled.
+     * |        |          |Note: UUART_PROTSTS[7:5] indicates the current interrupt event for receive line status interrupt.
+     * @var UUART_T::PROTSTS
+     * Offset: 0x64  USCI Protocol Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |TXSTIF    |Transmit Start Interrupt Flag
+     * |        |          |0 = A transmit start interrupt status has not occurred.
+     * |        |          |1 = A transmit start interrupt status has occurred.
+     * |        |          |Note 1: It is cleared by software writing one into this bit.
+     * |        |          |Note 2: Used for user to load next transmit data when there is no data in transmit buffer.
+     * |[2]     |TXENDIF   |Transmit End Interrupt Flag
+     * |        |          |0 = A transmit end interrupt status has not occurred.
+     * |        |          |1 = A transmit end interrupt status has occurred.
+     * |        |          |Note: It is cleared by software writing one into this bit.
+     * |[3]     |RXSTIF    |Receive Start Interrupt Flag
+     * |        |          |0 = A receive start interrupt status has not occurred.
+     * |        |          |1 = A receive start interrupt status has occurred.
+     * |        |          |Note: It is cleared by software writing one into this bit.
+     * |[4]     |RXENDIF   |Receive End Interrupt Flag
+     * |        |          |0 = A receive finish interrupt status has not occurred.
+     * |        |          |1 = A receive finish interrupt status has occurred.
+     * |        |          |Note: It is cleared by software writing one into this bit.
+     * |[5]     |PARITYERR |Parity Error Flag
+     * |        |          |This bit is set to logic 1 whenever the received character does not have a valid "parity bit".
+     * |        |          |0 = No parity error is generated.
+     * |        |          |1 = Parity error is generated.
+     * |        |          |Note: This bit can be cleared by write 1 among the BREAK, FRMERR and PARITYERR bits.
+     * |[6]     |FRMERR    |Framing Error Flag
+     * |        |          |This bit is set to logic 1 whenever the received character does not have a valid "stop bit" (that is, the stop bit following the last data bit or parity bit is detected as logic 0).
+     * |        |          |0 = No framing error is generated.
+     * |        |          |1 = Framing error is generated.
+     * |        |          |Note: This bit can be cleared by write 1 among the BREAK, FRMERR and PARITYERR bits.
+     * |[7]     |BREAK     |Break Flag
+     * |        |          |This bit is set to logic 1 whenever the received data input (RX) is held in the "spacing state" (logic 0) for longer than a full word transmission time (that is, the total time of "start bit" + data bits + parity + stop bits).
+     * |        |          |0 = No Break is generated.
+     * |        |          |1 = Break is generated in the receiver bus.
+     * |        |          |Note: This bit can be cleared by write 1 among the BREAK, FRMERR and PARITYERR bits.
+     * |[9]     |ABRDETIF  |Auto-baud Rate Interrupt Flag
+     * |        |          |This bit is set when auto-baud rate detection is done among the falling edge of the input data
+     * |        |          |If the ABRIEN (UUART_PROTCTL[6]) is set, the auto-baud rate interrupt will be generated
+     * |        |          |This bit can be set 4 times when the input data pattern is 0x55 and it is cleared before the next falling edge of the input bus.
+     * |        |          |0 = Auto-baud rate detect function is not done.
+     * |        |          |1 = One Bit auto-baud rate detect function is done.
+     * |        |          |Note: This bit can be cleared by writing 1 to it.
+     * |[10]    |RXBUSY    |RX Bus Status Flag (Read Only)
+     * |        |          |This bit indicates the busy status of the receiver.
+     * |        |          |0 = The receiver is Idle.
+     * |        |          |1 = The receiver is BUSY.
+     * |[11]    |ABERRSTS  |Auto-baud Rate Error Status
+     * |        |          |This bit is set when auto-baud rate detection counter overrun
+     * |        |          |When the auto-baud rate counter overrun, the user shall revise the CLKDIV (UUART_BRGEN[25:16]) value and enable ABREN (UUART_PROTCTL[6]) to detect the correct baud rate again.
+     * |        |          |0 = Auto-baud rate detect counter is not overrun.
+     * |        |          |1 = Auto-baud rate detect counter is overrun.
+     * |        |          |Note 1: This bit is set at the same time of ABRDETIF.
+     * |        |          |Note 2: This bit can be cleared by writing 1 to ABRDETIF or ABERRSTS.
+     * |[16]    |CTSSYNCLV |nCTS Synchronized Level Status (Read Only)
+     * |        |          |This bit used to indicate the current status of the internal synchronized nCTS signal.
+     * |        |          |0 = The internal synchronized nCTS is low.
+     * |        |          |1 = The internal synchronized nCTS is high.
+     * |[17]    |CTSLV     |nCTS Pin Status (Read Only)
+     * |        |          |This bit used to monitor the current status of nCTS pin input.
+     * |        |          |0 = nCTS pin input is low level voltage logic state.
+     * |        |          |1 = nCTS pin input is high level voltage logic state.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] USCI Control Register                                            */
+    __IO uint32_t INTEN;                 /*!< [0x0004] USCI Interrupt Enable Register                                   */
+    __IO uint32_t BRGEN;                 /*!< [0x0008] USCI Baud Rate Generator Register                                */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE0[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t DATIN0;                /*!< [0x0010] USCI Input Data Signal Configuration Register 0                  */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE1[3];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CTLIN0;                /*!< [0x0020] USCI Input Control Signal Configuration Register 0               */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE2[1];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t CLKIN;                 /*!< [0x0028] USCI Input Clock Signal Configuration Register                   */
+    __IO uint32_t LINECTL;               /*!< [0x002c] USCI Line Control Register                                       */
+    __O  uint32_t TXDAT;                 /*!< [0x0030] USCI Transmit Data Register                                      */
+    __I  uint32_t RXDAT;                 /*!< [0x0034] USCI Receive Data Register                                       */
+    __IO uint32_t BUFCTL;                /*!< [0x0038] USCI Transmit/Receive Buffer Control Register                    */
+    __IO uint32_t BUFSTS;                /*!< [0x003c] USCI Transmit/Receive Buffer Status Register                     */
+    __IO uint32_t PDMACTL;               /*!< [0x0040] USCI PDMA Control Register                                       */
+    /// @cond HIDDEN_SYMBOLS
+    __I  uint32_t RESERVE3[4];
+    /// @endcond //HIDDEN_SYMBOLS
+    __IO uint32_t WKCTL;                 /*!< [0x0054] USCI Wake-up Control Register                                    */
+    __IO uint32_t WKSTS;                 /*!< [0x0058] USCI Wake-up Status Register                                     */
+    __IO uint32_t PROTCTL;               /*!< [0x005c] USCI Protocol Control Register                                   */
+    __IO uint32_t PROTIEN;               /*!< [0x0060] USCI Protocol Interrupt Enable Register                          */
+    __IO uint32_t PROTSTS;               /*!< [0x0064] USCI Protocol Status Register                                    */
+} UUART_T;
+
+/**
+    @addtogroup UUART_CONST UUART Bit Field Definition
+    Constant Definitions for UUART Controller
+@{ */
+
+#define UUART_CTL_FUNMODE_Pos             (0)                                               /*!< UUART_T::CTL: FUNMODE Position          */
+#define UUART_CTL_FUNMODE_Msk             (0x7ul << UUART_CTL_FUNMODE_Pos)                  /*!< UUART_T::CTL: FUNMODE Mask              */
+
+#define UUART_INTEN_TXSTIEN_Pos           (1)                                               /*!< UUART_T::INTEN: TXSTIEN Position        */
+#define UUART_INTEN_TXSTIEN_Msk           (0x1ul << UUART_INTEN_TXSTIEN_Pos)                /*!< UUART_T::INTEN: TXSTIEN Mask            */
+
+#define UUART_INTEN_TXENDIEN_Pos          (2)                                               /*!< UUART_T::INTEN: TXENDIEN Position       */
+#define UUART_INTEN_TXENDIEN_Msk          (0x1ul << UUART_INTEN_TXENDIEN_Pos)               /*!< UUART_T::INTEN: TXENDIEN Mask           */
+
+#define UUART_INTEN_RXSTIEN_Pos           (3)                                               /*!< UUART_T::INTEN: RXSTIEN Position        */
+#define UUART_INTEN_RXSTIEN_Msk           (0x1ul << UUART_INTEN_RXSTIEN_Pos)                /*!< UUART_T::INTEN: RXSTIEN Mask            */
+
+#define UUART_INTEN_RXENDIEN_Pos          (4)                                               /*!< UUART_T::INTEN: RXENDIEN Position       */
+#define UUART_INTEN_RXENDIEN_Msk          (0x1ul << UUART_INTEN_RXENDIEN_Pos)               /*!< UUART_T::INTEN: RXENDIEN Mask           */
+
+#define UUART_BRGEN_RCLKSEL_Pos           (0)                                               /*!< UUART_T::BRGEN: RCLKSEL Position        */
+#define UUART_BRGEN_RCLKSEL_Msk           (0x1ul << UUART_BRGEN_RCLKSEL_Pos)                /*!< UUART_T::BRGEN: RCLKSEL Mask            */
+
+#define UUART_BRGEN_PTCLKSEL_Pos          (1)                                               /*!< UUART_T::BRGEN: PTCLKSEL Position       */
+#define UUART_BRGEN_PTCLKSEL_Msk          (0x1ul << UUART_BRGEN_PTCLKSEL_Pos)               /*!< UUART_T::BRGEN: PTCLKSEL Mask           */
+
+#define UUART_BRGEN_SPCLKSEL_Pos          (2)                                               /*!< UUART_T::BRGEN: SPCLKSEL Position       */
+#define UUART_BRGEN_SPCLKSEL_Msk          (0x3ul << UUART_BRGEN_SPCLKSEL_Pos)               /*!< UUART_T::BRGEN: SPCLKSEL Mask           */
+
+#define UUART_BRGEN_TMCNTEN_Pos           (4)                                               /*!< UUART_T::BRGEN: TMCNTEN Position        */
+#define UUART_BRGEN_TMCNTEN_Msk           (0x1ul << UUART_BRGEN_TMCNTEN_Pos)                /*!< UUART_T::BRGEN: TMCNTEN Mask            */
+
+#define UUART_BRGEN_TMCNTSRC_Pos          (5)                                               /*!< UUART_T::BRGEN: TMCNTSRC Position       */
+#define UUART_BRGEN_TMCNTSRC_Msk          (0x1ul << UUART_BRGEN_TMCNTSRC_Pos)               /*!< UUART_T::BRGEN: TMCNTSRC Mask           */
+
+#define UUART_BRGEN_PDSCNT_Pos            (8)                                               /*!< UUART_T::BRGEN: PDSCNT Position         */
+#define UUART_BRGEN_PDSCNT_Msk            (0x3ul << UUART_BRGEN_PDSCNT_Pos)                 /*!< UUART_T::BRGEN: PDSCNT Mask             */
+
+#define UUART_BRGEN_DSCNT_Pos             (10)                                              /*!< UUART_T::BRGEN: DSCNT Position          */
+#define UUART_BRGEN_DSCNT_Msk             (0x1ful << UUART_BRGEN_DSCNT_Pos)                 /*!< UUART_T::BRGEN: DSCNT Mask              */
+
+#define UUART_BRGEN_CLKDIV_Pos            (16)                                              /*!< UUART_T::BRGEN: CLKDIV Position         */
+#define UUART_BRGEN_CLKDIV_Msk            (0x3fful << UUART_BRGEN_CLKDIV_Pos)               /*!< UUART_T::BRGEN: CLKDIV Mask             */
+
+#define UUART_DATIN0_SYNCSEL_Pos          (0)                                               /*!< UUART_T::DATIN0: SYNCSEL Position       */
+#define UUART_DATIN0_SYNCSEL_Msk          (0x1ul << UUART_DATIN0_SYNCSEL_Pos)               /*!< UUART_T::DATIN0: SYNCSEL Mask           */
+
+#define UUART_DATIN0_ININV_Pos            (2)                                               /*!< UUART_T::DATIN0: ININV Position         */
+#define UUART_DATIN0_ININV_Msk            (0x1ul << UUART_DATIN0_ININV_Pos)                 /*!< UUART_T::DATIN0: ININV Mask             */
+
+#define UUART_DATIN0_EDGEDET_Pos          (3)                                               /*!< UUART_T::DATIN0: EDGEDET Position       */
+#define UUART_DATIN0_EDGEDET_Msk          (0x3ul << UUART_DATIN0_EDGEDET_Pos)               /*!< UUART_T::DATIN0: EDGEDET Mask           */
+
+#define UUART_CTLIN0_SYNCSEL_Pos          (0)                                               /*!< UUART_T::CTLIN0: SYNCSEL Position       */
+#define UUART_CTLIN0_SYNCSEL_Msk          (0x1ul << UUART_CTLIN0_SYNCSEL_Pos)               /*!< UUART_T::CTLIN0: SYNCSEL Mask           */
+
+#define UUART_CTLIN0_ININV_Pos            (2)                                               /*!< UUART_T::CTLIN0: ININV Position         */
+#define UUART_CTLIN0_ININV_Msk            (0x1ul << UUART_CTLIN0_ININV_Pos)                 /*!< UUART_T::CTLIN0: ININV Mask             */
+
+#define UUART_CLKIN_SYNCSEL_Pos           (0)                                               /*!< UUART_T::CLKIN: SYNCSEL Position        */
+#define UUART_CLKIN_SYNCSEL_Msk           (0x1ul << UUART_CLKIN_SYNCSEL_Pos)                /*!< UUART_T::CLKIN: SYNCSEL Mask            */
+
+#define UUART_LINECTL_LSB_Pos             (0)                                               /*!< UUART_T::LINECTL: LSB Position          */
+#define UUART_LINECTL_LSB_Msk             (0x1ul << UUART_LINECTL_LSB_Pos)                  /*!< UUART_T::LINECTL: LSB Mask              */
+
+#define UUART_LINECTL_DATOINV_Pos         (5)                                               /*!< UUART_T::LINECTL: DATOINV Position      */
+#define UUART_LINECTL_DATOINV_Msk         (0x1ul << UUART_LINECTL_DATOINV_Pos)              /*!< UUART_T::LINECTL: DATOINV Mask          */
+
+#define UUART_LINECTL_CTLOINV_Pos         (7)                                               /*!< UUART_T::LINECTL: CTLOINV Position      */
+#define UUART_LINECTL_CTLOINV_Msk         (0x1ul << UUART_LINECTL_CTLOINV_Pos)              /*!< UUART_T::LINECTL: CTLOINV Mask          */
+
+#define UUART_LINECTL_DWIDTH_Pos          (8)                                               /*!< UUART_T::LINECTL: DWIDTH Position       */
+#define UUART_LINECTL_DWIDTH_Msk          (0xful << UUART_LINECTL_DWIDTH_Pos)               /*!< UUART_T::LINECTL: DWIDTH Mask           */
+
+#define UUART_TXDAT_TXDAT_Pos             (0)                                               /*!< UUART_T::TXDAT: TXDAT Position          */
+#define UUART_TXDAT_TXDAT_Msk             (0xfffful << UUART_TXDAT_TXDAT_Pos)               /*!< UUART_T::TXDAT: TXDAT Mask              */
+
+#define UUART_RXDAT_RXDAT_Pos             (0)                                               /*!< UUART_T::RXDAT: RXDAT Position          */
+#define UUART_RXDAT_RXDAT_Msk             (0xfffful << UUART_RXDAT_RXDAT_Pos)               /*!< UUART_T::RXDAT: RXDAT Mask              */
+
+#define UUART_BUFCTL_TXCLR_Pos            (7)                                               /*!< UUART_T::BUFCTL: TXCLR Position         */
+#define UUART_BUFCTL_TXCLR_Msk            (0x1ul << UUART_BUFCTL_TXCLR_Pos)                 /*!< UUART_T::BUFCTL: TXCLR Mask             */
+
+#define UUART_BUFCTL_RXOVIEN_Pos          (14)                                              /*!< UUART_T::BUFCTL: RXOVIEN Position       */
+#define UUART_BUFCTL_RXOVIEN_Msk          (0x1ul << UUART_BUFCTL_RXOVIEN_Pos)               /*!< UUART_T::BUFCTL: RXOVIEN Mask           */
+
+#define UUART_BUFCTL_RXCLR_Pos            (15)                                              /*!< UUART_T::BUFCTL: RXCLR Position         */
+#define UUART_BUFCTL_RXCLR_Msk            (0x1ul << UUART_BUFCTL_RXCLR_Pos)                 /*!< UUART_T::BUFCTL: RXCLR Mask             */
+
+#define UUART_BUFCTL_TXRST_Pos            (16)                                              /*!< UUART_T::BUFCTL: TXRST Position         */
+#define UUART_BUFCTL_TXRST_Msk            (0x1ul << UUART_BUFCTL_TXRST_Pos)                 /*!< UUART_T::BUFCTL: TXRST Mask             */
+
+#define UUART_BUFCTL_RXRST_Pos            (17)                                              /*!< UUART_T::BUFCTL: RXRST Position         */
+#define UUART_BUFCTL_RXRST_Msk            (0x1ul << UUART_BUFCTL_RXRST_Pos)                 /*!< UUART_T::BUFCTL: RXRST Mask             */
+
+#define UUART_BUFSTS_RXEMPTY_Pos          (0)                                               /*!< UUART_T::BUFSTS: RXEMPTY Position       */
+#define UUART_BUFSTS_RXEMPTY_Msk          (0x1ul << UUART_BUFSTS_RXEMPTY_Pos)               /*!< UUART_T::BUFSTS: RXEMPTY Mask           */
+
+#define UUART_BUFSTS_RXFULL_Pos           (1)                                               /*!< UUART_T::BUFSTS: RXFULL Position        */
+#define UUART_BUFSTS_RXFULL_Msk           (0x1ul << UUART_BUFSTS_RXFULL_Pos)                /*!< UUART_T::BUFSTS: RXFULL Mask            */
+
+#define UUART_BUFSTS_RXOVIF_Pos           (3)                                               /*!< UUART_T::BUFSTS: RXOVIF Position        */
+#define UUART_BUFSTS_RXOVIF_Msk           (0x1ul << UUART_BUFSTS_RXOVIF_Pos)                /*!< UUART_T::BUFSTS: RXOVIF Mask            */
+
+#define UUART_BUFSTS_TXEMPTY_Pos          (8)                                               /*!< UUART_T::BUFSTS: TXEMPTY Position       */
+#define UUART_BUFSTS_TXEMPTY_Msk          (0x1ul << UUART_BUFSTS_TXEMPTY_Pos)               /*!< UUART_T::BUFSTS: TXEMPTY Mask           */
+
+#define UUART_BUFSTS_TXFULL_Pos           (9)                                               /*!< UUART_T::BUFSTS: TXFULL Position        */
+#define UUART_BUFSTS_TXFULL_Msk           (0x1ul << UUART_BUFSTS_TXFULL_Pos)                /*!< UUART_T::BUFSTS: TXFULL Mask            */
+
+#define UUART_BUFSTS_TXUDRIF_Pos          (11)                                              /*!< UUART_T::BUFSTS: TXUDRIF Position       */
+#define UUART_BUFSTS_TXUDRIF_Msk          (0x1ul << UUART_BUFSTS_TXUDRIF_Pos)               /*!< UUART_T::BUFSTS: TXUDRIF Mask           */
+
+#define UUART_PDMACTL_PDMARST_Pos         (0)                                               /*!< UUART_T::PDMACTL: PDMARST Position      */
+#define UUART_PDMACTL_PDMARST_Msk         (0x1ul << UUART_PDMACTL_PDMARST_Pos)              /*!< UUART_T::PDMACTL: PDMARST Mask          */
+
+#define UUART_PDMACTL_TXPDMAEN_Pos        (1)                                               /*!< UUART_T::PDMACTL: TXPDMAEN Position     */
+#define UUART_PDMACTL_TXPDMAEN_Msk        (0x1ul << UUART_PDMACTL_TXPDMAEN_Pos)             /*!< UUART_T::PDMACTL: TXPDMAEN Mask         */
+
+#define UUART_PDMACTL_RXPDMAEN_Pos        (2)                                               /*!< UUART_T::PDMACTL: RXPDMAEN Position     */
+#define UUART_PDMACTL_RXPDMAEN_Msk        (0x1ul << UUART_PDMACTL_RXPDMAEN_Pos)             /*!< UUART_T::PDMACTL: RXPDMAEN Mask         */
+
+#define UUART_PDMACTL_PDMAEN_Pos          (3)                                               /*!< UUART_T::PDMACTL: PDMAEN Position       */
+#define UUART_PDMACTL_PDMAEN_Msk          (0x1ul << UUART_PDMACTL_PDMAEN_Pos)               /*!< UUART_T::PDMACTL: PDMAEN Mask           */
+
+#define UUART_WKCTL_WKEN_Pos              (0)                                               /*!< UUART_T::WKCTL: WKEN Position           */
+#define UUART_WKCTL_WKEN_Msk              (0x1ul << UUART_WKCTL_WKEN_Pos)                   /*!< UUART_T::WKCTL: WKEN Mask               */
+
+#define UUART_WKCTL_PDBOPT_Pos            (2)                                               /*!< UUART_T::WKCTL: PDBOPT Position         */
+#define UUART_WKCTL_PDBOPT_Msk            (0x1ul << UUART_WKCTL_PDBOPT_Pos)                 /*!< UUART_T::WKCTL: PDBOPT Mask             */
+
+#define UUART_WKSTS_WKF_Pos               (0)                                               /*!< UUART_T::WKSTS: WKF Position            */
+#define UUART_WKSTS_WKF_Msk               (0x1ul << UUART_WKSTS_WKF_Pos)                    /*!< UUART_T::WKSTS: WKF Mask                */
+
+#define UUART_PROTCTL_STOPB_Pos           (0)                                               /*!< UUART_T::PROTCTL: STOPB Position        */
+#define UUART_PROTCTL_STOPB_Msk           (0x1ul << UUART_PROTCTL_STOPB_Pos)                /*!< UUART_T::PROTCTL: STOPB Mask            */
+
+#define UUART_PROTCTL_PARITYEN_Pos        (1)                                               /*!< UUART_T::PROTCTL: PARITYEN Position     */
+#define UUART_PROTCTL_PARITYEN_Msk        (0x1ul << UUART_PROTCTL_PARITYEN_Pos)             /*!< UUART_T::PROTCTL: PARITYEN Mask         */
+
+#define UUART_PROTCTL_EVENPARITY_Pos      (2)                                               /*!< UUART_T::PROTCTL: EVENPARITY Position   */
+#define UUART_PROTCTL_EVENPARITY_Msk      (0x1ul << UUART_PROTCTL_EVENPARITY_Pos)           /*!< UUART_T::PROTCTL: EVENPARITY Mask       */
+
+#define UUART_PROTCTL_RTSAUTOEN_Pos       (3)                                               /*!< UUART_T::PROTCTL: RTSAUTOEN Position    */
+#define UUART_PROTCTL_RTSAUTOEN_Msk       (0x1ul << UUART_PROTCTL_RTSAUTOEN_Pos)            /*!< UUART_T::PROTCTL: RTSAUTOEN Mask        */
+
+#define UUART_PROTCTL_CTSAUTOEN_Pos       (4)                                               /*!< UUART_T::PROTCTL: CTSAUTOEN Position    */
+#define UUART_PROTCTL_CTSAUTOEN_Msk       (0x1ul << UUART_PROTCTL_CTSAUTOEN_Pos)            /*!< UUART_T::PROTCTL: CTSAUTOEN Mask        */
+
+#define UUART_PROTCTL_RTSAUDIREN_Pos      (5)                                               /*!< UUART_T::PROTCTL: RTSAUDIREN Position   */
+#define UUART_PROTCTL_RTSAUDIREN_Msk      (0x1ul << UUART_PROTCTL_RTSAUDIREN_Pos)           /*!< UUART_T::PROTCTL: RTSAUDIREN Mask       */
+
+#define UUART_PROTCTL_ABREN_Pos           (6)                                               /*!< UUART_T::PROTCTL: ABREN Position        */
+#define UUART_PROTCTL_ABREN_Msk           (0x1ul << UUART_PROTCTL_ABREN_Pos)                /*!< UUART_T::PROTCTL: ABREN Mask            */
+
+#define UUART_PROTCTL_DATWKEN_Pos         (9)                                               /*!< UUART_T::PROTCTL: DATWKEN Position      */
+#define UUART_PROTCTL_DATWKEN_Msk         (0x1ul << UUART_PROTCTL_DATWKEN_Pos)              /*!< UUART_T::PROTCTL: DATWKEN Mask          */
+
+#define UUART_PROTCTL_CTSWKEN_Pos         (10)                                              /*!< UUART_T::PROTCTL: CTSWKEN Position      */
+#define UUART_PROTCTL_CTSWKEN_Msk         (0x1ul << UUART_PROTCTL_CTSWKEN_Pos)              /*!< UUART_T::PROTCTL: CTSWKEN Mask          */
+
+#define UUART_PROTCTL_WAKECNT_Pos         (11)                                              /*!< UUART_T::PROTCTL: WAKECNT Position      */
+#define UUART_PROTCTL_WAKECNT_Msk         (0xful << UUART_PROTCTL_WAKECNT_Pos)              /*!< UUART_T::PROTCTL: WAKECNT Mask          */
+
+#define UUART_PROTCTL_BRDETITV_Pos        (16)                                              /*!< UUART_T::PROTCTL: BRDETITV Position     */
+#define UUART_PROTCTL_BRDETITV_Msk        (0x1fful << UUART_PROTCTL_BRDETITV_Pos)           /*!< UUART_T::PROTCTL: BRDETITV Mask         */
+
+#define UUART_PROTCTL_STICKEN_Pos         (26)                                              /*!< UUART_T::PROTCTL: STICKEN Position      */
+#define UUART_PROTCTL_STICKEN_Msk         (0x1ul << UUART_PROTCTL_STICKEN_Pos)              /*!< UUART_T::PROTCTL: STICKEN Mask          */
+
+#define UUART_PROTCTL_BCEN_Pos            (29)                                              /*!< UUART_T::PROTCTL: BCEN Position         */
+#define UUART_PROTCTL_BCEN_Msk            (0x1ul << UUART_PROTCTL_BCEN_Pos)                 /*!< UUART_T::PROTCTL: BCEN Mask             */
+
+#define UUART_PROTCTL_DGE_Pos             (30)                                              /*!< UUART_T::PROTCTL: DEG Position          */
+#define UUART_PROTCTL_DEG_Msk             (0x1ul << UUART_PROTCTL_DGE_Pos)                  /*!< UUART_T::PROTCTL: DEG Mask              */
+
+#define UUART_PROTCTL_PROTEN_Pos          (31)                                              /*!< UUART_T::PROTCTL: PROTEN Position       */
+#define UUART_PROTCTL_PROTEN_Msk          (0x1ul << UUART_PROTCTL_PROTEN_Pos)               /*!< UUART_T::PROTCTL: PROTEN Mask           */
+
+#define UUART_PROTIEN_ABRIEN_Pos          (1)                                               /*!< UUART_T::PROTIEN: ABRIEN Position       */
+#define UUART_PROTIEN_ABRIEN_Msk          (0x1ul << UUART_PROTIEN_ABRIEN_Pos)               /*!< UUART_T::PROTIEN: ABRIEN Mask           */
+
+#define UUART_PROTIEN_RLSIEN_Pos          (2)                                               /*!< UUART_T::PROTIEN: RLSIEN Position       */
+#define UUART_PROTIEN_RLSIEN_Msk          (0x1ul << UUART_PROTIEN_RLSIEN_Pos)               /*!< UUART_T::PROTIEN: RLSIEN Mask           */
+
+#define UUART_PROTSTS_TXSTIF_Pos          (1)                                               /*!< UUART_T::PROTSTS: TXSTIF Position       */
+#define UUART_PROTSTS_TXSTIF_Msk          (0x1ul << UUART_PROTSTS_TXSTIF_Pos)               /*!< UUART_T::PROTSTS: TXSTIF Mask           */
+
+#define UUART_PROTSTS_TXENDIF_Pos         (2)                                               /*!< UUART_T::PROTSTS: TXENDIF Position      */
+#define UUART_PROTSTS_TXENDIF_Msk         (0x1ul << UUART_PROTSTS_TXENDIF_Pos)              /*!< UUART_T::PROTSTS: TXENDIF Mask          */
+
+#define UUART_PROTSTS_RXSTIF_Pos          (3)                                               /*!< UUART_T::PROTSTS: RXSTIF Position       */
+#define UUART_PROTSTS_RXSTIF_Msk          (0x1ul << UUART_PROTSTS_RXSTIF_Pos)               /*!< UUART_T::PROTSTS: RXSTIF Mask           */
+
+#define UUART_PROTSTS_RXENDIF_Pos         (4)                                               /*!< UUART_T::PROTSTS: RXENDIF Position      */
+#define UUART_PROTSTS_RXENDIF_Msk         (0x1ul << UUART_PROTSTS_RXENDIF_Pos)              /*!< UUART_T::PROTSTS: RXENDIF Mask          */
+
+#define UUART_PROTSTS_PARITYERR_Pos       (5)                                               /*!< UUART_T::PROTSTS: PARITYERR Position    */
+#define UUART_PROTSTS_PARITYERR_Msk       (0x1ul << UUART_PROTSTS_PARITYERR_Pos)            /*!< UUART_T::PROTSTS: PARITYERR Mask        */
+
+#define UUART_PROTSTS_FRMERR_Pos          (6)                                               /*!< UUART_T::PROTSTS: FRMERR Position       */
+#define UUART_PROTSTS_FRMERR_Msk          (0x1ul << UUART_PROTSTS_FRMERR_Pos)               /*!< UUART_T::PROTSTS: FRMERR Mask           */
+
+#define UUART_PROTSTS_BREAK_Pos           (7)                                               /*!< UUART_T::PROTSTS: BREAK Position        */
+#define UUART_PROTSTS_BREAK_Msk           (0x1ul << UUART_PROTSTS_BREAK_Pos)                /*!< UUART_T::PROTSTS: BREAK Mask            */
+
+#define UUART_PROTSTS_ABRDETIF_Pos        (9)                                               /*!< UUART_T::PROTSTS: ABRDETIF Position     */
+#define UUART_PROTSTS_ABRDETIF_Msk        (0x1ul << UUART_PROTSTS_ABRDETIF_Pos)             /*!< UUART_T::PROTSTS: ABRDETIF Mask         */
+
+#define UUART_PROTSTS_RXBUSY_Pos          (10)                                              /*!< UUART_T::PROTSTS: RXBUSY Position       */
+#define UUART_PROTSTS_RXBUSY_Msk          (0x1ul << UUART_PROTSTS_RXBUSY_Pos)               /*!< UUART_T::PROTSTS: RXBUSY Mask           */
+
+#define UUART_PROTSTS_ABERRSTS_Pos        (11)                                              /*!< UUART_T::PROTSTS: ABERRSTS Position     */
+#define UUART_PROTSTS_ABERRSTS_Msk        (0x1ul << UUART_PROTSTS_ABERRSTS_Pos)             /*!< UUART_T::PROTSTS: ABERRSTS Mask         */
+
+#define UUART_PROTSTS_CTSSYNCLV_Pos       (16)                                              /*!< UUART_T::PROTSTS: CTSSYNCLV Position    */
+#define UUART_PROTSTS_CTSSYNCLV_Msk       (0x1ul << UUART_PROTSTS_CTSSYNCLV_Pos)            /*!< UUART_T::PROTSTS: CTSSYNCLV Mask        */
+
+#define UUART_PROTSTS_CTSLV_Pos           (17)                                              /*!< UUART_T::PROTSTS: CTSLV Position        */
+#define UUART_PROTSTS_CTSLV_Msk           (0x1ul << UUART_PROTSTS_CTSLV_Pos)                /*!< UUART_T::PROTSTS: CTSLV Mask            */
+
+/** @} UUART_CONST */
+/** @} end of UUART register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __UUART_REG_H__ */

--- a/hal/m258ke/nuvoton/wdt_reg.h
+++ b/hal/m258ke/nuvoton/wdt_reg.h
@@ -1,0 +1,172 @@
+/**************************************************************************//**
+ * @file     wdt_reg.h
+ * @version  V1.00
+ * @brief    WDT register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __WDT_REG_H__
+#define __WDT_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup WDT Watch Dog Timer Controller (WDT)
+    Memory Mapped Structure for WDT Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var WDT_T::CTL
+     * Offset: 0x00  WDT Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1]     |RSTEN     |WDT Time-out Reset Enable Bit (Write Protect)
+     * |        |          |Setting this bit will enable the WDT time-out reset function If the WDT up counter value has not been cleared after the specific WDT reset delay period expires.
+     * |        |          |0 = WDT time-out reset function Disabled.
+     * |        |          |1 = WDT time-out reset function Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[2]     |RSTF      |WDT Time-out Reset Flag
+     * |        |          |This bit indicates the system has been reset by WDT time-out reset or not.
+     * |        |          |0 = WDT time-out reset did not occur.
+     * |        |          |1 = WDT time-out reset occurred.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[3]     |IF        |WDT Time-out Interrupt Flag
+     * |        |          |This bit will set to 1 while WDT up counter value reaches the selected WDT time-out interval
+     * |        |          |0 = WDT time-out interrupt did not occur.
+     * |        |          |1 = WDT time-out interrupt occurred.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[4]     |WKEN      |WDT Time-out Wake-up Function Control (Write Protect)
+     * |        |          |If this bit is set to 1, while WDT time-out interrupt flag IF (WDT_CTL[3]) is generated to 1 and interrupt enable bit INTEN (WDT_CTL[6]) is enabled, the WDT time-out interrupt signal will generate a wake-up trigger event to chip.
+     * |        |          |0 = Wake-up trigger event Disabled if WDT time-out interrupt signal generated.
+     * |        |          |1 = Wake-up trigger event Enabled if WDT time-out interrupt signal generated.
+     * |        |          |Note1: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note2: Chip can be woken up by WDT time-out interrupt signal generated only if WDT clock source is selected to 10 kHz internal low speed RC oscillator (LIRC) or LXT.
+     * |[5]     |WKF       |WDT Time-out Wake-up Flag (Write Protect)
+     * |        |          |This bit indicates the interrupt wake-up flag status of WDT
+     * |        |          |0 = WDT does not cause chip wake-up.
+     * |        |          |1 = Chip wake-up from Idle or Power-down mode if WDT time-out interrupt signal generated.
+     * |        |          |Note1: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note2: This bit is cleared by writing 1 to it.
+     * |[6]     |INTEN     |WDT Time-out Interrupt Enable Bit (Write Protect)
+     * |        |          |If this bit is enabled, the WDT time-out interrupt signal is generated and inform to CPU.
+     * |        |          |0 = WDT time-out interrupt Disabled.
+     * |        |          |1 = WDT time-out interrupt Enabled.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[7]     |WDTEN     |WDT Enable Bit (Write Protect)
+     * |        |          |0 = WDT Disabled (This action will reset the internal up counter value).
+     * |        |          |1 = WDT Enabled.
+     * |        |          |Note1: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note2: If CWDTEN[2:0] (combined by Config0[31] and Config0[4:3]) bits is not configured to 111, this bit is forced as 1 and user cannot change this bit to 0.
+     * |[11:8]  |TOUTSEL   |WDT Time-out Interval Selection (Write Protect)
+     * |        |          |These four bits select the time-out interval period for the WDT.
+     * |        |          |0000 = 2^4 * WDT_CLK.
+     * |        |          |0001 = 2^6 * WDT_CLK.
+     * |        |          |0010 = 2^8 * WDT_CLK.
+     * |        |          |0011 = 2^10 * WDT_CLK.
+     * |        |          |0100 = 2^12 * WDT_CLK.
+     * |        |          |0101 = 2^14 * WDT_CLK.
+     * |        |          |0110 = 2^16 * WDT_CLK.
+     * |        |          |0111 = 2^18 * WDT_CLK.
+     * |        |          |1000 = 2^20 * WDT_CLK.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |[30]    |SYNC      |WDT Enable Control SYNC Flag Indicator (Read Only)
+     * |        |          |If user executes enable/disable WDTEN (WDT_CTL[7]), this flag can be indicated enable/disable WDTEN function is completed or not.
+     * |        |          |0 = Set WDTEN bit is completed.
+     * |        |          |1 = Set WDTEN bit is synchronizing and not become active yet.
+     * |        |          |Note: Performing enable or disable WDTEN bit needs 2 * WDT_CLK period to become active.
+     * |[31]    |ICEDEBUG  |ICE Debug Mode Acknowledge Disable Bit (Write Protect)
+     * |        |          |0 = ICE debug mode acknowledgement affects WDT counting.
+     * |        |          |WDT up counter will be held while CPU is held by ICE.
+     * |        |          |1 = ICE debug mode acknowledgement Disabled.
+     * |        |          |WDT up counter will keep going no matter CPU is held by ICE or not.
+     * |        |          |Note: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * @var WDT_T::ALTCTL
+     * Offset: 0x04  WDT Alternative Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[1:0]   |RSTDSEL   |WDT Reset Delay Selection (Write Protect)
+     * |        |          |When WDT time-out happened, user has a time named WDT Reset Delay Period to clear WDT counter by writing 0x00005aa5 to RSTCNT (WDT_RSTCNT[31:0]) to prevent WDT time-out reset happened.
+     * |        |          |User can select a suitable setting of RSTDSEL for different WDT Reset Delay Period.
+     * |        |          |00 = WDT Reset Delay Period is 1026 * WDT_CLK.
+     * |        |          |01 = WDT Reset Delay Period is 130 * WDT_CLK.
+     * |        |          |10 = WDT Reset Delay Period is 18 * WDT_CLK.
+     * |        |          |11 = WDT Reset Delay Period is 3 * WDT_CLK.
+     * |        |          |Note1: This bit is write protected. Refer to the SYS_REGLCTL register.
+     * |        |          |Note2: This register will be reset to 0 if WDT time-out reset happened.
+     * @var WDT_T::RSTCNT
+     * Offset: 0x08  WDT Reset Counter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |RSTCNT    |WDT Reset Counter Register
+     * |        |          |Writing 0x00005AA5 to this field will reset the internal 18-bit WDT up counter value to 0.
+     * |        |          |Note1: Performing RSTCNT to reset counter needs 2 * WDT_CLK period to become active.
+     */
+    __IO uint32_t CTL;                   /*!< [0x0000] WDT Control Register                                             */
+    __IO uint32_t ALTCTL;                /*!< [0x0004] WDT Alternative Control Register                                 */
+    __O  uint32_t RSTCNT;                /*!< [0x0008] WDT Reset Counter Register                                       */
+} WDT_T;
+
+/**
+    @addtogroup WDT_CONST WDT Bit Field Definition
+    Constant Definitions for WDT Controller
+@{ */
+
+#define WDT_CTL_RSTEN_Pos                (1)                                               /*!< WDT_T::CTL: RSTEN Position             */
+#define WDT_CTL_RSTEN_Msk                (0x1ul << WDT_CTL_RSTEN_Pos)                      /*!< WDT_T::CTL: RSTEN Mask                 */
+
+#define WDT_CTL_RSTF_Pos                 (2)                                               /*!< WDT_T::CTL: RSTF Position              */
+#define WDT_CTL_RSTF_Msk                 (0x1ul << WDT_CTL_RSTF_Pos)                       /*!< WDT_T::CTL: RSTF Mask                  */
+
+#define WDT_CTL_IF_Pos                   (3)                                               /*!< WDT_T::CTL: IF Position                */
+#define WDT_CTL_IF_Msk                   (0x1ul << WDT_CTL_IF_Pos)                         /*!< WDT_T::CTL: IF Mask                    */
+
+#define WDT_CTL_WKEN_Pos                 (4)                                               /*!< WDT_T::CTL: WKEN Position              */
+#define WDT_CTL_WKEN_Msk                 (0x1ul << WDT_CTL_WKEN_Pos)                       /*!< WDT_T::CTL: WKEN Mask                  */
+
+#define WDT_CTL_WKF_Pos                  (5)                                               /*!< WDT_T::CTL: WKF Position               */
+#define WDT_CTL_WKF_Msk                  (0x1ul << WDT_CTL_WKF_Pos)                        /*!< WDT_T::CTL: WKF Mask                   */
+
+#define WDT_CTL_INTEN_Pos                (6)                                               /*!< WDT_T::CTL: INTEN Position             */
+#define WDT_CTL_INTEN_Msk                (0x1ul << WDT_CTL_INTEN_Pos)                      /*!< WDT_T::CTL: INTEN Mask                 */
+
+#define WDT_CTL_WDTEN_Pos                (7)                                               /*!< WDT_T::CTL: WDTEN Position             */
+#define WDT_CTL_WDTEN_Msk                (0x1ul << WDT_CTL_WDTEN_Pos)                      /*!< WDT_T::CTL: WDTEN Mask                 */
+
+#define WDT_CTL_TOUTSEL_Pos              (8)                                               /*!< WDT_T::CTL: TOUTSEL Position           */
+#define WDT_CTL_TOUTSEL_Msk              (0xful << WDT_CTL_TOUTSEL_Pos)                    /*!< WDT_T::CTL: TOUTSEL Mask               */
+
+#define WDT_CTL_SYNC_Pos                 (30)                                              /*!< WDT_T::CTL: SYNC Position              */
+#define WDT_CTL_SYNC_Msk                 (0x1ul << WDT_CTL_SYNC_Pos)                       /*!< WDT_T::CTL: SYNC Mask                  */
+
+#define WDT_CTL_ICEDEBUG_Pos             (31)                                              /*!< WDT_T::CTL: ICEDEBUG Position          */
+#define WDT_CTL_ICEDEBUG_Msk             (0x1ul << WDT_CTL_ICEDEBUG_Pos)                   /*!< WDT_T::CTL: ICEDEBUG Mask              */
+
+#define WDT_ALTCTL_RSTDSEL_Pos           (0)                                               /*!< WDT_T::ALTCTL: RSTDSEL Position        */
+#define WDT_ALTCTL_RSTDSEL_Msk           (0x3ul << WDT_ALTCTL_RSTDSEL_Pos)                 /*!< WDT_T::ALTCTL: RSTDSEL Mask            */
+
+/** @} WDT_CONST */
+/** @} end of WDT register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __WDT_REG_H__ */

--- a/hal/m258ke/nuvoton/wwdt_reg.h
+++ b/hal/m258ke/nuvoton/wwdt_reg.h
@@ -1,0 +1,149 @@
+/**************************************************************************//**
+ * @file     wwdt_reg.h
+ * @version  V1.00
+ * @brief    WWDT register definition header file
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *****************************************************************************/
+
+#ifndef __WWDT_REG_H__
+#define __WWDT_REG_H__
+
+#if defined ( __CC_ARM   )
+    #pragma anon_unions
+#endif
+
+/**
+    @addtogroup REGISTER Control Register
+    @{
+*/
+
+/**
+    @addtogroup WWDT Window Watchdog Timer (WWDT)
+    Memory Mapped Structure for WWDT Controller
+    @{
+*/
+
+typedef struct
+{
+
+
+    /**
+     * @var WWDT_T::RLDCNT
+     * Offset: 0x00  WWDT Reload Counter Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[31:0]  |RLDCNT    |WWDT Reload Counter Register
+     * |        |          |Writing 0x00005AA5 to this register will reload the WWDT counter value to 0x3F.
+     * |        |          |Note: User can only write WWDT_RLDCNT register to reload WWDT counter value when current WWDT counter value between 0 and CMPDAT (WWDT_CTL[21:16])
+     * |        |          |If user writes WWDT_RLDCNT when current WWDT counter value is larger than CMPDAT, WWDT reset signal will be generated immediately.
+     * @var WWDT_T::CTL
+     * Offset: 0x04  WWDT Control Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WWDTEN    |WWDT Enable Bit
+     * |        |          |0 = WWDT counter is stopped.
+     * |        |          |1 = WWDT counter starts counting.
+     * |[1]     |INTEN     |WWDT Interrupt Enable Bit
+     * |        |          |If this bit is enabled, the WWDT counter compare match interrupt signal is generated and inform to CPU.
+     * |        |          |0 = WWDT counter compare match interrupt Disabled.
+     * |        |          |1 = WWDT counter compare match interrupt Enabled.
+     * |[11:8]  |PSCSEL    |WWDT Counter Prescale Period Selection
+     * |        |          |0000 = Pre-scale is 1; Max time-out period is 1 * 64 * WWDT_CLK.
+     * |        |          |0001 = Pre-scale is 2; Max time-out period is 2 * 64 * WWDT_CLK.
+     * |        |          |0010 = Pre-scale is 4; Max time-out period is 4 * 64 * WWDT_CLK.
+     * |        |          |0011 = Pre-scale is 8; Max time-out period is 8 * 64 * WWDT_CLK.
+     * |        |          |0100 = Pre-scale is 16; Max time-out period is 16 * 64 * WWDT_CLK.
+     * |        |          |0101 = Pre-scale is 32; Max time-out period is 32 * 64 * WWDT_CLK.
+     * |        |          |0110 = Pre-scale is 64; Max time-out period is 64 * 64 * WWDT_CLK.
+     * |        |          |0111 = Pre-scale is 128; Max time-out period is 128 * 64 * WWDT_CLK.
+     * |        |          |1000 = Pre-scale is 192; Max time-out period is 192 * 64 * WWDT_CLK.
+     * |        |          |1001 = Pre-scale is 256; Max time-out period is 256 * 64 * WWDT_CLK.
+     * |        |          |1010 = Pre-scale is 384; Max time-out period is 384 * 64 * WWDT_CLK.
+     * |        |          |1011 = Pre-scale is 512; Max time-out period is 512 * 64 * WWDT_CLK.
+     * |        |          |1100 = Pre-scale is 768; Max time-out period is 768 * 64 * WWDT_CLK.
+     * |        |          |1101 = Pre-scale is 1024; Max time-out period is 1024 * 64 * WWDT_CLK.
+     * |        |          |1110 = Pre-scale is 1536; Max time-out period is 1536 * 64 * WWDT_CLK.
+     * |        |          |1111 = Pre-scale is 2048; Max time-out period is 2048 * 64 * WWDT_CLK.
+     * |[21:16] |CMPDAT    |WWDT Window Compare Register
+     * |        |          |Set this register to adjust the valid reload window.
+     * |        |          |Note: User can only write WWDT_RLDCNT register to reload WWDT counter value when current WWDT counter value between 0 and CMPDAT
+     * |        |          |If user writes WWDT_RLDCNT register when current WWDT counter value larger than CMPDAT, WWDT reset signal will generate immediately.
+     * |[31]    |ICEDEBUG  |ICE Debug Mode Acknowledge Disable Bit
+     * |        |          |0 = ICE debug mode acknowledgement effects WWDT counting.
+     * |        |          |WWDT down counter will be held while CPU is held by ICE.
+     * |        |          |1 = ICE debug mode acknowledgement Disabled.
+     * |        |          |Note: WWDT down counter will keep going no matter CPU is held by ICE or not.
+     * @var WWDT_T::STATUS
+     * Offset: 0x08  WWDT Status Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[0]     |WWDTIF    |WWDT Compare Match Interrupt Flag
+     * |        |          |This bit indicates the interrupt flag status of WWDT while WWDT counter value matches CMPDAT (WWDT_CTL[21:16]).
+     * |        |          |0 = No effect.
+     * |        |          |1 = WWDT counter value matches CMPDAT.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * |[1]     |WWDTRF    |WWDT Timer-out Reset Flag
+     * |        |          |This bit indicates the system has been reset by WWDT time-out reset or not.
+     * |        |          |0 = WWDT time-out reset did not occur.
+     * |        |          |1 = WWDT time-out reset occurred.
+     * |        |          |Note: This bit is cleared by writing 1 to it.
+     * @var WWDT_T::CNT
+     * Offset: 0x0C  WWDT Counter Value Register
+     * ---------------------------------------------------------------------------------------------------
+     * |Bits    |Field     |Descriptions
+     * | :----: | :----:   | :---- |
+     * |[5:0]   |CNTDAT    |WWDT Counter Value
+     * |        |          |CNTDAT will be updated continuously to monitor 6-bit WWDT down counter value.
+     */
+    __O  uint32_t RLDCNT;                /*!< [0x0000] WWDT Reload Counter Register                                     */
+    __IO uint32_t CTL;                   /*!< [0x0004] WWDT Control Register                                            */
+    __IO uint32_t STATUS;                /*!< [0x0008] WWDT Status Register                                             */
+    __I  uint32_t CNT;                   /*!< [0x000c] WWDT Counter Value Register                                      */
+} WWDT_T;
+
+/**
+    @addtogroup WWDT_CONST WWDT Bit Field Definition
+    Constant Definitions for WWDT Controller
+@{ */
+
+#define WWDT_RLDCNT_RLDCNT_Pos           (0)                                               /*!< WWDT_T::RLDCNT: RLDCNT Position        */
+#define WWDT_RLDCNT_RLDCNT_Msk           (0xfffffffful << WWDT_RLDCNT_RLDCNT_Pos)          /*!< WWDT_T::RLDCNT: RLDCNT Mask            */
+
+#define WWDT_CTL_WWDTEN_Pos              (0)                                               /*!< WWDT_T::CTL: WWDTEN Position           */
+#define WWDT_CTL_WWDTEN_Msk              (0x1ul << WWDT_CTL_WWDTEN_Pos)                    /*!< WWDT_T::CTL: WWDTEN Mask               */
+
+#define WWDT_CTL_INTEN_Pos               (1)                                               /*!< WWDT_T::CTL: INTEN Position            */
+#define WWDT_CTL_INTEN_Msk               (0x1ul << WWDT_CTL_INTEN_Pos)                     /*!< WWDT_T::CTL: INTEN Mask                */
+
+#define WWDT_CTL_PSCSEL_Pos              (8)                                               /*!< WWDT_T::CTL: PSCSEL Position           */
+#define WWDT_CTL_PSCSEL_Msk              (0xful << WWDT_CTL_PSCSEL_Pos)                    /*!< WWDT_T::CTL: PSCSEL Mask               */
+
+#define WWDT_CTL_CMPDAT_Pos              (16)                                              /*!< WWDT_T::CTL: CMPDAT Position           */
+#define WWDT_CTL_CMPDAT_Msk              (0x3ful << WWDT_CTL_CMPDAT_Pos)                   /*!< WWDT_T::CTL: CMPDAT Mask               */
+
+#define WWDT_CTL_ICEDEBUG_Pos            (31)                                              /*!< WWDT_T::CTL: ICEDEBUG Position         */
+#define WWDT_CTL_ICEDEBUG_Msk            (0x1ul << WWDT_CTL_ICEDEBUG_Pos)                  /*!< WWDT_T::CTL: ICEDEBUG Mask             */
+
+#define WWDT_STATUS_WWDTIF_Pos           (0)                                               /*!< WWDT_T::STATUS: WWDTIF Position        */
+#define WWDT_STATUS_WWDTIF_Msk           (0x1ul << WWDT_STATUS_WWDTIF_Pos)                 /*!< WWDT_T::STATUS: WWDTIF Mask            */
+
+#define WWDT_STATUS_WWDTRF_Pos           (1)                                               /*!< WWDT_T::STATUS: WWDTRF Position        */
+#define WWDT_STATUS_WWDTRF_Msk           (0x1ul << WWDT_STATUS_WWDTRF_Pos)                 /*!< WWDT_T::STATUS: WWDTRF Mask            */
+
+#define WWDT_CNT_CNTDAT_Pos              (0)                                               /*!< WWDT_T::CNT: CNTDAT Position           */
+#define WWDT_CNT_CNTDAT_Msk              (0x3ful << WWDT_CNT_CNTDAT_Pos)                   /*!< WWDT_T::CNT: CNTDAT Mask               */
+
+/** @} WWDT_CONST */
+/** @} end of WWDT register group */
+/** @} end of REGISTER group */
+
+#if defined ( __CC_ARM   )
+    #pragma no_anon_unions
+#endif
+
+#endif /* __WWDT_REG_H__ */

--- a/hal/m258ke/parallel_bus.c
+++ b/hal/m258ke/parallel_bus.c
@@ -1,0 +1,586 @@
+/*
+ * parallel_bus.c
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../parallel_bus.h"
+#include "../../util.h"
+#include "../gpio.h"
+#include "gpio_hw.h"
+#include "nuvoton/NuMicro.h"
+
+// Borrowed from Nuvoton's sample code
+#define GPIO_PIN_DATA(port, pin)	(*((volatile uint32_t *)((GPIO_PIN_DATA_BASE+(0x40*(port))) + ((pin)<<2))))
+#define PC10						GPIO_PIN_DATA(2, 10)
+#define PC11						GPIO_PIN_DATA(2, 11)
+#define PC12						GPIO_PIN_DATA(2, 12)
+
+/// Defines for speedier toggle of these pins
+#define FLASH_WE_PIN				PC12
+#define FLASH_OE_PIN				PC11
+#define FLASH_CS_PIN				PC10
+
+/// The index of the highest address line on the parallel bus
+#define PARALLEL_BUS_HIGHEST_ADDRESS_LINE	20
+
+// Data pins:
+// PB0-7: D8-D15
+// PB8-15: D0-D7
+// PE0-7: D24-D31
+// PE8-15: D16-D23
+
+// Address pins:
+// PA0-11: A0-A11
+// PC0-8: A12-A20
+
+static inline void ParallelBus_SetDataAllInput(void);
+static inline void ParallelBus_SetDataAllOutput(void);
+
+/// The /WE pin for the parallel bus
+static const GPIOPin flashWEPin = {GPIOC, 12};
+/// The /OE pin for the parallel bus
+static const GPIOPin flashOEPin = {GPIOC, 11};
+/// The /CS pin for the flash chip
+static const GPIOPin flashCSPin = {GPIOC, 10};
+
+// Macros for asserting and deasserting pins
+#define AssertControl(p) p = 0
+#define DeassertControl(p) p = 1
+
+/** Initializes the 32-bit data/21-bit address parallel bus.
+ *
+ */
+void ParallelBus_Init(void)
+{
+	// Configure all address lines as outputs, outputting address 0
+	ParallelBus_SetAddressDir((1UL << (PARALLEL_BUS_HIGHEST_ADDRESS_LINE + 1)) - 1);
+	ParallelBus_SetAddress(0);
+
+	// Set all data lines to pulled-up inputs
+	ParallelBus_SetDataAllInput();
+	ParallelBus_SetDataPullups(0xFFFFFFFFUL);
+
+	// Control lines
+	ParallelBus_SetCSDir(true);
+	ParallelBus_SetOEDir(true);
+	ParallelBus_SetWEDir(true);
+
+	// Default to only CS asserted
+	DeassertControl(FLASH_WE_PIN);
+	DeassertControl(FLASH_OE_PIN);
+	AssertControl(FLASH_CS_PIN);
+}
+
+/** Sets the address being output on the 21-bit address bus
+ *
+ * @param address The address
+ */
+void ParallelBus_SetAddress(uint32_t address)
+{
+	const uint32_t addrMaskA = 0xFFFUL;
+	const uint32_t addrMaskC = 0x1FFUL;
+
+	const uint32_t addrA = address & addrMaskA;
+	const uint32_t addrC = (address >> 12) & addrMaskC;
+
+	// For efficiency, we talk directly to the registers in this function,
+	// rather than going through the GPIO class.
+
+	uint32_t tmpA = PA->DOUT;
+	uint32_t tmpC = PC->DOUT;
+	tmpA &= ~addrMaskA;
+	tmpA |= addrA;
+	tmpC &= ~addrMaskC;
+	tmpC |= addrC;
+	PA->DOUT = tmpA;
+	PC->DOUT = tmpC;
+}
+
+/** Sets the output data on the 32-bit data bus
+ *
+ * @param data The data
+ */
+void ParallelBus_SetData(uint32_t data)
+{
+	const uint32_t dataMaskB = 0xFFFFUL;
+	const uint32_t dataMaskE = 0xFFFFUL;
+
+	const uint32_t dataB = (data >> 16) & dataMaskB;
+	const uint32_t dataE = (data >> 0) & dataMaskE;
+
+	// For efficiency, we talk directly to the registers in this function,
+	// rather than going through the GPIO class.
+
+	PB->DOUT = dataB;
+	PE->DOUT = dataE;
+}
+
+/** Sets the output value of the CS pin
+ *
+ * @param high True if it should be high, false if low
+ */
+void ParallelBus_SetCS(bool high)
+{
+	GPIO_Set(flashCSPin, high);
+}
+
+/** Sets the output value of the OE pin
+ *
+ * @param high True if it should be high, false if low
+ */
+void ParallelBus_SetOE(bool high)
+{
+	GPIO_Set(flashOEPin, high);
+}
+
+/** Sets the output value of the WE pin
+ *
+ * @param high True if it should be high, false if low
+ */
+void ParallelBus_SetWE(bool high)
+{
+	GPIO_Set(flashWEPin, high);
+}
+
+/**
+ * @brief Interleaves zeros between each bit in a 16-bit value
+ * @param value The original value to interleave, 16 bits
+ * @return Interleaved version of value, 32 bits
+ *
+ * For example, if value = 0b0000111100110101, then it will return:
+ * 0b00000000010101010000010100010001
+ */
+static uint32_t InterleaveZeros(uint16_t value)
+{
+	uint32_t x = value;
+
+	// https://graphics.stanford.edu/~seander/bithacks.html#InterleaveBMN
+	static const uint32_t B[] = {0x55555555UL, 0x33333333UL, 0x0F0F0F0FUL, 0x00FF00FFUL};
+	static const uint32_t S[] = {1UL, 2UL, 4UL, 8UL};
+
+	x = (x | (x << S[3])) & B[3];
+	x = (x | (x << S[2])) & B[2];
+	x = (x | (x << S[1])) & B[1];
+	x = (x | (x << S[0])) & B[0];
+
+	return x;
+}
+
+/** Sets which pins on the 21-bit address bus should be outputs
+ *
+ * @param outputs Mask of pins that should be outputs. 1 = output, 0 = input
+ *
+ * Typically the address pins will be outputs. This flexibility is provided in
+ * case we want to do electrical testing.
+ */
+void ParallelBus_SetAddressDir(uint32_t outputs)
+{
+	const uint32_t addrMaskA = 0xFFFUL;
+	const uint32_t addrMaskC = 0x1FFUL;
+
+	const uint32_t addrA = outputs & addrMaskA;
+	const uint32_t addrC = (outputs >> 12) & addrMaskC;
+
+	// For efficiency, we talk directly to the PORT registers in this function,
+	// rather than going through the GPIO class.
+
+	// There are actually 2 bits per pin. We want to write 00 if input,
+	// 01 if output. So we need to interleave a zero in between each bit
+	// to match the register layout.
+
+	const uint32_t regMaskA = 0xFFFFFFUL;
+	const uint32_t regMaskC = 0x3FFFFUL;
+
+	const uint32_t regA = InterleaveZeros(addrA);
+	const uint32_t regC = InterleaveZeros(addrC);
+
+	uint32_t tmpA = PA->MODE;
+	uint32_t tmpC = PC->MODE;
+	tmpA &= ~regMaskA;
+	tmpA |= regA;
+	tmpC &= ~regMaskC;
+	tmpC |= regC;
+	PA->MODE = tmpA;
+	PC->MODE = tmpC;
+}
+
+/** Sets which pins on the 32-bit data bus should be outputs
+ *
+ * @param outputs Mask of pins that should be outputs. 1 = output, 0 = input
+ *
+ * Typically all pins would be set as inputs or outputs, and it's automatically
+ * handled by the read/write cycle functions. This function exists mainly for
+ * test purposes.
+ */
+void ParallelBus_SetDataDir(uint32_t outputs)
+{
+	const uint32_t dataMaskB = 0xFFFFUL;
+	const uint32_t dataMaskE = 0xFFFFUL;
+
+	const uint32_t dataB = (outputs >> 16) & dataMaskB;
+	const uint32_t dataE = (outputs >> 0) & dataMaskE;
+
+	// For efficiency, we talk directly to the registers in this function,
+	// rather than going through the GPIO class.
+
+	// There are actually 2 bits per pin. We want to write 00 if input,
+	// 01 if output. So we need to interleave a zero in between each bit
+	// to match the register layout.
+
+	const uint32_t regB = InterleaveZeros(dataB);
+	const uint32_t regE = InterleaveZeros(dataE);
+
+	PB->MODE = regB;
+	PE->MODE = regE;
+}
+
+/**
+ * @brief Sets all data pins as inputs
+ *
+ * This is an optimized version for the read cycle functions
+ */
+static inline void ParallelBus_SetDataAllInput(void)
+{
+	PB->MODE = 0;
+	PE->MODE = 0;
+}
+
+/**
+ * @brief Sets all data pins as outputs
+ *
+ * This is an optimized version for the write cycle functions
+ */
+static inline void ParallelBus_SetDataAllOutput(void)
+{
+	PB->MODE = 0x55555555UL;
+	PE->MODE = 0x55555555UL;
+}
+
+/** Sets the direction of the CS pin
+ *
+ * @param output True if it's an output, false if it's an input
+ *
+ * Typically this pin will be an output. This flexibility is provided in case
+ * we want to do electrical testing.
+ */
+void ParallelBus_SetCSDir(bool output)
+{
+	GPIO_SetDirection(flashCSPin, output);
+}
+
+/** Sets the direction of the OE pin
+ *
+ * @param output True if it's an output, false if it's an input
+ *
+ * Typically this pin will be an output. This flexibility is provided in case
+ * we want to do electrical testing.
+ */
+void ParallelBus_SetOEDir(bool output)
+{
+	GPIO_SetDirection(flashOEPin, output);
+}
+
+/** Sets the direction of the WE pin
+ *
+ * @param output True if it's an output, false if it's an input
+ *
+ * Typically this pin will be an output. This flexibility is provided in case
+ * we want to do electrical testing.
+ */
+void ParallelBus_SetWEDir(bool output)
+{
+	GPIO_SetDirection(flashWEPin, output);
+}
+
+/** Sets which pins on the 21-bit address bus should be pulled up (if inputs)
+ *
+ * @param pullups Mask of pins that should be pullups.
+ *
+ * This would typically only be used for testing. Under normal operation, the
+ * address bus will be outputting, so the pullups are irrelevant.
+ */
+void ParallelBus_SetAddressPullups(uint32_t pullups)
+{
+	const uint32_t addrMaskA = 0xFFFUL;
+	const uint32_t addrMaskC = 0x1FFUL;
+
+	const uint32_t addrA = pullups & addrMaskA;
+	const uint32_t addrC = (pullups >> 12) & addrMaskC;
+
+	// For efficiency, we talk directly to the registers in this function,
+	// rather than going through the GPIO class.
+
+	// There are actually 2 bits per pin. We want to write 00 if disabled,
+	// 01 if enabled. So we need to interleave a zero in between each bit
+	// to match the register layout.
+
+	const uint32_t regMaskA = 0xFFFFFFUL;
+	const uint32_t regMaskC = 0x3FFFFUL;
+
+	const uint32_t regA = InterleaveZeros(addrA);
+	const uint32_t regC = InterleaveZeros(addrC);
+
+	uint32_t tmpA = PA->PUSEL;
+	uint32_t tmpC = PC->PUSEL;
+	tmpA &= ~regMaskA;
+	tmpA |= regA;
+	tmpC &= ~regMaskC;
+	tmpC |= regC;
+	PA->PUSEL = tmpA;
+	PC->PUSEL = tmpC;
+}
+
+/** Sets which pins on the 32-bit data bus should be pulled up (if inputs)
+ *
+ * @param pullups Mask of pins that should be pullups.
+ *
+ * Typically these will be enabled in order to provide a default value if a
+ * chip isn't responding properly. Sometimes it's useful to customize it during
+ * testing though.
+ */
+void ParallelBus_SetDataPullups(uint32_t pullups)
+{
+	const uint32_t dataMaskB = 0xFFFFUL;
+	const uint32_t dataMaskE = 0xFFFFUL;
+
+	const uint32_t dataB = (pullups >> 16) & dataMaskB;
+	const uint32_t dataE = (pullups >> 0) & dataMaskE;
+
+	// For efficiency, we talk directly to the registers in this function,
+	// rather than going through the GPIO class.
+
+	// There are actually 2 bits per pin. We want to write 00 if input,
+	// 01 if output. So we need to interleave a zero in between each bit
+	// to match the register layout.
+
+	const uint32_t regB = InterleaveZeros(dataB);
+	const uint32_t regE = InterleaveZeros(dataE);
+
+	PB->PUSEL = regB;
+	PE->PUSEL = regE;
+}
+
+/** Sets whether the CS pin is pulled up, if it's an input.
+ *
+ * @param pullup True if the CS pin should be pulled up, false if not
+ *
+ * This would typically only be used for testing. Under normal operation, this
+ * pin will be set as an output, so the pullup state is irrelevant.
+ */
+void ParallelBus_SetCSPullup(bool pullup)
+{
+	GPIO_SetPullup(flashCSPin, pullup);
+}
+
+/** Sets whether the OE pin is pulled up, if it's an input.
+ *
+ * @param pullup True if the OE pin should be pulled up, false if not
+ *
+ * This would typically only be used for testing. Under normal operation, this
+ * pin will be set as an output, so the pullup state is irrelevant.
+ */
+void ParallelBus_SetOEPullup(bool pullup)
+{
+	GPIO_SetPullup(flashOEPin, pullup);
+}
+
+/** Sets whether the WE pin is pulled up, if it's an input.
+ *
+ * @param pullup True if the WE pin should be pulled up, false if not
+ *
+ * This would typically only be used for testing. Under normal operation, this
+ * pin will be set as an output, so the pullup state is irrelevant.
+ */
+void ParallelBus_SetWEPullup(bool pullup)
+{
+	GPIO_SetPullup(flashWEPin, pullup);
+}
+
+/** Reads the current data on the address bus.
+ *
+ * @return The address bus readback
+ *
+ * This would typically only be used for testing. Under normal operation, the
+ * address bus will be outputting, so the readback is irrelevant.
+ */
+uint32_t ParallelBus_ReadAddress(void)
+{
+	const uint32_t addrMaskA = 0xFFFUL;
+	const uint32_t addrMaskC = 0x1FFUL;
+
+	// For efficiency, we talk directly to the registers in this function,
+	// rather than going through the GPIO class.
+
+	const uint32_t readA = PA->PIN;
+	const uint32_t readC = PC->PIN;
+
+	uint32_t result = readA & addrMaskA;
+	result |= ((readC & addrMaskC) << 12);
+	return result;
+}
+
+/** Reads the current data on the 32-bit data bus.
+ *
+ * @return The 32-bit data readback
+ */
+uint32_t ParallelBus_ReadData(void)
+{
+	const uint32_t dataMaskB = 0xFFFFUL;
+	const uint32_t dataMaskE = 0xFFFFUL;
+
+	const uint32_t readB = PB->PIN;
+	const uint32_t readE = PE->PIN;
+
+	uint32_t result = readE & dataMaskE;
+	result |= ((readB & dataMaskB) << 16);
+	return result;
+}
+
+/** Reads the status of the CS pin, if it's set as an input.
+ *
+ * @return True if the CS pin is high, false if it's low
+ *
+ * This would typically only be used for testing. Under normal operation, this
+ * pin will be set as an output, so the readback is irrelevant.
+ */
+bool ParallelBus_ReadCS(void)
+{
+	return GPIO_Read(flashCSPin);
+}
+
+/** Reads the status of the OE pin, if it's set as an input.
+ *
+ * @return True if the OE pin is high, false if it's low
+ *
+ * This would typically only be used for testing. Under normal operation, this
+ * pin will be set as an output, so the readback is irrelevant.
+ */
+bool ParallelBus_ReadOE(void)
+{
+	return GPIO_Read(flashOEPin);
+}
+
+/** Reads the status of the WE pin, if it's set as an input.
+ *
+ * @return True if the WE pin is high, false if it's low
+ *
+ * This would typically only be used for testing. Under normal operation, this
+ * pin will be set as an output, so the readback is irrelevant.
+ */
+bool ParallelBus_ReadWE(void)
+{
+	return GPIO_Read(flashWEPin);
+}
+
+/** Performs a write cycle on the parallel bus.
+ *
+ * @param address The address to write to
+ * @param data The 32-bit data to write to the bus
+ */
+void ParallelBus_WriteCycle(uint32_t address, uint32_t data)
+{
+	// We should currently be in a state of "CS is asserted, OE/WE not asserted".
+	// As an optimization, operate under that assumption.
+
+	// Set address
+	ParallelBus_SetAddress(address);
+
+	// Ensure the data pins are all outputs
+	ParallelBus_SetDataAllOutput();
+
+	// Set data
+	ParallelBus_SetData(data);
+
+	// Assert and then deassert WE to actually do the write cycle.
+	AssertControl(FLASH_WE_PIN);
+	DeassertControl(FLASH_WE_PIN);
+
+	// Control lines are left as "CS asserted, OE/WE not asserted" here.
+}
+
+/** Performs a read cycle on the parallel bus.
+ *
+ * @param address The address to read from
+ * @return The returned 32-bit data
+ */
+uint32_t ParallelBus_ReadCycle(uint32_t address)
+{
+	uint32_t ret;
+
+	// We should currently be in a state of "CS is asserted, OE/WE not asserted".
+	// As an optimization, operate under that assumption.
+
+	// Ensure the data pins are all inputs
+	ParallelBus_SetDataAllInput();
+
+	// Assert OE so we start reading from the chip. Safe to do now that
+	// the data pins have been set as inputs.
+	AssertControl(FLASH_OE_PIN);
+
+	// Set address
+	ParallelBus_SetAddress(address);
+
+	// Read data
+	ret = ParallelBus_ReadData();
+
+	// Deassert OE, and we're done.
+	DeassertControl(FLASH_OE_PIN);
+
+	// Control lines are left as "CS asserted, OE/WE not asserted" here.
+
+	// Return the final value
+	return ret;
+}
+
+/** Reads a bunch of consecutive data from the parallel bus
+ *
+ * @param startAddress The address to start reading from
+ * @param buf Buffer to store the readback
+ * @param len The number of 32-bit words to read
+ *
+ * This function is just a time saver if we know we will be reading a big block
+ * of data. It doesn't bother playing with the control lines between each byte.
+ */
+void ParallelBus_Read(uint32_t startAddress, uint32_t *buf, uint16_t len)
+{
+	// We should currently be in a state of "CS is asserted, OE/WE not asserted".
+	// As an optimization, operate under that assumption.
+
+	// Ensure the data pins are all inputs
+	ParallelBus_SetDataAllInput();
+
+	// Assert OE, now the chip will start spitting out data.
+	AssertControl(FLASH_OE_PIN);
+
+	while (len--)
+	{
+		// Set address
+		ParallelBus_SetAddress(startAddress++);
+
+		// Read data
+		*buf++ = ParallelBus_ReadData();
+	}
+
+	// Deassert OE once we are done
+	DeassertControl(FLASH_OE_PIN);
+
+	// Control lines are left as "CS asserted, OE/WE not asserted" here.
+}

--- a/hal/m258ke/spi.c
+++ b/hal/m258ke/spi.c
@@ -1,0 +1,110 @@
+/*
+ * spi.c
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../spi.h"
+#include "gpio_hw.h"
+#include <stddef.h>
+
+/** Gets the SPI hardware controller at the specified index
+ *
+ * @param index The index of the controller. No SPI is available on the M258KE.
+ * @return The SPI controller, or NULL if an invalid index is supplied
+ */
+SPIController *SPI_Controller(uint8_t index)
+{
+	(void)index;
+	return NULL;
+}
+
+/** Initializes the supplied SPI controller
+ *
+ * @param c The controller
+ */
+void SPI_InitController(SPIController *c)
+{
+	(void)c;
+}
+
+/** Initializes the supplied SPI device
+ *
+ * @param spi The device
+ * @param maxClock The maximum clock rate supported by the device in Hz
+ * @param mode The SPI mode (see the SPI_MODE_*, SPI_CPHA, and SPI_CPOL defines)
+ * @return True on success, false on failure
+ */
+bool SPI_InitDevice(SPIDevice *spi, uint32_t maxClock, uint8_t mode)
+{
+	(void)spi;
+	(void)maxClock;
+	(void)mode;
+	return false;
+}
+
+/** Allows an SPI device to request control of the bus.
+ *
+ * @param spi The SPI device
+ */
+void SPI_RequestBus(SPIDevice *spi)
+{
+	(void)spi;
+}
+
+/** Allows an SPI device to relinquish control of the bus.
+ *
+ * @param spi The SPI device
+ */
+void SPI_ReleaseBus(SPIDevice *spi)
+{
+	(void)spi;
+}
+
+/** Asserts an SPI device's chip select pin
+ *
+ * @param spi The SPI device
+ */
+void SPI_Assert(SPIDevice *spi)
+{
+	(void)spi;
+}
+
+/** Deasserts an SPI device's chip select pin
+ *
+ * @param spi The SPI device
+ */
+void SPI_Deassert(SPIDevice *spi)
+{
+	(void)spi;
+}
+
+/** Transfers a single byte to/from an SPI device
+ *
+ * @param spi The SPI device
+ * @param b The byte to send
+ * @return The byte that was simultaneously received
+ */
+uint8_t SPI_RWByte(SPIDevice *spi, uint8_t b)
+{
+	(void)spi;
+	(void)b;
+	return 0;
+}

--- a/hal/m258ke/spi_private.h
+++ b/hal/m258ke/spi_private.h
@@ -1,0 +1,33 @@
+/*
+ * spi_private.h
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef HAL_M258KE_SPI_PRIVATE_H_
+#define HAL_M258KE_SPI_PRIVATE_H_
+
+/// Private data for an SPI device on the M258KE
+typedef struct SPIDevicePrivate
+{
+	/// There's nothing needed. We don't need SPI on this device.
+} SPIDevicePrivate;
+
+#endif /* HAL_M258KE_SPI_PRIVATE_H_ */

--- a/hal/m258ke/usbcdc.c
+++ b/hal/m258ke/usbcdc.c
@@ -1,0 +1,468 @@
+/*
+ * usbcdc.c
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Portions of this code also came from Nuvoton's BSP, originally
+ * licensed as Apache-2.0:
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *
+ */
+
+#include "usbcdc_hw.h"
+#include <stdbool.h>
+
+// Undocumented register for HIRC trim from Nuvoton's samples
+#define TRIM_INIT				(SYS_BASE + 0x118)
+
+#define SET_LINE_CODE			0x20
+#define GET_LINE_CODE			0x21
+#define SET_CONTROL_LINE_STATE  0x22
+
+/// Setup buffer uses first 8 bytes of USB SRAM
+#define SETUP_BUF_BASE			0
+#define SETUP_BUF_LEN			8
+/// EP0 and EP1 share the same USB SRAM, 64 bytes of control
+#define EP0_BUF_BASE			(SETUP_BUF_BASE + SETUP_BUF_LEN)
+#define EP0_BUF_LEN				EP0_MAX_PKT_SIZE
+#define EP1_BUF_BASE			(SETUP_BUF_BASE + SETUP_BUF_LEN)
+#define EP1_BUF_LEN				EP1_MAX_PKT_SIZE
+/// EP2 uses 8 bytes for interrupt IN (not really used though)
+#define EP2_BUF_BASE			(EP1_BUF_BASE + EP1_BUF_LEN)
+#define EP2_BUF_LEN				EP2_MAX_PKT_SIZE
+/// EP3 uses 64 bytes for bulk IN
+#define EP3_BUF_BASE			(EP2_BUF_BASE + EP2_BUF_LEN)
+#define EP3_BUF_LEN				EP3_MAX_PKT_SIZE
+/// EP4 uses 64 bytes for bulk OUT
+#define EP4_BUF_BASE			(EP3_BUF_BASE + EP3_BUF_LEN)
+#define EP4_BUF_LEN				EP4_MAX_PKT_SIZE
+
+/// Struct to represent the current line coding
+typedef struct
+{
+	uint32_t baudRate; // Baud rate
+	uint8_t stopBits;  // stop bit
+	uint8_t parity;    // parity
+	uint8_t dataBits;  // data bits
+} CDCLineCoding;
+
+static void USBCDC_SendDataInBuffer(void);
+static void USBCDC_InitEndpoints(void);
+static void USBCDC_ClassRequest(void);
+
+/// Default HIRC trim value in case of errors
+static uint32_t trimInit;
+/// Toggle flag for ensuring the received endpoint 4 packet is the expected one
+static volatile uint32_t ep4OutToggle = 0;
+/// Line coding for CDC device, not used by this firmware
+static CDCLineCoding cdcLineCoding = {0, 0, 0, 0};
+/// Control signal for CDC device, not used by this firmware
+static uint16_t cdcCtrlSignal;
+
+/// Buffer to send to the CDC serial port
+static uint8_t cdcTxBuf[EP3_MAX_PKT_SIZE];
+/// Current position in the TX buffer
+static uint32_t cdcTxBufPos = 0;
+/// Flag that is true if a TX is currently active
+static volatile bool cdcTxActive = false;
+/// Buffer we read into
+static uint8_t cdcRxBuf[EP4_MAX_PKT_SIZE];
+/// Current length of RX buffer
+static uint32_t cdcRxLen = 0;
+/// Current position into RX buffer
+static uint32_t cdcRxPos = 0;
+/// Flag that is true if new RX data is ready to read
+static volatile bool cdcRxReady = false;
+
+/** Initializes the USB CDC serial port
+ *
+ */
+void USBCDC_Init(void)
+{
+	// Set up USB
+	USBD_Open(&gsInfo, USBCDC_ClassRequest);
+	USBCDC_InitEndpoints();
+	USBD_Start();
+	NVIC_EnableIRQ(USBD_IRQn);
+
+	// Backup the default trim value, go back to it if there's an error
+	trimInit = M32(TRIM_INIT);
+
+	// Clear USB SOF flag; it will be used to detect if we have a USB
+	// signal available to use for HIRC trim
+	USBD_CLR_INT_FLAG(USBD_INTSTS_SOFIF_Msk);
+}
+
+/** Performs any necessary periodic tasks for the USB CDC serial port
+ *
+ */
+void USBCDC_Check(void)
+{
+	// If we haven't enabled auto trim, and we have a USB signal available,
+	// then do it!
+	if (((SYS->HIRCTRIMCTL & SYS_HIRCTRIMCTL_FREQSEL_Msk) != 0x1) &&
+		(USBD->INTSTS & USBD_INTSTS_SOFIF_Msk))
+	{
+		// Clear SOF flag for next time
+		USBD_CLR_INT_FLAG(USBD_INTSTS_SOFIF_Msk);
+
+		// Start USB trim:
+		// - HIRC trim reference is USB clock
+		// - Enable auto trim, and trim to 48 MHz
+		// - Use 4 cycles for trimming
+		// - Boundary enabled (value = 10)
+		SYS->HIRCTRIMCTL = (0x1UL << SYS_HIRCTRIMCTL_REFCKSEL_Pos)
+						   | (0x1UL << SYS_HIRCTRIMCTL_FREQSEL_Pos)
+						   | (0x0UL << SYS_HIRCTRIMCTL_LOOPSEL_Pos)
+						   | (0x1UL << SYS_HIRCTRIMCTL_BOUNDEN_Pos)
+						   | (10UL  << SYS_HIRCTRIMCTL_BOUNDARY_Pos);
+	}
+
+	// If we detect a clock error or trim failure, disable auto trim. We can try again later.
+	if (SYS->HIRCTRIMSTS & (SYS_HIRCTRIMSTS_CLKERIF_Msk | SYS_HIRCTRIMSTS_TFAILIF_Msk))
+	{
+		// Restore original trim value we read at startup
+		M32(TRIM_INIT) = trimInit;
+
+		// Disable USB trim
+		SYS->HIRCTRIMCTL = 0;
+
+		// Clear the error flags
+		SYS->HIRCTRIMSTS = SYS_HIRCTRIMSTS_CLKERIF_Msk | SYS_HIRCTRIMSTS_TFAILIF_Msk;
+
+		// Clear the SOF flag so the next time it's set we know we have a USB signal
+		USBD_CLR_INT_FLAG(USBD_INTSTS_SOFIF_Msk);
+	}
+
+	// Flush the USB CDC port every main loop just like LUFA does
+	USBCDC_Flush();
+}
+
+/** Sends a byte out the USB serial port
+ *
+ * @param b The byte
+ */
+void USBCDC_SendByte(uint8_t b)
+{
+	// Fill up our buffer to send out the USB serial port
+	cdcTxBuf[cdcTxBufPos++] = b;
+	if (cdcTxBufPos == EP3_MAX_PKT_SIZE)
+	{
+		// If we reached a full packet size, send the data in the buffer
+		USBCDC_SendDataInBuffer();
+	}
+}
+
+/** Reads a byte from the USB serial port, if available
+ *
+ * @return The byte, or -1 if there is nothing available
+ */
+int16_t USBCDC_ReadByte(void)
+{
+	// Assume not ready
+	int16_t ret = -1;
+
+	// If we have data ready to read out of the USB controller's endpoint buffer, grab it now
+	if (cdcRxLen == 0 && cdcRxReady)
+	{
+		// Flag that we handled the read event
+		cdcRxReady = false;
+
+		// Reset our read pointer just in case
+		cdcRxPos = 0;
+
+		// Read all of the data out from the USB controller
+		cdcRxLen = USBD_GET_PAYLOAD_LEN(EP4);
+		USBD_MemCopy(cdcRxBuf, (uint8_t *)(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP4)), cdcRxLen);
+
+		// We grabbed all of the packet data, so tell the USB controller we're done with it
+		USBD_SET_PAYLOAD_LEN(EP4, EP4_MAX_PKT_SIZE);
+	}
+
+	// If we have something left in our buffer since the last read, use it
+	if (cdcRxLen > 0)
+	{
+		ret = cdcRxBuf[cdcRxPos++];
+
+		// If we finished reading from the buffer, mark it as finished.
+		if (cdcRxPos == cdcRxLen)
+		{
+			cdcRxPos = 0;
+			cdcRxLen = 0;
+		}
+	}
+
+	return ret;
+}
+
+/** Sends out any remaining data in the TX buffer
+ *
+ */
+void USBCDC_Flush(void)
+{
+	// If we have something waiting to send, send it out now
+	if (cdcTxBufPos > 0)
+	{
+		bool needsZLP = cdcTxBufPos == EP3_MAX_PKT_SIZE;
+		USBCDC_SendDataInBuffer();
+
+		// If we are flushing after sending a full packet of data,
+		// send a ZLP afterward to indicate end of transmit to host
+		if (needsZLP)
+		{
+			USBCDC_SendDataInBuffer();
+		}
+	}
+}
+
+/** Sends the data in the EP3 TX buffer to the host
+ *
+ */
+static void USBCDC_SendDataInBuffer(void)
+{
+	// Wait for any previous transmit to finish first
+	while (cdcTxActive);
+
+	// Send out the packet
+	USBD_MemCopy((uint8_t *)(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP3)), cdcTxBuf, cdcTxBufPos);
+	cdcTxActive = true;
+	USBD_SET_PAYLOAD_LEN(EP3, cdcTxBufPos);
+
+	// Reset our buffer position; we've given all the data to the USB controller
+	cdcTxBufPos = 0;
+}
+
+/** IRQ handler called when USB endpoint 3 is ready (CDC TX data finished transferring)
+ *
+ */
+void EP3_Handler(void)
+{
+	// All we have to do is flag that we no longer have an active transmission.
+	// USBCDC_SendDataInBuffer() will handle the rest.
+	cdcTxActive = false;
+}
+
+/** IRQ handler called when USB endpoint 4 is ready (CDC RX data ready to read)
+ *
+ */
+void EP4_Handler(void)
+{
+	// Verify the toggle has changed. If it's still the same, re-request the data.
+	if (ep4OutToggle == (USBD->EPSTS0 & USBD_EPSTS0_EPSTS4_Msk))
+	{
+		USBD_SET_PAYLOAD_LEN(EP4, EP4_MAX_PKT_SIZE);
+	}
+	// Toggle changed, so we're good to go. Toggle for next time and flag that we
+	// have data ready to read. USBCDC_ReadByte() will handle the rest.
+	else
+	{
+		ep4OutToggle = USBD->EPSTS0 & USBD_EPSTS0_EPSTS4_Msk;
+		cdcRxReady = true;
+	}
+}
+
+/** Main IRQ handler for USB device controller
+ *
+ */
+void USBD_IRQHandler(void)
+{
+	uint32_t intStatus = USBD_GET_INT_FLAG();
+	uint32_t busState = USBD_GET_BUS_STATE();
+
+	// Bus interrupt
+	if (intStatus & USBD_INTSTS_BUSIF_Msk)
+	{
+		// Clear the flag
+		USBD_CLR_INT_FLAG(USBD_INTSTS_BUSIF_Msk);
+
+		// The bus was reset - SE0 status for long enough
+		if (busState & USBD_STATE_USBRST)
+		{
+			// Enable USB, reset everything
+			USBD_ENABLE_USB();
+			USBD_SwReset();
+			ep4OutToggle = 0;
+		}
+
+		// Entered suspend status (bus idle)
+		if (busState & USBD_STATE_SUSPEND)
+		{
+			// Disable PHY while we're suspended
+			USBD_DISABLE_PHY();
+		}
+
+		if (busState & USBD_STATE_RESUME)
+		{
+			// Re-enable USB (mainly just the PHY is what we want)
+			USBD_ENABLE_USB();
+		}
+	}
+
+	// USB event
+	if (intStatus & USBD_INTSTS_USBIF_Msk)
+	{
+		// Setup packet?
+		if (intStatus & USBD_INTSTS_SETUP_Msk)
+		{
+			// Clear the flag...
+			USBD_CLR_INT_FLAG(USBD_INTSTS_SETUP);
+
+			// Stop EP0 and EP1 which are the control endpoints
+			USBD_STOP_TRANSACTION(EP0);
+			USBD_STOP_TRANSACTION(EP1);
+
+			// Now handle the received setup packet
+			USBD_ProcessSetupPacket();
+		}
+
+		// EP0 - control in
+		if (intStatus & USBD_INTSTS_EPEVT0_Msk)
+		{
+			USBD_CLR_INT_FLAG(USBD_INTSTS_EPEVT0_Msk);
+			USBD_CtrlIn();
+		}
+
+		// EP1 - control out
+		if (intStatus & USBD_INTSTS_EPEVT1_Msk)
+		{
+			USBD_CLR_INT_FLAG(USBD_INTSTS_EPEVT1_Msk);
+			USBD_CtrlOut();
+		}
+
+		// Do nothing for EP2 for now
+
+		// EP3 - bulk in for CDC data
+		if (intStatus & USBD_INTSTS_EPEVT3_Msk)
+		{
+			USBD_CLR_INT_FLAG(USBD_INTSTS_EPEVT3_Msk);
+			EP3_Handler();
+		}
+
+		// EP4 - bulk out for CDC data
+		if (intStatus & USBD_INTSTS_EPEVT4_Msk)
+		{
+			USBD_CLR_INT_FLAG(USBD_INTSTS_EPEVT4_Msk);
+			EP4_Handler();
+		}
+	}
+}
+
+/** Initializes endpoint buffers in USB SRAM
+ *
+ */
+void USBCDC_InitEndpoints(void)
+{
+	// First 8 bytes are for setup packets
+	USBD->STBUFSEG = SETUP_BUF_BASE;
+
+	// EP0 = control IN, address 0, 64 bytes
+	USBD_CONFIG_EP(EP0, USBD_CFG_CSTALL | USBD_CFG_EPMODE_IN | 0);
+	USBD_SET_EP_BUF_ADDR(EP0, EP0_BUF_BASE);
+
+	// EP1 = control OUT, address 0, uses same 64 bytes as control IN
+	USBD_CONFIG_EP(EP1, USBD_CFG_CSTALL | USBD_CFG_EPMODE_OUT | 0);
+	USBD_SET_EP_BUF_ADDR(EP1, EP1_BUF_BASE);
+
+	// EP2 = interrupt IN, address 2, 8 bytes
+	USBD_CONFIG_EP(EP2, USBD_CFG_EPMODE_IN | INT_IN_EP_NUM);
+	USBD_SET_EP_BUF_ADDR(EP2, EP2_BUF_BASE);
+
+	// EP3 = bulk IN, address 3, 64 bytes
+	USBD_CONFIG_EP(EP3, USBD_CFG_EPMODE_IN | BULK_IN_EP_NUM);
+	USBD_SET_EP_BUF_ADDR(EP3, EP3_BUF_BASE);
+
+	// EP4 = bulk OUT, address 4, 64 bytes
+	USBD_CONFIG_EP(EP4, USBD_CFG_EPMODE_OUT | BULK_OUT_EP_NUM);
+	USBD_SET_EP_BUF_ADDR(EP4, EP4_BUF_BASE);
+
+	// Mark that we are able to receive on EP4
+	USBD_SET_PAYLOAD_LEN(EP4, EP4_MAX_PKT_SIZE);
+}
+
+/** USB class request callback for CDC device
+ *
+ */
+void USBCDC_ClassRequest(void)
+{
+	uint8_t buf[8];
+
+	// Grab the setup packet...
+	USBD_GetSetupPacket(buf);
+
+	// Device to host?
+	if (buf[0] & 0x80)
+	{
+		switch (buf[1])
+		{
+		case GET_LINE_CODE:
+			if (buf[4] == 0)
+			{
+				USBD_MemCopy((uint8_t *)(USBD_BUF_BASE + USBD_GET_EP_BUF_ADDR(EP0)), (uint8_t *)&cdcLineCoding, 7);
+			}
+
+			// Data stage
+			USBD_SET_DATA1(EP0);
+			USBD_SET_PAYLOAD_LEN(EP0, 7);
+
+			// Status stage
+			USBD_PrepareCtrlOut(0, 0);
+			break;
+
+		default:
+			// Stall
+			USBD_SET_EP_STALL(EP0);
+			USBD_SET_EP_STALL(EP1);
+			break;
+		}
+	}
+	// Host to device
+	else
+	{
+		switch (buf[1])
+		{
+		case SET_CONTROL_LINE_STATE:
+			if (buf[4] == 0)
+			{
+				cdcCtrlSignal = (buf[3] << 8) | buf[2];
+			}
+
+			// Status stage
+			USBD_SET_DATA1(EP0);
+			USBD_SET_PAYLOAD_LEN(EP0, 0);
+			break;
+
+		case SET_LINE_CODE:
+			if (buf[4] == 0)
+			{
+				USBD_PrepareCtrlOut((uint8_t *)&cdcLineCoding, 7);
+			}
+
+			// Status stage
+			USBD_SET_DATA1(EP0);
+			USBD_SET_PAYLOAD_LEN(EP0, 0);
+			break;
+
+		default:
+			// Stall
+			USBD_SET_EP_STALL(EP0);
+			USBD_SET_EP_STALL(EP1);
+			break;
+		}
+	}
+}

--- a/hal/m258ke/usbcdc_hw.h
+++ b/hal/m258ke/usbcdc_hw.h
@@ -1,0 +1,113 @@
+/*
+ * usbcdc_hw.h
+ *
+ *  Created on: Jun 19, 2023
+ *      Author: Doug
+ *
+ * Copyright (C) 2011-2023 Doug Brown
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Portions of this code also came from Nuvoton's BSP, originally
+ * licensed as Apache-2.0:
+ * @copyright (C) 2019 Nuvoton Technology Corp. All rights reserved.
+ *
+ */
+
+#ifndef HAL_M258KE_USBCDC_HW_H_
+#define HAL_M258KE_USBCDC_HW_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "nuvoton/NuMicro.h"
+#include "nuvoton/usbd.h"
+
+/// Maximum packet sizes of each endpoint
+#define EP0_MAX_PKT_SIZE    64
+#define EP1_MAX_PKT_SIZE    64
+#define EP2_MAX_PKT_SIZE    8
+#define EP3_MAX_PKT_SIZE    64
+#define EP4_MAX_PKT_SIZE    64
+
+/// Assigned endpoint numbers for CDC serial port
+#define INT_IN_EP_NUM       2
+#define BULK_IN_EP_NUM      3
+#define BULK_OUT_EP_NUM     4
+
+/** Initializes the USB CDC serial port
+ *
+ */
+void USBCDC_Init(void);
+
+/** Disconnects the USB CDC device from the host
+ *
+ */
+static inline void USBCDC_Disable(void)
+{
+    USBD_SET_SE0();
+}
+
+/** Performs any necessary periodic tasks for the USB CDC serial port
+ *
+ */
+void USBCDC_Check(void);
+
+/** Sends a byte out the USB serial port
+ *
+ * @param b The byte
+ */
+void USBCDC_SendByte(uint8_t b);
+
+/** Sends a block of data over the USB CDC serial port
+ *
+ * @param data The data to send
+ * @param len The number of bytes
+ * @return True on success, false on failure
+ */
+static inline bool USBCDC_SendData(uint8_t const *data, uint16_t len)
+{
+	while (len--)
+	{
+		USBCDC_SendByte(*data++);
+	}
+
+	return true;
+}
+
+/** Reads a byte from the USB serial port, if available
+ *
+ * @return The byte, or -1 if there is nothing available
+ */
+int16_t USBCDC_ReadByte(void);
+
+/** Reads a byte from the USB CDC serial port. Blocks until one is available.
+ *
+ * @return The byte read
+ */
+static inline uint8_t USBCDC_ReadByteBlocking(void)
+{
+	int16_t b;
+	do
+	{
+		b = USBCDC_ReadByte();
+	} while (b < 0);
+	return (uint8_t)b;
+}
+
+/** Flushes remaining data out to the USB serial port
+ *
+ */
+void USBCDC_Flush(void);
+
+#endif /* HAL_M258KE_USBCDC_HW_H_ */

--- a/hal/parallel_bus.h
+++ b/hal/parallel_bus.h
@@ -42,10 +42,15 @@ void ParallelBus_SetOEDir(bool output);
 void ParallelBus_SetWEDir(bool output);
 
 void ParallelBus_SetAddressPullups(uint32_t pullups);
+void ParallelBus_SetAddressPulldowns(uint32_t pulldowns);
 void ParallelBus_SetDataPullups(uint32_t pullups);
+void ParallelBus_SetDataPulldowns(uint32_t pulldowns);
 void ParallelBus_SetCSPullup(bool pullup);
+void ParallelBus_SetCSPulldown(bool pulldown);
 void ParallelBus_SetOEPullup(bool pullup);
+void ParallelBus_SetOEPulldown(bool pulldown);
 void ParallelBus_SetWEPullup(bool pullup);
+void ParallelBus_SetWEPulldown(bool pulldown);
 
 uint32_t ParallelBus_ReadAddress(void);
 uint32_t ParallelBus_ReadData(void);

--- a/hal/parallel_bus.h
+++ b/hal/parallel_bus.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/spi.h
+++ b/hal/spi.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/hal/usbcdc.h
+++ b/hal/usbcdc.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/led.h
+++ b/led.h
@@ -27,6 +27,8 @@
 #include "hal/board.h"
 #include "hal/gpio.h"
 
+static inline void LED_Off(void);
+
 /** Initializes the LED and turns it off
  *
  */
@@ -34,7 +36,7 @@ static inline void LED_Init(void)
 {
 	GPIOPin ledPin = Board_LEDPin();
 	GPIO_SetDirection(ledPin, true);
-	GPIO_SetOff(ledPin);
+	LED_Off();
 }
 
 /** Turns the LED on
@@ -42,7 +44,11 @@ static inline void LED_Init(void)
  */
 static inline void LED_On(void)
 {
+#if BOARD_LED_INVERTED
+	GPIO_SetOff(Board_LEDPin());
+#else
 	GPIO_SetOn(Board_LEDPin());
+#endif
 }
 
 /** Turns the LED off
@@ -50,7 +56,11 @@ static inline void LED_On(void)
  */
 static inline void LED_Off(void)
 {
+#if BOARD_LED_INVERTED
+	GPIO_SetOn(Board_LEDPin());
+#else
 	GPIO_SetOff(Board_LEDPin());
+#endif
 }
 
 /** Toggles the LED

--- a/led.h
+++ b/led.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/main.c
+++ b/main.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  * -----------------------------------------------------------------------------
  *

--- a/programmer_protocol.h
+++ b/programmer_protocol.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/simm_programmer.c
+++ b/simm_programmer.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/simm_programmer.c
+++ b/simm_programmer.c
@@ -46,7 +46,7 @@
 /// Version info to respond with
 #define VERSION_MAJOR						1
 #define VERSION_MINOR						5
-#define VERSION_REVISION					0
+#define VERSION_REVISION					1
 
 /// The number of erase sector groups we know about currently.
 /// If it's zero, we don't know, so fall back to defaults.

--- a/simm_programmer.h
+++ b/simm_programmer.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/tests/simm_electrical_test.c
+++ b/tests/simm_electrical_test.c
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/tests/simm_electrical_test.c
+++ b/tests/simm_electrical_test.c
@@ -24,6 +24,7 @@
 #include "simm_electrical_test.h"
 #include "../hal/parallel_bus.h"
 #include "hardware.h"
+#include "board_hw.h"
 
 /// The index of the highest SIMM address pin
 #define SIMM_HIGHEST_ADDRESS_LINE			20
@@ -40,6 +41,8 @@
 
 /// The index reported as a short when it's a ground short
 #define GROUND_FAIL_INDEX					0xFF
+/// The index reported as a short when it's a +5V short
+#define VCC_FAIL_INDEX						0xFE
 /// The index reported when A0 is shorted
 #define FIRST_ADDRESS_LINE_FAIL_INDEX		0
 /// The index reported when A20 is shorted
@@ -101,10 +104,15 @@ int SIMMElectricalTest_Run(void (*errorHandler)(uint8_t, uint8_t))
 	ParallelBus_SetOEDir(false);
 	ParallelBus_SetWEDir(false);
 	ParallelBus_SetAddressPullups(SIMM_ADDRESS_PINS_MASK);
+	ParallelBus_SetAddressPulldowns(0);
 	ParallelBus_SetDataPullups(SIMM_DATA_PINS_MASK);
+	ParallelBus_SetDataPulldowns(0);
 	ParallelBus_SetCSPullup(true);
+	ParallelBus_SetCSPulldown(false);
 	ParallelBus_SetOEPullup(true);
+	ParallelBus_SetOEPulldown(false);
 	ParallelBus_SetWEPullup(true);
+	ParallelBus_SetWEPulldown(false);
 
 	// Wait a brief moment...
 	DelayMS(DELAY_SETTLE_TIME_MS);
@@ -196,7 +204,109 @@ int SIMMElectricalTest_Run(void (*errorHandler)(uint8_t, uint8_t))
 
 	// OK, now we know which lines are shorted to ground. We need to keep that
 	// in mind, because those lines will now show as shorted to ALL other
-	// lines...ignore them during tests to find other independent shorts
+	// lines...ignore them during tests to find other independent shorts.
+
+	// If the arch also supports checking for shorts to VCC, check for those next.
+#if BOARD_SUPPORTS_PULLDOWNS
+	ParallelBus_SetAddressPullups(0);
+	ParallelBus_SetAddressPulldowns(SIMM_ADDRESS_PINS_MASK);
+	ParallelBus_SetDataPullups(0);
+	ParallelBus_SetDataPulldowns(SIMM_DATA_PINS_MASK);
+	ParallelBus_SetCSPullup(false);
+	ParallelBus_SetCSPulldown(true);
+	ParallelBus_SetOEPullup(false);
+	ParallelBus_SetOEPulldown(true);
+	ParallelBus_SetWEPullup(false);
+	ParallelBus_SetWEPulldown(true);
+
+	// Wait a brief moment...
+	DelayMS(DELAY_SETTLE_TIME_MS);
+
+	// Now loop through every pin and check it.
+	curPin = 0;
+
+	// Read the address pins back first
+	readback = ParallelBus_ReadAddress();
+	// Check each bit for a HIGH which would indicate a short to VCC
+	for (i = 0; i <= SIMM_HIGHEST_ADDRESS_LINE; i++)
+	{
+		// Did we find a high bit?
+		if (readback & 1)
+		{
+			// That means this pin is shorted to VCC.
+			// So notify the caller that we have a VCC short on this pin
+			if (errorHandler)
+			{
+				errorHandler(curPin, VCC_FAIL_INDEX);
+			}
+
+			// And of course increment the error counter.
+			numErrors++;
+		}
+
+		// No matter what, though, move on to the next bit and pin.
+		readback >>= 1;
+		curPin++;
+	}
+
+	// Repeat the exact same process for the data pins
+	readback = ParallelBus_ReadData();
+	for (i = 0; i <= SIMM_HIGHEST_DATA_LINE; i++)
+	{
+		if (readback & 1)
+		{
+			if (errorHandler)
+			{
+				errorHandler(curPin, VCC_FAIL_INDEX);
+			}
+			numErrors++;
+		}
+
+		readback >>= 1;
+		curPin++;
+	}
+
+	// Check chip select in the same way...
+	if (ParallelBus_ReadCS())
+	{
+		if (errorHandler)
+		{
+			errorHandler(curPin, VCC_FAIL_INDEX);
+		}
+		numErrors++;
+	}
+	curPin++;
+
+	// Output enable...
+	if (ParallelBus_ReadOE())
+	{
+		if (errorHandler)
+		{
+			errorHandler(curPin, VCC_FAIL_INDEX);
+		}
+		numErrors++;
+	}
+	curPin++;
+
+	// Write enable...
+	if (ParallelBus_ReadWE())
+	{
+		if (errorHandler)
+		{
+			errorHandler(curPin, VCC_FAIL_INDEX);
+		}
+		numErrors++;
+	}
+	curPin++; // Doesn't need to be here, but for consistency I'm leaving it.
+
+	// Clear the pulldowns now that we're done; we won't need them anymore
+	// for the rest of the testing
+	ParallelBus_SetAddressPulldowns(0);
+	ParallelBus_SetDataPulldowns(0);
+	ParallelBus_SetCSPulldown(false);
+	ParallelBus_SetOEPulldown(false);
+	ParallelBus_SetWEPulldown(false);
+#endif
 
 	// Now, check each individual line vs. all other lines on the SIMM for any
 	// shorts between them

--- a/tests/simm_electrical_test.h
+++ b/tests/simm_electrical_test.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 

--- a/toolchain-m258ke.cmake
+++ b/toolchain-m258ke.cmake
@@ -1,0 +1,16 @@
+# This will tell CMake that we are cross compiling
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_VERSION 1)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# Make sure it knows what binaries to use
+set(CMAKE_AR arm-none-eabi-ar)
+set(CMAKE_ASM_COMPILER arm-none-eabi-gcc)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(CMAKE_LINKER arm-none-eabi-ld)
+set(CMAKE_OBJCOPY arm-none-eabi-objcopy)
+set(CMAKE_RANLIB arm-none-eabi-ranlib)
+set(CMAKE_SIZE arm-none-eabi-size)
+set(CMAKE_STRIP arm-none-eabi-strip)

--- a/util.h
+++ b/util.h
@@ -6,10 +6,10 @@
  *
  * Copyright (C) 2011-2023 Doug Brown
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -17,8 +17,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 


### PR DESCRIPTION
Add support for the Nuvoton M258KE microcontroller used in the CayMac ROMmate-2. This is a port of the firmware to a completely different architecture (ARM-based).

Due to the licensing of Nuvoton's USB libraries (Apache 2.0), this also results in a change to use GPLv3 going forward.

Since the M258KE supports pulldown resistors, this also adds the ability for the electrical test to use them to detect short circuits involving +5V. This detection is only available on this new architecture because it requires pulldowns and the AVR doesn't have them.

Bump the version to 1.5.1 just so we have a good reference point for compatibility.